### PR TITLE
docs(project): add contributor guidelines and convention documents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## 📝 Description
+
+<!-- What does this PR do and why? -->
+
+## 🏷️ Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
+- [ ] `style` — formatting only (ktlint, rustfmt…)
+- [ ] `docs` — documentation only
+- [ ] `test` — adding or updating tests
+- [ ] `chore` / `build` / `ci` — tooling, dependencies, configuration
+
+## 🖼️ Media
+
+<!-- Screenshots, screen recordings, or API response examples if applicable. Delete this section if not relevant. -->
+
+## ✅ Checklist
+
+- [ ] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
+- [ ] The author has proofread the PR
+- [ ] New/changed logic is covered by tests (unit and/or integration)
+- [ ] No compiler warnings introduced
+- [ ] No sensitive data (secrets, credentials, tokens) committed
+- [ ] Documentation updated if public APIs or architecture decisions changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,29 +21,17 @@ The project is organized into several key directories:
 - `/rust-backend` (Future): Placeholder for potential Rust backend services.
 - `/Resources`: Static assets, documentation, or other shared resources.
 
-## 3. General Principles
-
-### Collaboration & Communication
-
-- **Respectful Interaction**: All interactions should be respectful and constructive.
-- **Clear Communication**: Be clear and concise in your communications (code comments, commit messages, pull request descriptions).
-- **Ask Questions**: Don't hesitate to ask questions if something is unclear.
-
-### Code Quality & Maintainability
-
-- **Readability**: Write code that is easy to understand and maintain.
-- **Consistency**: Adhere to established coding conventions and architectural patterns.
-- **Testing**: Write comprehensive tests to ensure correctness and prevent regressions.
-- **Documentation**: Document complex logic, public APIs, and architectural decisions.
-
-## 4. Project Guidelines & Conventions
+## 3. Project Guidelines & Conventions
 
 For detailed guidelines on specific parts of the project, please refer to the following documents:
 
-### General Conventions
+### Collaboration & Communication
+
+- **Collaboration, Git & CI Conventions**: [`GIT_AND_COLLABORATION.md`](docs/conventions/GIT_AND_COLLABORATION.md)
+
+### Code Quality & Maintainability
 
 - **General Coding Conventions**: [`CODING_CONVENTIONS.md`](docs/conventions/CODING_CONVENTIONS.md)
-- **Git & CI Conventions**: [`GIT_CONVENTIONS.md`](docs/conventions/GIT_CONVENTIONS.md)
 
 ### Technology-Specific Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,32 +29,34 @@ The project is organized into several key directories:
 - **Clear Communication**: Be clear and concise in your communications (code comments, commit messages, pull request descriptions).
 - **Ask Questions**: Don't hesitate to ask questions if something is unclear.
 
-### Performance & Security
+### Code Quality & Maintainability
 
-- **Performance Awareness**: Consider performance implications when designing and implementing features.
-- **Security First**: Prioritize security in all aspects of development, especially for backend services.
+- **Readability**: Write code that is easy to understand and maintain.
+- **Consistency**: Adhere to established coding conventions and architectural patterns.
+- **Testing**: Write comprehensive tests to ensure correctness and prevent regressions.
+- **Documentation**: Document complex logic, public APIs, and architectural decisions.
 
-## 4. CI & Policies
+## 4. Project Guidelines & Conventions
 
-- **Pull Requests**: All code must be reviewed via PRs before merging into `main`.
-- **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline.
-- **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
-- **Security Scans**: Integrate automated security scanning where applicable.
-
-## 5. Conventions & Guidelines
-
-For detailed guidelines, overarching principles, and technology-specific standards, please refer to the dedicated documents:
+For detailed guidelines on specific parts of the project, please refer to the following documents:
 
 ### General Conventions
-- **Git & Branching**: [`GIT_CONVENTIONS.md`](docs/conventions/GIT_CONVENTIONS.md)
-- **Clean Code & General Coding**: [`CODING_CONVENTIONS.md`](docs/conventions/CODING_CONVENTIONS.md)
 
-### Technology-Specific Conventions
-- **Client Application (KMP/CMP)**: [`KMP_CONVENTIONS.md`](docs/conventions/KMP_CONVENTIONS.md)
-- **Spring Boot Backend**: [`SPRING_BOOT_CONVENTIONS.md`](docs/conventions/SPRING_BOOT_CONVENTIONS.md)
-- **Rust Backend (Future)**: [`RUST_CONVENTIONS.md`](docs/conventions/RUST_CONVENTIONS.md)
-- **API Testing with Bruno**: [`BRUNO_CONVENTIONS.md`](docs/conventions/BRUNO_CONVENTIONS.md)
+- **General Coding Conventions**: [`CODING_CONVENTIONS.md`](docs/conventions/CODING_CONVENTIONS.md)
+- **Git & CI Conventions**: [`GIT_CONVENTIONS.md`](docs/conventions/GIT_CONVENTIONS.md)
 
-### Product & Features
+### Technology-Specific Guidelines
+
+- **Client Application (KMP/Compose Multiplatform) Conventions**:
+    - [`KMP_CONVENTIONS.md`](docs/conventions/KMP_CONVENTIONS.md)
+- **Spring Boot Backend Server Conventions**:
+    - [`SPRING_BOOT_CONVENTIONS.md`](docs/conventions/SPRING_BOOT_CONVENTIONS.md)
+- **Rust Backend (Future) Conventions**:
+    - [`RUST_CONVENTIONS.md`](docs/conventions/RUST_CONVENTIONS.md)
+- **API Testing with Bruno Conventions**:
+    - [`BRUNO_CONVENTIONS.md`](docs/conventions/BRUNO_CONVENTIONS.md)
+
+## 5. Product & Features
+
 - **Functional Specifications**: [`FUNCTIONAL_SPEC.md`](docs/specs/FUNCTIONAL_SPEC.md)
 - **Ideas & Future Features**: [`IDEAS_BOX.md`](docs/specs/IDEAS_BOX.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# TTRPG Companion - Project Guidelines for Contributors
+
+This document serves as the central guide for all contributors (human or AI) to the project.
+It outlines overarching principles, project structure, and general development practices. For technology-specific details, please refer to the dedicated specification files linked below.
+
+## 1. Project Overview
+
+The `ttrpg-companion` project aims to provide a comprehensive digital toolkit for tabletop role-playing games. It consists of multiple components:
+
+- **Client Application**: A cross-platform application (Android, iOS, Desktop) for users to manage campaigns, characters, and game resources.
+- **Backend Services**: One or more backend services to provide data storage, real-time functionalities, and potentially AI-driven features.
+- **API Testing**: Collections for robust API testing using Bruno.
+
+## 2. Project Structure
+
+The project is organized into several key directories:
+
+- `/cmp-ttrpg-companion`: Contains the Kotlin Multiplatform client application code.
+- `/spring-server`: Contains the Spring Boot backend server code.
+- `/bruno`: Contains API testing collections and environments for Bruno.
+- `/rust-backend` (Future): Placeholder for potential Rust backend services.
+- `/Resources`: Static assets, documentation, or other shared resources.
+
+## 3. General Principles
+
+### Collaboration & Communication
+
+- **Respectful Interaction**: All interactions should be respectful and constructive.
+- **Clear Communication**: Be clear and concise in your communications (code comments, commit messages, pull request descriptions).
+- **Ask Questions**: Don't hesitate to ask questions if something is unclear.
+
+### Performance & Security
+
+- **Performance Awareness**: Consider performance implications when designing and implementing features.
+- **Security First**: Prioritize security in all aspects of development, especially for backend services.
+
+## 4. CI & Policies
+
+- **Pull Requests**: All code must be reviewed via PRs before merging into `main`.
+- **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline.
+- **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
+- **Security Scans**: Integrate automated security scanning where applicable.
+
+## 5. Conventions & Guidelines
+
+For detailed guidelines, overarching principles, and technology-specific standards, please refer to the dedicated documents:
+
+### General Conventions
+- **Git & Branching**: [`GIT_CONVENTIONS.md`](docs/conventions/GIT_CONVENTIONS.md)
+- **Clean Code & General Coding**: [`CODING_CONVENTIONS.md`](docs/conventions/CODING_CONVENTIONS.md)
+
+### Technology-Specific Conventions
+- **Client Application (KMP/CMP)**: [`KMP_CONVENTIONS.md`](docs/conventions/KMP_CONVENTIONS.md)
+- **Spring Boot Backend**: [`SPRING_BOOT_CONVENTIONS.md`](docs/conventions/SPRING_BOOT_CONVENTIONS.md)
+- **Rust Backend (Future)**: [`RUST_CONVENTIONS.md`](docs/conventions/RUST_CONVENTIONS.md)
+- **API Testing with Bruno**: [`BRUNO_CONVENTIONS.md`](docs/conventions/BRUNO_CONVENTIONS.md)
+
+### Product & Features
+- **Functional Specifications**: [`FUNCTIONAL_SPEC.md`](docs/specs/FUNCTIONAL_SPEC.md)
+- **Ideas & Future Features**: [`IDEAS_BOX.md`](docs/specs/IDEAS_BOX.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,15 +21,15 @@ The project is organized into several key directories:
 - `/rust-backend` (Future): Placeholder for potential Rust backend services.
 - `/Resources`: Static assets, documentation, or other shared resources.
 
-## 3. Project Guidelines & Conventions
+## 3. Project Guidelines and Conventions
 
 For detailed guidelines on specific parts of the project, please refer to the following documents:
 
-### Collaboration & Communication
+### Collaboration and Communication
 
 - **Collaboration, Git & CI Conventions**: [`GIT_AND_COLLABORATION.md`](docs/conventions/GIT_AND_COLLABORATION.md)
 
-### Code Quality & Maintainability
+### Code Quality and Maintainability
 
 - **General Coding Conventions**: [`CODING_CONVENTIONS.md`](docs/conventions/CODING_CONVENTIONS.md)
 
@@ -43,8 +43,3 @@ For detailed guidelines on specific parts of the project, please refer to the fo
     - [`RUST_CONVENTIONS.md`](docs/conventions/RUST_CONVENTIONS.md)
 - **API Testing with Bruno Conventions**:
     - [`BRUNO_CONVENTIONS.md`](docs/conventions/BRUNO_CONVENTIONS.md)
-
-## 4. Product & Features
-
-- **Functional Specifications**: [`FUNCTIONAL_SPEC.md`](docs/specs/FUNCTIONAL_SPEC.md)
-- **Ideas & Future Features**: [`IDEAS_BOX.md`](docs/specs/IDEAS_BOX.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ For detailed guidelines on specific parts of the project, please refer to the fo
 - **API Testing with Bruno Conventions**:
     - [`BRUNO_CONVENTIONS.md`](docs/conventions/BRUNO_CONVENTIONS.md)
 
-## 5. Product & Features
+## 4. Product & Features
 
 - **Functional Specifications**: [`FUNCTIONAL_SPEC.md`](docs/specs/FUNCTIONAL_SPEC.md)
 - **Ideas & Future Features**: [`IDEAS_BOX.md`](docs/specs/IDEAS_BOX.md)

--- a/docs/conventions/BRUNO_CONVENTIONS.md
+++ b/docs/conventions/BRUNO_CONVENTIONS.md
@@ -44,10 +44,10 @@ bruno/
 - **Variables**: Use environment variables for host URLs, API keys, and other environment-specific values.
     - Prefix environment-specific variables with `BASE_URL`, `API_KEY`, etc.
     - Example `local.bru`:
-        ```json
-        {
-          "BASE_URL": "http://localhost:8080",
-          "AUTH_TOKEN": ""
+        ```
+        vars {
+          BASE_URL: http://localhost:8080
+          AUTH_TOKEN:
         }
         ```
 

--- a/docs/conventions/BRUNO_CONVENTIONS.md
+++ b/docs/conventions/BRUNO_CONVENTIONS.md
@@ -1,0 +1,94 @@
+# Bruno API Testing Conventions
+
+This document outlines the conventions and best practices for using Bruno for API testing within the project.
+Bruno collections are primarily located in the `bruno` directory at the project root.
+
+Refer to `../../AGENTS.md` for project-wide guidelines.
+
+## 1. Purpose of Bruno Collections
+
+Bruno is used for:
+- **API Functional Testing**: Ensuring individual API endpoints behave as expected.
+- **API Integration Testing**: Verifying the interaction between different API endpoints or services.
+- **API Documentation**: Providing executable examples of how to interact with the API.
+- **Pre-deployment Checks**: Running critical API tests before deploying new versions of the backend services.
+
+## 2. Bruno Collection Structure
+
+Collections should be organized logically within the `bruno` directory. A suggested structure is:
+
+```
+bruno/
+├── <service-name>/            # e.g., spring-server, rust-backend
+│   ├── <feature-area>/        # e.g., auth, campaigns, creatures
+│   │   ├── GET_all_campaigns.bru
+│   │   ├── POST_create_campaign.bru
+│   │   └── ...
+│   ├── environments/
+│   │   ├── local.bru
+│   │   └── production.bru
+│   └── setup.bru              # Optional: For global setup requests (e.g., login to get token)
+├── common/                    # Requests/variables shared across services
+│   └── auth_token_env.bru
+└── README.md                  # Explanation of collections and setup
+```
+
+## 3. Naming Conventions
+
+- **Collection Folders**: Use `kebab-case` for service and feature area folders (e.g., `spring-server`, `campaign-management`).
+- **Request Files**: Use `HTTP_METHOD_description.bru` (e.g., `GET_all_campaigns.bru`, `POST_create_new_user.bru`). Descriptions should be concise and clearly indicate the request's purpose.
+
+## 4. Environments
+
+- **Environment Files**: Each service should have an `environments` folder containing `[env-name].bru` files (e.g., `local.bru`, `production.bru`).
+- **Variables**: Use environment variables for host URLs, API keys, and other environment-specific values.
+    - Prefix environment-specific variables with `BASE_URL`, `API_KEY`, etc.
+    - Example `local.bru`:
+        ```json
+        {
+          "BASE_URL": "http://localhost:8080",
+          "AUTH_TOKEN": ""
+        }
+        ```
+
+## 5. Request Best Practices
+
+- **Clear Purpose**: Each request should have a single, clear purpose.
+- **Descriptive Names**: The request name should accurately reflect what it does.
+- **Assertions**: Include assertions to validate responses (status codes, body content, headers). Bruno's built-in `Tests` tab should be utilized for this.
+    ```javascript
+    // Example Bruno Test Script
+    test("Status code is 200 OK", function() {
+      expect(res.status).to.equal(200);
+    });
+    test("Response contains a list of campaigns", function() {
+      expect(res.body).to.be.an('array');
+      expect(res.body[0]).to.have.property('id');
+    });
+    ```
+- **Pre-request Scripts**: Use pre-request scripts for dynamic data generation, authentication token acquisition, or setting up prerequisites.
+    ```javascript
+    // Example Pre-request Script (e.g., setting a dynamic variable)
+    bru.setVar('timestamp', Date.now());
+    ```
+- **Post-request Scripts**: Use post-request scripts to extract data from responses (e.g., an ID from a `POST` request to be used in a subsequent `GET` or `DELETE` request) and save it to environment variables.
+    ```javascript
+    // Example Post-request Script
+    const response = res.body;
+    if (response && response.id) {
+      bru.setEnvVar('createdCampaignId', response.id);
+    }
+    ```
+- **Variables**: Use Bruno's `{{variableName}}` syntax for referencing variables (environment, collection, or local).
+
+## 6. Authentication
+
+- **Token Management**: For APIs requiring authentication tokens (e.g., JWT, OAuth), implement a dedicated request or pre-request script to obtain the token and store it as an environment variable (e.g., `AUTH_TOKEN`). Subsequent requests can then reference this variable in their `Authorization` header.
+
+## 7. Version Control
+
+- **Commit Bruno Files**: Bruno collection files (`.bru` files) are plain text and should be committed to Git. This allows for version control, collaboration, and review.
+
+## 8. CI/CD Integration
+
+- **CLI Runner**: Explore integrating Bruno's CLI runner (`bru`) into CI/CD pipelines to automate API tests. This ensures API health and correctness with every code change.

--- a/docs/conventions/CODING_CONVENTIONS.md
+++ b/docs/conventions/CODING_CONVENTIONS.md
@@ -1,59 +1,48 @@
 # General Coding Conventions
 
-This document outlines the general coding philosophy and Clean Code principles for the entire project.
-These rules apply regardless of the underlying technology stack (Kotlin, Rust, etc.).
+This document outlines the core Clean Code principles for the project.
+These rules apply across all technologies (Kotlin, Rust, etc.).
 
-For language-specific rules, refer to the respective technology convention files. Refer to `../../AGENTS.md` for overall project guidelines.
+Refer to `../../AGENTS.md` for overall project guidelines.
 
 ## 1. Meaningful Names
 
-- **Intention-Revealing**: The name of a variable, function, or class should answer all the big questions. It should tell you why it exists, what it does, and how it is used. If a name requires a comment, then the name does not reveal its intent.
-- **Class Names**: Classes and objects should have noun or noun phrase names like `Campaign`, `CharacterProfile`, or `AccountParser`. Avoid words like `Manager`, `Processor`, `Data`, or `Info`.
-- **Method Names**: Methods should have verb or verb phrase names like `postPayment`, `deletePage`, or `save`.
-- **Pronounceable and Searchable**: Use names that can be read aloud easily and are long enough to be easily searchable across the codebase.
-- **Avoid Disinformation**: Avoid leaving false clues that obscure the meaning of code. Do not use abbreviations or types in the name (e.g., avoid `accountList` if it's not actually a `List`; use `accounts`).
+- **Reveal Intent**: Names must explain why a variable exists, what it does, and how to use it. If a name needs a comment, it is not clear enough.
+- **Class Names**: Use nouns or noun phrases like `Campaign` or `CharacterProfile`. Try to avoid vague words like `Manager`, `Processor`, or `Data`.
+- **Method Names**: Use verbs or verb phrases like `postPayment`, `save`, or `deletePage`.
+- **Be Explicit**: Avoid abbreviations and single letters. Do not use misleading names (e.g., avoid `accountList` if it is actually a `Set`).
 
 ## 2. Functions
 
-- **Small**: The first rule of functions is that they should be small. 
-- **Do One Thing**: Functions should do one thing and do it well. If a function does multiple things, extract them into separate functions.
-- **One Level of Abstraction per Function**: Ensure that the statements within a function are all at the same level of abstraction. Don't mix high-level concepts with low-level details.
-- **Function Arguments**: The ideal number of arguments for a function is zero (niladic). Next comes one (monadic), followed closely by two (dyadic). Three arguments (triadic) should be avoided where possible. More than three requires very special justification.
-- **Command Query Separation (CQS)**: Functions should either do something (command) or answer something (query), but not both.
-- **Avoid Side Effects**: Your function promises to do one thing, but it also does other *hidden* things. This is a lie and leads to temporal couplings and subtle bugs.
+- **Keep them Small**: Functions should rarely exceed 20 lines.
+- **Do One Thing (SRP)**: If you can extract a block into a well-named function, your current function is doing too much.
+- **One Level of Abstraction**: Do not mix high-level concepts with low-level details in the same function.
+- **Limit Arguments**: Aim for 0 to 2 arguments. If you need more, group them into a dedicated data class or struct.
+- **Command Query Separation (CQS)**: A function should either change state (Command) or return data (Query), never both.
+- **No Hidden Side Effects**: Do exactly what the function name promises and nothing else.
 
 ## 3. Comments
 
-Comments are often considered failures to express intent in code. Code is the only truth.
-
-- **Explain Yourself in Code**: The best comment is the one you don't need to write. Prioritize refactoring code to be self-explanatory over writing a comment to explain bad code.
-- **Good Comments**: 
-    - Legal comments (copyright).
-    - Explanation of intent (the *Why*, not the *What*).
-    - Warning of consequences (e.g., "Don't run this unless...").
-    - TODO comments (use sparingly and clean them up regularly).
-    - Public API documentation (e.g., KDoc, Rustdoc) to define contracts.
-- **Bad Comments**: 
-    - Redundant comments (explaining what the code obviously does).
-    - Misleading comments.
-    - Commented-out code: **Never leave commented-out code.** Delete it. Git will remember it.
-    - Journal comments (changelogs in file headers). Use Git instead.
+- **Express Intent in Code**: Code tells the truth, while comments often get outdated and lie. Refactor your code to make it self-explanatory instead of adding a comment.
+- **Explain "Why", Not "What"**: Only write inline comments to explain business rules, context, or unavoidable hacks.
+- **Good Comments**: Public API contracts (KDoc/Rustdoc), TODOs, Legal headers.
+- **Bad Comments**: Redundant explanations, commented-out code (delete it, Git remembers), changelogs.
 
 ## 4. Error Handling
 
-- **Use Exceptions/Results over Error Codes**: Depending on the language, use Exceptions (Kotlin) or Result types (Rust) rather than returning error flags or codes that clutter the caller's logic.
-- **Extract Try/Catch Blocks**: Error handling is "one thing". Functions that handle errors should do nothing else. Extract the body of the `try` block (or the `match` block) into its own function.
-- **Provide Context with Exceptions**: Create informative error messages and pass them along with your exceptions/results. Mention the operation that failed and the type of failure.
-- **Fail Fast**: Validate preconditions early. Halt execution or return an error as soon as an invalid state is detected.
+- **Fail Fast**: Validate inputs immediately. Halt execution or return errors as soon as an invalid state is detected.
+- **Use Exceptions/Results**: Use idiomatic error handling (Kotlin Exceptions, Rust `Result`) instead of returning arbitrary error codes.
+- **Isolate Error Handling**: Extract `try/catch` or `match` blocks into their own functions. Error handling is "one thing".
+- **Provide Context**: Include enough information in error messages to easily trace the source of the failure.
 
-## 6. Code Organization and Formatting
+## 5. Organization & Formatting
 
-- **The Newspaper Metaphor**: A source file should read like a newspaper article. The name should be simple but explanatory. The topmost parts should provide high-level concepts and algorithms. Detail should increase as we move downward.
-- **Vertical Density and Distance**: Concepts that are closely related should be kept vertically close to each other. Local variables should be declared as close to their usage as possible.
-- **Automated Formatting**: Do not argue over formatting rules. Rely entirely on automated formatters (`ktlint` for Kotlin, `rustfmt` for Rust). If the CI pipeline passes the formatting check, the formatting is correct.
+- **Automated Formatting**: Rely 100% on formatters (`ktlint`, `rustfmt`). If the CI pipeline passes, the formatting is correct. No debates.
+- **Newspaper Metaphor**: Put high-level concepts at the top of the file, increasing detail as you read downward.
+- **Keep Related Code Close**: Group related concepts vertically. Declare local variables right before their first use.
 
-## 7. Objects and Data Structures
+## 6. Objects and Data Structures
 
-- **Data Abstraction**: Hide the internal structure of your objects. Expose abstract interfaces that allow users to manipulate the *essence* of the data, without having to know its implementation.
-- **Law of Demeter**: A module should not know about the innards of the objects it manipulates. Avoid "train wrecks" like `object.getA().getB().doSomething()`.
-- **Favor Immutability**: By default, design data structures and variables to be immutable. It prevents side effects and makes concurrent programming significantly safer.
+- **Favor Immutability**: Make data structures immutable by default to prevent side-effect bugs and ensure thread safety.
+- **Law of Demeter**: Don't chain calls through internal properties (`a.getB().getC().doSomething()`). Modules shouldn't know the inner workings of the objects they manipulate.
+- **Data Abstraction**: Hide internal implementation details. Expose interfaces that allow users to manipulate the essence of the data.

--- a/docs/conventions/CODING_CONVENTIONS.md
+++ b/docs/conventions/CODING_CONVENTIONS.md
@@ -46,3 +46,14 @@ Refer to `../../AGENTS.md` for overall project guidelines.
 - **Favor Immutability**: Make data structures immutable by default to prevent side-effect bugs and ensure thread safety.
 - **Law of Demeter**: Don't chain calls through internal properties (`a.getB().getC().doSomething()`). Modules shouldn't know the inner workings of the objects they manipulate.
 - **Data Abstraction**: Hide internal implementation details. Expose interfaces that allow users to manipulate the essence of the data.
+
+## 7. Testing
+
+- **Comprehensive Coverage**: Write comprehensive tests to ensure correctness and prevent regressions.
+- **F.I.R.S.T. Principles**: Tests should be Fast, Independent, Repeatable, Self-Validating, and Timely.
+- **Clear Assertions**: Strive to have a single logical assertion or concept per test function to make failures easy to diagnose.
+
+## 8. Performance & Security
+
+- **Prioritize Readability over Performance**: Readability and maintainability almost always take precedence over performance. Avoid premature optimization. Write clean code first; optimize only when proven necessary by profiling.
+- **Security First**: Prioritize security in all aspects of development, especially for backend services. Never trust client input without validation.

--- a/docs/conventions/CODING_CONVENTIONS.md
+++ b/docs/conventions/CODING_CONVENTIONS.md
@@ -10,7 +10,6 @@ Refer to `../../AGENTS.md` for overall project guidelines.
 - **Readability**: Write code that is easy to understand and maintain. Readability and maintainability almost always take precedence over performance.
 - **Consistency**: Adhere to established coding conventions and architectural patterns.
 - **Avoid premature optimization**: Write clean code first; optimize only when proven necessary by profiling.
-- **Testing**: Write comprehensive tests to ensure correctness and prevent regressions.
 - **Security**: Prioritize security in all aspects of development, especially for backend services. Never trust client input without validation.
 - **Documentation**: Document complex logic, public APIs, and architectural decisions.
 

--- a/docs/conventions/CODING_CONVENTIONS.md
+++ b/docs/conventions/CODING_CONVENTIONS.md
@@ -1,0 +1,30 @@
+# General Coding Conventions
+
+This document outlines the general coding philosophy, Clean Code principles, and commenting guidelines for the entire project, regardless of the underlying technology stack (Kotlin, Rust, etc.). 
+
+For language-specific rules, refer to the respective technology convention files. Refer to `../../AGENTS.md` for overall project guidelines.
+
+## 1. The Golden Rule: Self-Documenting Code
+
+The primary goal when writing code is readability and maintainability. Your code should be the ultimate source of truth and should be self-sufficient in explaining its intent.
+
+- **Expressive Naming**: Use clear, descriptive, and intention-revealing names for variables, functions, classes, and modules. If a name requires a comment to explain what it represents, the name is not good enough.
+- **Small, Focused Functions**: Functions should do one thing, do it well, and do it only. If a function is doing too much, extract it into smaller, well-named sub-functions. This naturally eliminates the need for "header" comments inside long functions.
+- **Fail Fast**: Validate inputs and preconditions early. Use language-specific tools (like `require()`, `check()` in Kotlin, or early `return Err()` / assertions in Rust) to halt execution when things go wrong, rather than letting invalid state propagate.
+
+## 2. Comments
+
+Comments are a double-edged sword. While sometimes necessary, they often become outdated and lie, whereas code must always execute truthfully.
+
+### Inline Comments: The "Why", Not the "What"
+- **Code is the "What" and "How"**: If you feel the need to write a comment to explain *what* a block of code is doing, you have likely failed to make the code clear enough. Extract a variable, rename a function, or simplify the logic instead.
+- **Comments are the "Why"**: Only use inline comments to explain business context, complex domain logic that cannot be simplified, external constraints, or "hacky" workarounds that are necessary due to third-party limitations. Explain *why* a particular approach was chosen when it's not obvious.
+
+### API Documentation (KDoc, Javadoc, Rustdocs)
+- **Public Contracts**: While inline comments should be sparse, formal API documentation is highly encouraged (and often required) for public interfaces, shared modules, and core domain logic.
+- **Purpose**: Use API documentation (e.g., KDoc in Kotlin, `///` in Rust) to define the contract: what parameters are expected, what the function returns, what errors it might throw, and its general behavior. This aids consumers of your API so they don't have to read the implementation details to use it.
+
+## 3. General Paradigms
+
+- **Favor Immutability**: By default, design data structures and variables to be immutable. Mutability increases cognitive load and is the source of many subtle bugs, especially in concurrent environments.
+- **Formatting**: Do not argue over code formatting. Rely entirely on automated formatters and linters (`ktlint` for Kotlin, `rustfmt` and `clippy` for Rust). If the CI pipeline passes the formatting check, the formatting is correct.

--- a/docs/conventions/CODING_CONVENTIONS.md
+++ b/docs/conventions/CODING_CONVENTIONS.md
@@ -1,30 +1,59 @@
 # General Coding Conventions
 
-This document outlines the general coding philosophy, Clean Code principles, and commenting guidelines for the entire project, regardless of the underlying technology stack (Kotlin, Rust, etc.). 
+This document outlines the general coding philosophy and Clean Code principles for the entire project.
+These rules apply regardless of the underlying technology stack (Kotlin, Rust, etc.).
 
 For language-specific rules, refer to the respective technology convention files. Refer to `../../AGENTS.md` for overall project guidelines.
 
-## 1. The Golden Rule: Self-Documenting Code
+## 1. Meaningful Names
 
-The primary goal when writing code is readability and maintainability. Your code should be the ultimate source of truth and should be self-sufficient in explaining its intent.
+- **Intention-Revealing**: The name of a variable, function, or class should answer all the big questions. It should tell you why it exists, what it does, and how it is used. If a name requires a comment, then the name does not reveal its intent.
+- **Class Names**: Classes and objects should have noun or noun phrase names like `Campaign`, `CharacterProfile`, or `AccountParser`. Avoid words like `Manager`, `Processor`, `Data`, or `Info`.
+- **Method Names**: Methods should have verb or verb phrase names like `postPayment`, `deletePage`, or `save`.
+- **Pronounceable and Searchable**: Use names that can be read aloud easily and are long enough to be easily searchable across the codebase.
+- **Avoid Disinformation**: Avoid leaving false clues that obscure the meaning of code. Do not use abbreviations or types in the name (e.g., avoid `accountList` if it's not actually a `List`; use `accounts`).
 
-- **Expressive Naming**: Use clear, descriptive, and intention-revealing names for variables, functions, classes, and modules. If a name requires a comment to explain what it represents, the name is not good enough.
-- **Small, Focused Functions**: Functions should do one thing, do it well, and do it only. If a function is doing too much, extract it into smaller, well-named sub-functions. This naturally eliminates the need for "header" comments inside long functions.
-- **Fail Fast**: Validate inputs and preconditions early. Use language-specific tools (like `require()`, `check()` in Kotlin, or early `return Err()` / assertions in Rust) to halt execution when things go wrong, rather than letting invalid state propagate.
+## 2. Functions
 
-## 2. Comments
+- **Small**: The first rule of functions is that they should be small. 
+- **Do One Thing**: Functions should do one thing and do it well. If a function does multiple things, extract them into separate functions.
+- **One Level of Abstraction per Function**: Ensure that the statements within a function are all at the same level of abstraction. Don't mix high-level concepts with low-level details.
+- **Function Arguments**: The ideal number of arguments for a function is zero (niladic). Next comes one (monadic), followed closely by two (dyadic). Three arguments (triadic) should be avoided where possible. More than three requires very special justification.
+- **Command Query Separation (CQS)**: Functions should either do something (command) or answer something (query), but not both.
+- **Avoid Side Effects**: Your function promises to do one thing, but it also does other *hidden* things. This is a lie and leads to temporal couplings and subtle bugs.
 
-Comments are a double-edged sword. While sometimes necessary, they often become outdated and lie, whereas code must always execute truthfully.
+## 3. Comments
 
-### Inline Comments: The "Why", Not the "What"
-- **Code is the "What" and "How"**: If you feel the need to write a comment to explain *what* a block of code is doing, you have likely failed to make the code clear enough. Extract a variable, rename a function, or simplify the logic instead.
-- **Comments are the "Why"**: Only use inline comments to explain business context, complex domain logic that cannot be simplified, external constraints, or "hacky" workarounds that are necessary due to third-party limitations. Explain *why* a particular approach was chosen when it's not obvious.
+Comments are often considered failures to express intent in code. Code is the only truth.
 
-### API Documentation (KDoc, Javadoc, Rustdocs)
-- **Public Contracts**: While inline comments should be sparse, formal API documentation is highly encouraged (and often required) for public interfaces, shared modules, and core domain logic.
-- **Purpose**: Use API documentation (e.g., KDoc in Kotlin, `///` in Rust) to define the contract: what parameters are expected, what the function returns, what errors it might throw, and its general behavior. This aids consumers of your API so they don't have to read the implementation details to use it.
+- **Explain Yourself in Code**: The best comment is the one you don't need to write. Prioritize refactoring code to be self-explanatory over writing a comment to explain bad code.
+- **Good Comments**: 
+    - Legal comments (copyright).
+    - Explanation of intent (the *Why*, not the *What*).
+    - Warning of consequences (e.g., "Don't run this unless...").
+    - TODO comments (use sparingly and clean them up regularly).
+    - Public API documentation (e.g., KDoc, Rustdoc) to define contracts.
+- **Bad Comments**: 
+    - Redundant comments (explaining what the code obviously does).
+    - Misleading comments.
+    - Commented-out code: **Never leave commented-out code.** Delete it. Git will remember it.
+    - Journal comments (changelogs in file headers). Use Git instead.
 
-## 3. General Paradigms
+## 4. Error Handling
 
-- **Favor Immutability**: By default, design data structures and variables to be immutable. Mutability increases cognitive load and is the source of many subtle bugs, especially in concurrent environments.
-- **Formatting**: Do not argue over code formatting. Rely entirely on automated formatters and linters (`ktlint` for Kotlin, `rustfmt` and `clippy` for Rust). If the CI pipeline passes the formatting check, the formatting is correct.
+- **Use Exceptions/Results over Error Codes**: Depending on the language, use Exceptions (Kotlin) or Result types (Rust) rather than returning error flags or codes that clutter the caller's logic.
+- **Extract Try/Catch Blocks**: Error handling is "one thing". Functions that handle errors should do nothing else. Extract the body of the `try` block (or the `match` block) into its own function.
+- **Provide Context with Exceptions**: Create informative error messages and pass them along with your exceptions/results. Mention the operation that failed and the type of failure.
+- **Fail Fast**: Validate preconditions early. Halt execution or return an error as soon as an invalid state is detected.
+
+## 6. Code Organization and Formatting
+
+- **The Newspaper Metaphor**: A source file should read like a newspaper article. The name should be simple but explanatory. The topmost parts should provide high-level concepts and algorithms. Detail should increase as we move downward.
+- **Vertical Density and Distance**: Concepts that are closely related should be kept vertically close to each other. Local variables should be declared as close to their usage as possible.
+- **Automated Formatting**: Do not argue over formatting rules. Rely entirely on automated formatters (`ktlint` for Kotlin, `rustfmt` for Rust). If the CI pipeline passes the formatting check, the formatting is correct.
+
+## 7. Objects and Data Structures
+
+- **Data Abstraction**: Hide the internal structure of your objects. Expose abstract interfaces that allow users to manipulate the *essence* of the data, without having to know its implementation.
+- **Law of Demeter**: A module should not know about the innards of the objects it manipulates. Avoid "train wrecks" like `object.getA().getB().doSomething()`.
+- **Favor Immutability**: By default, design data structures and variables to be immutable. It prevents side effects and makes concurrent programming significantly safer.

--- a/docs/conventions/CODING_CONVENTIONS.md
+++ b/docs/conventions/CODING_CONVENTIONS.md
@@ -5,14 +5,23 @@ These rules apply across all technologies (Kotlin, Rust, etc.).
 
 Refer to `../../AGENTS.md` for overall project guidelines.
 
-## 1. Meaningful Names
+## 1. Code Quality & Maintainability
+
+- **Readability**: Write code that is easy to understand and maintain. Readability and maintainability almost always take precedence over performance.
+- **Consistency**: Adhere to established coding conventions and architectural patterns.
+- **Avoid premature optimization**: Write clean code first; optimize only when proven necessary by profiling.
+- **Testing**: Write comprehensive tests to ensure correctness and prevent regressions.
+- **Security**: Prioritize security in all aspects of development, especially for backend services. Never trust client input without validation.
+- **Documentation**: Document complex logic, public APIs, and architectural decisions.
+
+## 2. Meaningful Names
 
 - **Reveal Intent**: Names must explain why a variable exists, what it does, and how to use it. If a name needs a comment, it is not clear enough.
 - **Class Names**: Use nouns or noun phrases like `Campaign` or `CharacterProfile`. Try to avoid vague words like `Manager`, `Processor`, or `Data`.
 - **Method Names**: Use verbs or verb phrases like `postPayment`, `save`, or `deletePage`.
 - **Be Explicit**: Avoid abbreviations and single letters. Do not use misleading names (e.g., avoid `accountList` if it is actually a `Set`).
 
-## 2. Functions
+## 3. Functions
 
 - **Keep them Small**: Functions should rarely exceed 20 lines.
 - **Do One Thing (SRP)**: If you can extract a block into a well-named function, your current function is doing too much.
@@ -21,39 +30,34 @@ Refer to `../../AGENTS.md` for overall project guidelines.
 - **Command Query Separation (CQS)**: A function should either change state (Command) or return data (Query), never both.
 - **No Hidden Side Effects**: Do exactly what the function name promises and nothing else.
 
-## 3. Comments
+## 4. Comments
 
 - **Express Intent in Code**: Code tells the truth, while comments often get outdated and lie. Refactor your code to make it self-explanatory instead of adding a comment.
 - **Explain "Why", Not "What"**: Only write inline comments to explain business rules, context, or unavoidable hacks.
 - **Good Comments**: Public API contracts (KDoc/Rustdoc), TODOs, Legal headers.
 - **Bad Comments**: Redundant explanations, commented-out code (delete it, Git remembers), changelogs.
 
-## 4. Error Handling
+## 5. Error Handling
 
 - **Fail Fast**: Validate inputs immediately. Halt execution or return errors as soon as an invalid state is detected.
 - **Use Exceptions/Results**: Use idiomatic error handling (Kotlin Exceptions, Rust `Result`) instead of returning arbitrary error codes.
 - **Isolate Error Handling**: Extract `try/catch` or `match` blocks into their own functions. Error handling is "one thing".
 - **Provide Context**: Include enough information in error messages to easily trace the source of the failure.
 
-## 5. Organization & Formatting
+## 6. Organization & Formatting
 
 - **Automated Formatting**: Rely 100% on formatters (`ktlint`, `rustfmt`). If the CI pipeline passes, the formatting is correct. No debates.
 - **Newspaper Metaphor**: Put high-level concepts at the top of the file, increasing detail as you read downward.
 - **Keep Related Code Close**: Group related concepts vertically. Declare local variables right before their first use.
 
-## 6. Objects and Data Structures
+## 7. Objects and Data Structures
 
 - **Favor Immutability**: Make data structures immutable by default to prevent side-effect bugs and ensure thread safety.
 - **Law of Demeter**: Don't chain calls through internal properties (`a.getB().getC().doSomething()`). Modules shouldn't know the inner workings of the objects they manipulate.
 - **Data Abstraction**: Hide internal implementation details. Expose interfaces that allow users to manipulate the essence of the data.
 
-## 7. Testing
+## 8. Testing
 
 - **Comprehensive Coverage**: Write comprehensive tests to ensure correctness and prevent regressions.
 - **F.I.R.S.T. Principles**: Tests should be Fast, Independent, Repeatable, Self-Validating, and Timely.
 - **Clear Assertions**: Strive to have a single logical assertion or concept per test function to make failures easy to diagnose.
-
-## 8. Performance & Security
-
-- **Prioritize Readability over Performance**: Readability and maintainability almost always take precedence over performance. Avoid premature optimization. Write clean code first; optimize only when proven necessary by profiling.
-- **Security First**: Prioritize security in all aspects of development, especially for backend services. Never trust client input without validation.

--- a/docs/conventions/GIT_AND_COLLABORATION.md
+++ b/docs/conventions/GIT_AND_COLLABORATION.md
@@ -1,11 +1,17 @@
-# Git Conventions
+# Git & Collaboration Conventions
 
-This document outlines the Git conventions and branching strategy used across the project.
+This document outlines the collaboration guidelines, Git conventions, and branching strategy used across the project.
 Adhering to these conventions helps maintain a clean, understandable, and traceable project history.
 
 Refer to `../../AGENTS.md` for overall project guidelines.
 
-## 1. Conventional Commits
+## 1. Collaboration & Communication
+
+- **Respectful Interaction**: All interactions should be respectful and constructive.
+- **Clear Communication**: Be clear and concise in your communications (code comments, commit messages, pull request descriptions).
+- **Ask Questions**: Don't hesitate to ask questions if something is unclear.
+
+## 2. Conventional Commits
 
 We follow **Conventional Commits** to keep the history clean and to allow automated changelog generation.
 
@@ -21,7 +27,7 @@ We follow **Conventional Commits** to keep the history clean and to allow automa
 - **Scope**: The component affected (e.g., `project`, `compose-app`, `server-auth`, `bruno-api`).
 - **Subject**: Use the imperative, present tense: "change" not "changed" nor "changes". Don't capitalize the first letter. No dot (.) at the end.
 
-## 2. Commit Examples
+## 3. Commit Examples
 
 Here are some examples of valid commit messages:
 
@@ -33,7 +39,7 @@ Here are some examples of valid commit messages:
 - test(bruno-api): add E2E test for user registration flow
 - build(compose-app): update gradle wrapper to 8.x
 
-## 3. Trunk-Based Development Branching Strategy
+## 4. Trunk-Based Development Branching Strategy
 
 We utilize a **Trunk-Based Development** branching strategy. This means:
 
@@ -45,7 +51,7 @@ We utilize a **Trunk-Based Development** branching strategy. This means:
 
 This approach promotes continuous integration, reduces merge conflicts, and enables faster delivery of features.
 
-## 4. CI & Policies
+## 5. CI & Policies
 
 - **Pull Requests**: All code must be reviewed via PRs before merging into `main`.
 - **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline.

--- a/docs/conventions/GIT_AND_COLLABORATION.md
+++ b/docs/conventions/GIT_AND_COLLABORATION.md
@@ -45,7 +45,7 @@ We utilize a **Trunk-Based Development** branching strategy. This means:
 
 - **Single Main Branch:** All development happens directly on or very close to a single main branch (often named `main`).
 - **Small, Frequent Commits:** Developers commit small changes frequently to the main branch, often multiple times a day.
-- **Short-Lived Feature Branches:** If feature branches are used, they are kept very short-lived and merged back into the main branch as quickly as possible (typically within a day or two). Naming convention: `feature/short-description` (e.g., `feature/create-campaign`), `bugfix/issue-description`.
+- **Short-Lived Feature Branches:** If feature branches are used, they are kept very short-lived and merged back into the main branch as quickly as possible (typically within a day or two). Branch names mirror commit types: `feat/short-description`, `fix/issue-description`, `refactor/short-description`, `docs/short-description`, `chore/short-description`, etc. (e.g., `feat/create-campaign`, `fix/login-xss`).
 - **Continuous Integration:** A robust Continuous Integration (CI) system is essential to automatically build and test changes pushed to the main branch, catching integration issues early.
 - **Feature Flags:** To deploy incomplete features without affecting users, feature flags (also known as feature toggles) are used to enable or disable features at runtime. This allows for continuous delivery and reduces the need for long-lived feature branches.
 

--- a/docs/conventions/GIT_CONVENTIONS.md
+++ b/docs/conventions/GIT_CONVENTIONS.md
@@ -44,3 +44,10 @@ We utilize a **Trunk-Based Development** branching strategy. This means:
 - **Feature Flags:** To deploy incomplete features without affecting users, feature flags (also known as feature toggles) are used to enable or disable features at runtime. This allows for continuous delivery and reduces the need for long-lived feature branches.
 
 This approach promotes continuous integration, reduces merge conflicts, and enables faster delivery of features.
+
+## 4. CI & Policies
+
+- **Pull Requests**: All code must be reviewed via PRs before merging into `main`.
+- **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline.
+- **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
+- **Security Scans**: Integrate automated security scanning where applicable.

--- a/docs/conventions/GIT_CONVENTIONS.md
+++ b/docs/conventions/GIT_CONVENTIONS.md
@@ -1,6 +1,7 @@
 # Git Conventions
 
-This document outlines the Git conventions and branching strategy used across the project. Adhering to these conventions helps maintain a clean, understandable, and traceable project history.
+This document outlines the Git conventions and branching strategy used across the project.
+Adhering to these conventions helps maintain a clean, understandable, and traceable project history.
 
 Refer to `../../AGENTS.md` for overall project guidelines.
 
@@ -16,39 +17,30 @@ We follow **Conventional Commits** to keep the history clean and to allow automa
 <body>
 ```
 
-*   **Types**: `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`, `ci`, `build` (and potentially `perf`, `security`).
-*   **Scope**: The component affected (e.g., `project`, `compose-app`, `server-auth`, `bruno-api`).
-*   **Subject**: Use the imperative, present tense: "change" not "changed" nor "changes". Don't capitalize the first letter. No dot (.) at the end.
+- **Types**: `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`, `ci`, `build` (and potentially `perf`, `security`).
+- **Scope**: The component affected (e.g., `project`, `compose-app`, `server-auth`, `bruno-api`).
+- **Subject**: Use the imperative, present tense: "change" not "changed" nor "changes". Don't capitalize the first letter. No dot (.) at the end.
 
-*   **Subject**: Use the imperative, present tense: "change" not "changed" nor "changes". Don't capitalize the first letter. No dot (.) at the end.
-
-## 3. Commit Examples
+## 2. Commit Examples
 
 Here are some examples of valid commit messages:
 
-*   feat(compose-app): add new campaign creation form
+- feat(compose-app): add new campaign creation form
+- fix(server-auth): prevent XSS attack in login endpoint
+- docs(project): update AGENTS.md with new project overview
+- style(compose-app): format `CampaignListScreen.kt` with ktlint
+- refactor(spring-server): extract common logging logic to a utility class
+- test(bruno-api): add E2E test for user registration flow
+- build(compose-app): update gradle wrapper to 8.x
 
-*   fix(server-auth): prevent XSS attack in login endpoint**
-    A bug fix related to security in the authentication server.
-
-*   docs(project): update AGENTS.md with new project overview
-
-*   style(compose-app): format `CampaignListScreen.kt` with ktlint
-
-*   refactor(spring-server): extract common logging logic to a utility class
-
-*   test(bruno-api): add E2E test for user registration flow
-
-*   build(compose-app): update gradle wrapper to 8.x
-
-## 4. Trunk-Based Development Branching Strategy
+## 3. Trunk-Based Development Branching Strategy
 
 We utilize a **Trunk-Based Development** branching strategy. This means:
 
-*   **Single Main Branch:** All development happens directly on or very close to a single main branch (often named `main`).
-*   **Small, Frequent Commits:** Developers commit small changes frequently to the main branch, often multiple times a day.
-*   **Short-Lived Feature Branches:** If feature branches are used, they are kept very short-lived and merged back into the main branch as quickly as possible (typically within a day or two). Naming convention: `feature/short-description` (e.g., `feature/create-campaign`), `bugfix/issue-description`.
-*   **Continuous Integration:** A robust Continuous Integration (CI) system is essential to automatically build and test changes pushed to the main branch, catching integration issues early.
-*   **Feature Flags:** To deploy incomplete features without affecting users, feature flags (also known as feature toggles) are used to enable or disable features at runtime. This allows for continuous delivery and reduces the need for long-lived feature branches.
+- **Single Main Branch:** All development happens directly on or very close to a single main branch (often named `main`).
+- **Small, Frequent Commits:** Developers commit small changes frequently to the main branch, often multiple times a day.
+- **Short-Lived Feature Branches:** If feature branches are used, they are kept very short-lived and merged back into the main branch as quickly as possible (typically within a day or two). Naming convention: `feature/short-description` (e.g., `feature/create-campaign`), `bugfix/issue-description`.
+- **Continuous Integration:** A robust Continuous Integration (CI) system is essential to automatically build and test changes pushed to the main branch, catching integration issues early.
+- **Feature Flags:** To deploy incomplete features without affecting users, feature flags (also known as feature toggles) are used to enable or disable features at runtime. This allows for continuous delivery and reduces the need for long-lived feature branches.
 
 This approach promotes continuous integration, reduces merge conflicts, and enables faster delivery of features.

--- a/docs/conventions/GIT_CONVENTIONS.md
+++ b/docs/conventions/GIT_CONVENTIONS.md
@@ -1,0 +1,54 @@
+# Git Conventions
+
+This document outlines the Git conventions and branching strategy used across the project. Adhering to these conventions helps maintain a clean, understandable, and traceable project history.
+
+Refer to `../../AGENTS.md` for overall project guidelines.
+
+## 1. Conventional Commits
+
+We follow **Conventional Commits** to keep the history clean and to allow automated changelog generation.
+
+### Commit Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+```
+
+*   **Types**: `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`, `ci`, `build` (and potentially `perf`, `security`).
+*   **Scope**: The component affected (e.g., `project`, `compose-app`, `server-auth`, `bruno-api`).
+*   **Subject**: Use the imperative, present tense: "change" not "changed" nor "changes". Don't capitalize the first letter. No dot (.) at the end.
+
+*   **Subject**: Use the imperative, present tense: "change" not "changed" nor "changes". Don't capitalize the first letter. No dot (.) at the end.
+
+## 3. Commit Examples
+
+Here are some examples of valid commit messages:
+
+*   feat(compose-app): add new campaign creation form
+
+*   fix(server-auth): prevent XSS attack in login endpoint**
+    A bug fix related to security in the authentication server.
+
+*   docs(project): update AGENTS.md with new project overview
+
+*   style(compose-app): format `CampaignListScreen.kt` with ktlint
+
+*   refactor(spring-server): extract common logging logic to a utility class
+
+*   test(bruno-api): add E2E test for user registration flow
+
+*   build(compose-app): update gradle wrapper to 8.x
+
+## 4. Trunk-Based Development Branching Strategy
+
+We utilize a **Trunk-Based Development** branching strategy. This means:
+
+*   **Single Main Branch:** All development happens directly on or very close to a single main branch (often named `main`).
+*   **Small, Frequent Commits:** Developers commit small changes frequently to the main branch, often multiple times a day.
+*   **Short-Lived Feature Branches:** If feature branches are used, they are kept very short-lived and merged back into the main branch as quickly as possible (typically within a day or two). Naming convention: `feature/short-description` (e.g., `feature/create-campaign`), `bugfix/issue-description`.
+*   **Continuous Integration:** A robust Continuous Integration (CI) system is essential to automatically build and test changes pushed to the main branch, catching integration issues early.
+*   **Feature Flags:** To deploy incomplete features without affecting users, feature flags (also known as feature toggles) are used to enable or disable features at runtime. This allows for continuous delivery and reduces the need for long-lived feature branches.
+
+This approach promotes continuous integration, reduces merge conflicts, and enables faster delivery of features.

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -6,14 +6,14 @@ Refer to `../../AGENTS.md` for project-wide guidelines.
 
 ## 1. Tech Stack & Dependency Management
 
--   **Language**: Kotlin (latest stable version).
--   **Multiplatform**: Kotlin Multiplatform (KMP) targeting Android, iOS, and Desktop (JVM).
--   **UI Framework**: Compose Multiplatform.
--   **Local Database**: SQLDelight.
--   **Dependency Injection**: Manual DI only; no external DI libraries allowed.
--   **Dependency Management**:
-    -   Gradle Version Catalogs (`gradle/libs.versions.toml`) + `buildSrc`.
-    -   *Never hardcode dependency versions in build scripts.*
+- **Language**: Kotlin (latest stable version).
+- **Multiplatform**: Kotlin Multiplatform (KMP) targeting Android, iOS, and Desktop (JVM).
+- **UI Framework**: Compose Multiplatform.
+- **Local Database**: SQLDelight.
+- **Dependency Injection**: Manual DI only; no external DI libraries allowed.
+- **Dependency Management**:
+    - Gradle Version Catalogs (`gradle/libs.versions.toml`) + `buildSrc`.
+    - *Never hardcode dependency versions in build scripts.*
 
 ## 2. Architecture
 
@@ -21,22 +21,22 @@ The application follows a **Clean Architecture** and **Layered** approach adapte
 
 ### Modules
 
--   **`shared/core`**: Contains pure Kotlin code (Domain layer, generic utilities) and cross-platform Data layer implementations (e.g., SQLDelight repositories).
--   **`composeApp`**: Contains the Presentation layer using Compose Multiplatform and ViewModels.
+- **`shared/core`**: Contains pure Kotlin code (Domain layer, generic utilities) and cross-platform Data layer implementations (e.g., SQLDelight repositories).
+- **`composeApp`**: Contains the Presentation layer using Compose Multiplatform and ViewModels.
 
 ### Presentation Layer (MVVM + UDF)
 
--   Use **Model-View-ViewModel (MVVM)**.
--   Follow **Unidirectional Data Flow (UDF)**:
-    -   State flows down: ViewModels expose a single `StateFlow<ViewState>`.
-    -   Events flow up: Composables pass user actions to the ViewModel via specific functions (e.g., `viewModel::onActionClicked`).
--   Keep ViewModels platform-agnostic using `lifecycle-viewmodel-compose` from JetBrains.
--   Do not pass ViewModels down the Composable tree. Pass state and lambda callbacks instead.
+- **Use Model-View-ViewModel (MVVM)**.
+- **Follow Unidirectional Data Flow (UDF)**:
+    - State flows down: ViewModels expose a single `StateFlow<ViewState>`.
+    - Events flow up: Composables pass user actions to the ViewModel via specific functions (e.g., `viewModel::onActionClicked`).
+- **Keep ViewModels platform-agnostic** using `lifecycle-viewmodel-compose` from JetBrains.
+- **Do not pass ViewModels down the Composable tree**. Pass state and lambda callbacks instead.
 
 ### Domain & Data Layers
 
--   **Domain**: Pure Kotlin. Contains Entities and Use Cases/Interactors. Independent of any framework.
--   **Data**: Repositories abstract the data sources. Return Kotlin `Flow` for reactive data streams and `suspend` functions for one-shot operations.
+- **Domain**: Pure Kotlin. Contains Entities and Use Cases/Interactors. Independent of any framework.
+- **Data**: Repositories abstract the data sources. Return Kotlin `Flow` for reactive data streams and `suspend` functions for one-shot operations.
 
 ## 3. Coding Conventions
 
@@ -44,29 +44,29 @@ The project enforces code formatting using **ktlint**.
 
 ### Kotlin Idioms
 
--   Favor immutability: use `val` over `var` and immutable collections (`List`, `Set`, `Map`) by default.
--   Use Kotlin Coroutines and Flows for asynchronous programming.
--   Use `require()`, `check()`, and `error()` for preconditions and state validation.
--   Avoid nullable types where possible. Use sealed classes/interfaces for representing exhaustive states (e.g., `Loading`, `Success`, `Error`).
--   **Comments**: Prioritize self-documenting code. Add comments only when the code's intent is not immediately obvious, or to explain *why* a particular approach was taken, rather than *what* the code does.
+- Favor immutability: use `val` over `var` and immutable collections (`List`, `Set`, `Map`) by default.
+- Use Kotlin Coroutines and Flows for asynchronous programming.
+- Use `require()`, `check()`, and `error()` for preconditions and state validation.
+- Avoid nullable types where possible. Use sealed classes/interfaces for representing exhaustive states (e.g., `Loading`, `Success`, `Error`).
+- **Comments**: Prioritize self-documenting code. Add comments only when the code's intent is not immediately obvious, or to explain *why* a particular approach was taken, rather than *what* the code does.
 
 ### Jetpack Compose Guidelines
 
--   **Naming**: Composable functions returning `Unit` must be `PascalCase` (e.g., `CreateCampaignScreen`). Composables returning a value should be `camelCase`.
--   **Modifiers**: Every Composable should accept a `modifier: Modifier = Modifier` as the first optional parameter.
--   **State Hoisting**: Hoist state to the lowest common parent. Composables should be as stateless as possible.
--   **Previews**: Write `@Preview` functions for all UI components. Use `androidx.compose.ui.tooling.preview.Preview` from `org.jetbrains.compose.ui:ui-tooling-preview` module for Multiplatform previews.
--   **Resources**: Use the generated KMP resources (`Res.string.xxx`, `Res.drawable.xxx`).
+- **Naming**: Composable functions returning `Unit` must be `PascalCase` (e.g., `CreateCampaignScreen`). Composables returning a value should be `camelCase`.
+- **Modifiers**: Every Composable should accept a `modifier: Modifier = Modifier` as the first optional parameter.
+- **State Hoisting**: Hoist state to the lowest common parent. Composables should be as stateless as possible.
+- **Previews**: Write `@Preview` functions for all UI components. Use `androidx.compose.ui.tooling.preview.Preview` from `org.jetbrains.compose.ui:ui-tooling-preview` module for Multiplatform previews.
+- **Resources**: Use the generated KMP resources (`Res.string.xxx`, `Res.drawable.xxx`).
 
 ## 4. Testing
 
--   **Unit Tests**: Test pure business logic (Domain layer) and ViewModels in the `commonTest` source set.
--   **Coroutines Testing**: Use `runTest` and inject test dispatchers for predictable coroutine execution.
--   **UI Tests**: Test Compose UI components in isolation (if applicable via Android instrumented tests or Desktop UI tests).
--   Focus on behavior testing rather than implementation details.
+- **Unit Tests**: Test pure business logic (Domain layer) and ViewModels in the `commonTest` source set.
+- **Coroutines Testing**: Use `runTest` and inject test dispatchers for predictable coroutine execution.
+- **UI Tests**: Test Compose UI components in isolation (if applicable via Android instrumented tests or Desktop UI tests).
+- Focus on behavior testing rather than implementation details.
 
 ## 5. CI & Policies (KMP Specific)
 
--   **Code Quality**: PRs must pass `ktlintCheck` and the project must build successfully for all targets (`android`, `ios`, `desktop`) on the CI pipeline.
--   **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
--   **Documentation**: Document complex business logic, public APIs, and architectural decisions. Prioritize self-documenting code. Use KDoc for public APIs in shared modules to clearly define their contracts, parameters, return values, and behavior, aiding consumers in understanding how to use the API without delving into implementation details.
+- **Code Quality**: PRs must pass `ktlintCheck` and the project must build successfully for all targets (`android`, `ios`, `desktop`) on the CI pipeline.
+- **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
+- **Documentation**: Document complex business logic, public APIs, and architectural decisions. Prioritize self-documenting code. Use KDoc for public APIs in shared modules to clearly define their contracts, parameters, return values, and behavior, aiding consumers in understanding how to use the API without delving into implementation details.

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -64,7 +64,7 @@ The project enforces code formatting using **ktlint**.
 - **UI Tests**: Test Compose UI components in isolation (if applicable via Android instrumented tests or Desktop UI tests).
 - Focus on behavior testing rather than implementation details.
 
-## 5. CI & Policies (KMP Specific)
+## 5. CI & Policies
 
 - **Code Quality**: PRs must pass `ktlintCheck` and the project must build successfully for all targets (`android`, `ios`, `desktop`) on the CI pipeline.
 - **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -48,7 +48,6 @@ The project enforces code formatting using **ktlint**.
 - Use Kotlin Coroutines and Flows for asynchronous programming.
 - Use `require()`, `check()`, and `error()` for preconditions and state validation.
 - Avoid nullable types where possible. Use sealed classes/interfaces for representing exhaustive states (e.g., `Loading`, `Success`, `Error`).
-- **Comments**: Prioritize self-documenting code. Add comments only when the code's intent is not immediately obvious, or to explain *why* a particular approach was taken, rather than *what* the code does.
 
 ### Jetpack Compose Guidelines
 
@@ -69,4 +68,4 @@ The project enforces code formatting using **ktlint**.
 
 - **Code Quality**: PRs must pass `ktlintCheck` and the project must build successfully for all targets (`android`, `ios`, `desktop`) on the CI pipeline.
 - **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
-- **Documentation**: Document complex business logic, public APIs, and architectural decisions. Prioritize self-documenting code. Use KDoc for public APIs in shared modules to clearly define their contracts, parameters, return values, and behavior, aiding consumers in understanding how to use the API without delving into implementation details.
+- **Documentation**: Document complex business logic, public APIs, and architectural decisions. Use KDoc for public APIs in shared modules to clearly define their contracts.

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -66,6 +66,8 @@ The project enforces code formatting using **ktlint**.
 
 ## 5. CI & Policies
 
-- **Code Quality**: PRs must pass `ktlintCheck` and the project must build successfully for all targets (`android`, `ios`, `desktop`) on the CI pipeline.
-- **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
-- **Documentation**: Document complex business logic, public APIs, and architectural decisions. Use KDoc for public APIs in shared modules to clearly define their contracts.
+Refer to [`GIT_AND_COLLABORATION.md`](GIT_AND_COLLABORATION.md) for general CI policies (warnings as errors, PR requirements, security scans).
+
+KMP-specific CI requirements:
+- PRs must pass `ktlintCheck` and the project must build successfully for all targets (`android`, `ios`, `desktop`).
+- Use KDoc for public APIs in shared modules to clearly define their contracts.

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -1,0 +1,72 @@
+# Kotlin Multiplatform & Compose Multiplatform Conventions
+
+This document details the specific architectural patterns, coding conventions, and testing guidelines for the Kotlin Multiplatform (KMP) and Compose Multiplatform (CMP) parts of the project, primarily located in the `cmp-ttrpg-companion` directory.
+
+Refer to `../../AGENTS.md` for project-wide guidelines.
+
+## 1. Tech Stack & Dependency Management
+
+-   **Language**: Kotlin (latest stable version).
+-   **Multiplatform**: Kotlin Multiplatform (KMP) targeting Android, iOS, and Desktop (JVM).
+-   **UI Framework**: Compose Multiplatform.
+-   **Local Database**: SQLDelight.
+-   **Dependency Injection**: Manual DI only; no external DI libraries allowed.
+-   **Dependency Management**:
+    -   Gradle Version Catalogs (`gradle/libs.versions.toml`) + `buildSrc`.
+    -   *Never hardcode dependency versions in build scripts.*
+
+## 2. Architecture
+
+The application follows a **Clean Architecture** and **Layered** approach adapted for Kotlin Multiplatform.
+
+### Modules
+
+-   **`shared/core`**: Contains pure Kotlin code (Domain layer, generic utilities) and cross-platform Data layer implementations (e.g., SQLDelight repositories).
+-   **`composeApp`**: Contains the Presentation layer using Compose Multiplatform and ViewModels.
+
+### Presentation Layer (MVVM + UDF)
+
+-   Use **Model-View-ViewModel (MVVM)**.
+-   Follow **Unidirectional Data Flow (UDF)**:
+    -   State flows down: ViewModels expose a single `StateFlow<ViewState>`.
+    -   Events flow up: Composables pass user actions to the ViewModel via specific functions (e.g., `viewModel::onActionClicked`).
+-   Keep ViewModels platform-agnostic using `lifecycle-viewmodel-compose` from JetBrains.
+-   Do not pass ViewModels down the Composable tree. Pass state and lambda callbacks instead.
+
+### Domain & Data Layers
+
+-   **Domain**: Pure Kotlin. Contains Entities and Use Cases/Interactors. Independent of any framework.
+-   **Data**: Repositories abstract the data sources. Return Kotlin `Flow` for reactive data streams and `suspend` functions for one-shot operations.
+
+## 3. Coding Conventions
+
+The project enforces code formatting using **ktlint**.
+
+### Kotlin Idioms
+
+-   Favor immutability: use `val` over `var` and immutable collections (`List`, `Set`, `Map`) by default.
+-   Use Kotlin Coroutines and Flows for asynchronous programming.
+-   Use `require()`, `check()`, and `error()` for preconditions and state validation.
+-   Avoid nullable types where possible. Use sealed classes/interfaces for representing exhaustive states (e.g., `Loading`, `Success`, `Error`).
+-   **Comments**: Prioritize self-documenting code. Add comments only when the code's intent is not immediately obvious, or to explain *why* a particular approach was taken, rather than *what* the code does.
+
+### Jetpack Compose Guidelines
+
+-   **Naming**: Composable functions returning `Unit` must be `PascalCase` (e.g., `CreateCampaignScreen`). Composables returning a value should be `camelCase`.
+-   **Modifiers**: Every Composable should accept a `modifier: Modifier = Modifier` as the first optional parameter.
+-   **State Hoisting**: Hoist state to the lowest common parent. Composables should be as stateless as possible.
+-   **Previews**: Write `@Preview` functions for all UI components. Use `androidx.compose.ui.tooling.preview.Preview` from `org.jetbrains.compose.ui:ui-tooling-preview` module for Multiplatform previews.
+-   **Resources**: Use the generated KMP resources (`Res.string.xxx`, `Res.drawable.xxx`).
+
+## 4. Testing
+
+-   **Unit Tests**: Test pure business logic (Domain layer) and ViewModels in the `commonTest` source set.
+-   **Coroutines Testing**: Use `runTest` and inject test dispatchers for predictable coroutine execution.
+-   **UI Tests**: Test Compose UI components in isolation (if applicable via Android instrumented tests or Desktop UI tests).
+-   Focus on behavior testing rather than implementation details.
+
+## 5. CI & Policies (KMP Specific)
+
+-   **Code Quality**: PRs must pass `ktlintCheck` and the project must build successfully for all targets (`android`, `ios`, `desktop`) on the CI pipeline.
+-   **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
+-   **Documentation**: Document complex business logic, public APIs, and architectural decisions. Prioritize self-documenting code. Use KDoc for public APIs in shared modules to clearly define their contracts, parameters, return values, and behavior, aiding consumers in understanding how to use the API without delving into implementation details.

--- a/docs/conventions/RUST_CONVENTIONS.md
+++ b/docs/conventions/RUST_CONVENTIONS.md
@@ -1,0 +1,46 @@
+# Rust Backend Conventions
+
+This document outlines the architectural patterns, coding conventions, and best practices specifically for any Rust services within the project.
+
+Refer to `../../AGENTS.md` for project-wide guidelines.
+
+## 1. Tech Stack & Dependency Management
+- **Language**: Rust (latest stable edition).
+- **Package Manager**: Cargo.
+- **Web Framework**: Axum (for web services).
+- **Asynchronous Runtime**: Tokio.
+- **Database Client**: `sqlx`.
+- **Dependency Management**: Manage dependencies via `Cargo.toml`.
+
+## 2. Architecture
+
+### Service Architecture
+- Design services to be modular and focused on single responsibilities.
+- Consider a layered approach (e.g., Handlers, Services/Business Logic, Repositories).
+- Utilize Rust's ownership and borrowing system to ensure memory safety and concurrency without data races.
+
+## 3. Coding Conventions
+- **Code Formatting**: Adhere to `rustfmt` for consistent code formatting.
+- **Linting**: Use `clippy` to catch common mistakes and improve Rust code.
+- **Error Handling**: Favor `Result` and `Option` for explicit error handling over panics. Use custom error types where appropriate.
+- **Concurrency**: Utilize `async/await` and Rust's robust concurrency primitives (`Arc`, `Mutex`, `RwLock`, channels) responsibly.
+- **Documentation**: Write clear and comprehensive `///` documentation comments for public APIs.
+
+## 4. API Design
+- Design RESTful APIs if applicable, following similar principles as other backend services.
+- Ensure clear data serialization/deserialization, typically using `serde`.
+
+## 5. Testing
+- **Unit Tests**: Write unit tests for individual functions and modules, typically inline with the code.
+- **Integration Tests**: Create integration tests in the `tests` directory to test interactions between components or with external services.
+- **Property-Based Testing**: Consider using libraries like `proptest` for robust testing of complex logic.
+
+## 6. Performance & Safety
+- **Benchmarking**: Use Rust's built-in benchmarking tools or `criterion` for performance-critical sections.
+- **Unsafe Rust**: Minimize the use of `unsafe` blocks and ensure thorough justification and review when necessary.
+- **Memory Management**: Leverage Rust's compile-time memory safety. Avoid common pitfalls like excessive cloning.
+
+## 7. CI & Policies
+- **Build & Test**: Ensure `cargo build` and `cargo test` pass for all pull requests.
+- **Linting**: Integrate `clippy` checks into the CI pipeline.
+- **Security Audits**: Consider `cargo audit` for checking known vulnerabilities in dependencies.

--- a/docs/conventions/RUST_CONVENTIONS.md
+++ b/docs/conventions/RUST_CONVENTIONS.md
@@ -41,6 +41,10 @@ Refer to `../../AGENTS.md` for project-wide guidelines.
 - **Memory Management**: Leverage Rust's compile-time memory safety. Avoid common pitfalls like excessive cloning.
 
 ## 7. CI & Policies
-- **Build & Test**: Ensure `cargo build` and `cargo test` pass for all pull requests.
-- **Linting**: Integrate `clippy` checks into the CI pipeline.
-- **Security Audits**: Consider `cargo audit` for checking known vulnerabilities in dependencies.
+
+Refer to [`GIT_AND_COLLABORATION.md`](GIT_AND_COLLABORATION.md) for general CI policies (warnings as errors, PR requirements, security scans).
+
+Rust-specific CI requirements:
+- `cargo build` and `cargo test` must pass for all pull requests.
+- `clippy` checks must be integrated into the CI pipeline.
+- Run `cargo audit` to check for known vulnerabilities in dependencies.

--- a/docs/conventions/SPRING_BOOT_CONVENTIONS.md
+++ b/docs/conventions/SPRING_BOOT_CONVENTIONS.md
@@ -15,17 +15,50 @@ Refer to `../../AGENTS.md` for project-wide guidelines.
 
 ## 2. Architecture
 
-The Spring Boot server will follow a layered architecture, typically including:
+The Spring Boot server follows **Clean Architecture** with a layered approach:
 
-- **Controller Layer**: Handles HTTP requests and responses, exposing RESTful APIs.
-- **Service Layer**: Contains business logic and orchestrates operations.
-- **Repository Layer**: Interacts with the database, abstracting data access.
+- **Controller Layer**: Handles HTTP requests/responses. Maps request bodies to domain models or DTOs and delegates to the Service layer. Never contains business logic.
+- **Service Layer**: Contains all business logic and orchestrates operations between repositories and external services.
+- **Repository Layer**: Abstracts data access. Returns domain models, not raw JPA entities.
+
+### Package Structure
+
+Organize by **feature/domain**, not by layer:
+
+```
+com.cyrillrx.rpg.server/
+├── campaign/
+│   ├── CampaignController.kt
+│   ├── domain/
+│   │   ├── CampaignService.kt
+│   │   └── model/
+│   └── data/
+│       ├── CampaignEntity.kt
+│       └── CampaignRepository.kt
+├── security/
+│   └── ...
+└── shared/
+    └── ...  # Cross-cutting utilities
+```
+
+### DTOs vs Domain Models
+
+- Use dedicated **request/response DTOs** at the Controller boundary (e.g., `CreateCampaignRequest`, `CampaignResponse`).
+- Keep **domain models** free of Spring/JPA annotations — they live in the `domain/model/` package.
+- Use **JPA entities** only in the `data/` package; map to/from domain models before returning from repositories.
 
 ## 3. API Design
 
 - Design RESTful APIs following principles like statelessness, resource-based URLs, and standard HTTP methods.
 - Use clear and consistent naming conventions for API endpoints and request/response bodies.
 - Implement proper error handling with appropriate HTTP status codes and informative error messages.
+
+## 3.5. Kotlin Idioms for Spring Boot
+
+- Use `data class` for request/response DTOs.
+- Avoid `lateinit var` for injected dependencies; prefer constructor injection, which works naturally with Kotlin's `val`.
+- Be explicit about nullability on JPA entity fields — Hibernate may set fields to `null` even for non-nullable Kotlin types. Use `var` with a sensible default or nullable type for JPA-managed fields.
+- Prefer Kotlin's `require()` / `check()` for precondition validation in service methods.
 
 ## 4. Security
 

--- a/docs/conventions/SPRING_BOOT_CONVENTIONS.md
+++ b/docs/conventions/SPRING_BOOT_CONVENTIONS.md
@@ -21,36 +21,30 @@ The Spring Boot server will follow a layered architecture, typically including:
 - **Service Layer**: Contains business logic and orchestrates operations.
 - **Repository Layer**: Interacts with the database, abstracting data access.
 
-## 3. Coding Conventions
-
-- Follow standard Kotlin/Java coding conventions (e.g., official style guides).
-- Use meaningful names for classes, methods, and variables.
-- Favor immutability where appropriate.
-
-## 4. API Design
+## 3. API Design
 
 - Design RESTful APIs following principles like statelessness, resource-based URLs, and standard HTTP methods.
 - Use clear and consistent naming conventions for API endpoints and request/response bodies.
 - Implement proper error handling with appropriate HTTP status codes and informative error messages.
 
-## 5. Security
+## 4. Security
 
 - Implement authentication and authorization mechanisms (e.g., Spring Security with JWT).
 - Ensure sensitive data is handled securely (e.g., encryption, proper storage).
 - Validate all input to prevent common vulnerabilities like SQL injection and XSS.
 
-## 6. Testing
+## 5. Testing
 
 - **Unit Tests**: Write unit tests for business logic in the Service layer.
 - **Integration Tests**: Write integration tests for controllers and repository interactions using Spring Boot's testing utilities.
 - **End-to-End Tests**: Consider using tools like Bruno (see `BRUNO_CONVENTIONS.md`) for API end-to-end testing.
 
-## 7. Configuration
+## 6. Configuration
 
 - Manage configuration using Spring Boot's externalized configuration features (e.g., `application.properties` or `application.yml`, environment variables).
 - Avoid hardcoding sensitive information; use environment variables or a secure vault solution.
 
-## 8. Logging
+## 7. Logging
 
 - Implement consistent logging practices using a logging framework (e.g., SLF4J with Logback).
 - Configure log levels appropriately for different environments.

--- a/docs/conventions/SPRING_BOOT_CONVENTIONS.md
+++ b/docs/conventions/SPRING_BOOT_CONVENTIONS.md
@@ -1,0 +1,56 @@
+# Spring Boot Server Conventions
+
+This document outlines the architectural patterns, coding conventions, and best practices specifically for the Spring Boot server component of the project, located in the `spring-server` directory.
+
+Refer to `../../AGENTS.md` for project-wide guidelines.
+
+## 1. Tech Stack & Dependency Management
+
+-   **Language**: Kotlin.
+-   **Framework**: Spring Boot (latest stable version).
+-   **Build Tool**: Gradle.
+-   **Database**: PostgreSQL.
+-   **ORM**: Spring Data JPA with Hibernate.
+-   **Dependency Management**: Utilize Gradle for dependency management, ensuring versions are managed consistently (e.g., via Gradle Version Catalogs).
+
+## 2. Architecture
+
+The Spring Boot server will follow a layered architecture, typically including:
+
+-   **Controller Layer**: Handles HTTP requests and responses, exposing RESTful APIs.
+-   **Service Layer**: Contains business logic and orchestrates operations.
+-   **Repository Layer**: Interacts with the database, abstracting data access.
+
+## 3. Coding Conventions
+
+-   Follow standard Kotlin/Java coding conventions (e.g., official style guides).
+-   Use meaningful names for classes, methods, and variables.
+-   Favor immutability where appropriate.
+
+## 4. API Design
+
+-   Design RESTful APIs following principles like statelessness, resource-based URLs, and standard HTTP methods.
+-   Use clear and consistent naming conventions for API endpoints and request/response bodies.
+-   Implement proper error handling with appropriate HTTP status codes and informative error messages.
+
+## 5. Security
+
+-   Implement authentication and authorization mechanisms (e.g., Spring Security with JWT).
+-   Ensure sensitive data is handled securely (e.g., encryption, proper storage).
+-   Validate all input to prevent common vulnerabilities like SQL injection and XSS.
+
+## 6. Testing
+
+-   **Unit Tests**: Write unit tests for business logic in the Service layer.
+-   **Integration Tests**: Write integration tests for controllers and repository interactions using Spring Boot's testing utilities.
+-   **End-to-End Tests**: Consider using tools like Bruno (see `BRUNO_CONVENTIONS.md`) for API end-to-end testing.
+
+## 7. Configuration
+
+-   Manage configuration using Spring Boot's externalized configuration features (e.g., `application.properties` or `application.yml`, environment variables).
+-   Avoid hardcoding sensitive information; use environment variables or a secure vault solution.
+
+## 8. Logging
+
+-   Implement consistent logging practices using a logging framework (e.g., SLF4J with Logback).
+-   Configure log levels appropriately for different environments.

--- a/docs/conventions/SPRING_BOOT_CONVENTIONS.md
+++ b/docs/conventions/SPRING_BOOT_CONVENTIONS.md
@@ -6,51 +6,51 @@ Refer to `../../AGENTS.md` for project-wide guidelines.
 
 ## 1. Tech Stack & Dependency Management
 
--   **Language**: Kotlin.
--   **Framework**: Spring Boot (latest stable version).
--   **Build Tool**: Gradle.
--   **Database**: PostgreSQL.
--   **ORM**: Spring Data JPA with Hibernate.
--   **Dependency Management**: Utilize Gradle for dependency management, ensuring versions are managed consistently (e.g., via Gradle Version Catalogs).
+- **Language**: Kotlin.
+- **Framework**: Spring Boot (latest stable version).
+- **Build Tool**: Gradle.
+- **Database**: PostgreSQL.
+- **ORM**: Spring Data JPA with Hibernate.
+- **Dependency Management**: Utilize Gradle for dependency management, ensuring versions are managed consistently (e.g., via Gradle Version Catalogs).
 
 ## 2. Architecture
 
 The Spring Boot server will follow a layered architecture, typically including:
 
--   **Controller Layer**: Handles HTTP requests and responses, exposing RESTful APIs.
--   **Service Layer**: Contains business logic and orchestrates operations.
--   **Repository Layer**: Interacts with the database, abstracting data access.
+- **Controller Layer**: Handles HTTP requests and responses, exposing RESTful APIs.
+- **Service Layer**: Contains business logic and orchestrates operations.
+- **Repository Layer**: Interacts with the database, abstracting data access.
 
 ## 3. Coding Conventions
 
--   Follow standard Kotlin/Java coding conventions (e.g., official style guides).
--   Use meaningful names for classes, methods, and variables.
--   Favor immutability where appropriate.
+- Follow standard Kotlin/Java coding conventions (e.g., official style guides).
+- Use meaningful names for classes, methods, and variables.
+- Favor immutability where appropriate.
 
 ## 4. API Design
 
--   Design RESTful APIs following principles like statelessness, resource-based URLs, and standard HTTP methods.
--   Use clear and consistent naming conventions for API endpoints and request/response bodies.
--   Implement proper error handling with appropriate HTTP status codes and informative error messages.
+- Design RESTful APIs following principles like statelessness, resource-based URLs, and standard HTTP methods.
+- Use clear and consistent naming conventions for API endpoints and request/response bodies.
+- Implement proper error handling with appropriate HTTP status codes and informative error messages.
 
 ## 5. Security
 
--   Implement authentication and authorization mechanisms (e.g., Spring Security with JWT).
--   Ensure sensitive data is handled securely (e.g., encryption, proper storage).
--   Validate all input to prevent common vulnerabilities like SQL injection and XSS.
+- Implement authentication and authorization mechanisms (e.g., Spring Security with JWT).
+- Ensure sensitive data is handled securely (e.g., encryption, proper storage).
+- Validate all input to prevent common vulnerabilities like SQL injection and XSS.
 
 ## 6. Testing
 
--   **Unit Tests**: Write unit tests for business logic in the Service layer.
--   **Integration Tests**: Write integration tests for controllers and repository interactions using Spring Boot's testing utilities.
--   **End-to-End Tests**: Consider using tools like Bruno (see `BRUNO_CONVENTIONS.md`) for API end-to-end testing.
+- **Unit Tests**: Write unit tests for business logic in the Service layer.
+- **Integration Tests**: Write integration tests for controllers and repository interactions using Spring Boot's testing utilities.
+- **End-to-End Tests**: Consider using tools like Bruno (see `BRUNO_CONVENTIONS.md`) for API end-to-end testing.
 
 ## 7. Configuration
 
--   Manage configuration using Spring Boot's externalized configuration features (e.g., `application.properties` or `application.yml`, environment variables).
--   Avoid hardcoding sensitive information; use environment variables or a secure vault solution.
+- Manage configuration using Spring Boot's externalized configuration features (e.g., `application.properties` or `application.yml`, environment variables).
+- Avoid hardcoding sensitive information; use environment variables or a secure vault solution.
 
 ## 8. Logging
 
--   Implement consistent logging practices using a logging framework (e.g., SLF4J with Logback).
--   Configure log levels appropriately for different environments.
+- Implement consistent logging practices using a logging framework (e.g., SLF4J with Logback).
+- Configure log levels appropriately for different environments.


### PR DESCRIPTION
## 📝 Description

Establishes the full documentation baseline for contributors (human and AI):

- `AGENTS.md`: central guide linking all convention documents, project structure, and components
- `GIT_AND_COLLABORATION.md`: conventional commits, trunk-based development, branch naming, CI policies
- `CODING_CONVENTIONS.md`: Clean Code principles (naming, functions, comments, error handling, testing)
- `KMP_CONVENTIONS.md`: MVVM + UDF architecture, Compose guidelines, coroutines, ktlint
- `SPRING_BOOT_CONVENTIONS.md`: Clean Architecture, package structure, DTO/entity separation, Kotlin idioms
- `RUST_CONVENTIONS.md`: Axum + Tokio stack, error handling, `rustfmt`/`clippy`
- `BRUNO_CONVENTIONS.md`: collection structure, naming, environments, assertions, CI integration
- `.github/pull_request_template.md`: PR template aligned with the conventions

## 🏷️  Type of change

- [x] `docs` — documentation only

## ✅ Checklist

- [x] The author has proofread the PR
- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed