### PR TITLE
docs(prd): add product requirement documents for all core features

### DIFF
--- a/docs/prd/PRD-000-VISION.md
+++ b/docs/prd/PRD-000-VISION.md
@@ -1,0 +1,105 @@
+# PRD-000 — Vision & Foundation
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+## Overview
+
+TTRPG Companion is a cross-platform mobile and desktop application designed to support tabletop role-playing game sessions.
+It targets both Game Masters (GMs) and players, providing tools to manage campaigns, characters, rules references, and in-session utilities — all in one place.
+
+## Problem Statement
+
+Managing a TTRPG session involves juggling a large amount of information: spell lists, character sheets, monster stats, campaign notes, inventory. Physical books and scattered notes are slow and error-prone. Existing digital tools are either too specialized, not available offline, or require an internet connection and account from the start.
+
+## Goals
+
+- Provide a companion app usable from day one with no account required (offline-first).
+- Enable seamless data sync and sharing between devices and players when online.
+- Support D&D 5e as the primary rule system, with extensibility to others.
+- Keep the experience simple and fast during a live session.
+
+## User Roles
+
+Roles are **not fixed account types** — they are **per-campaign roles** determined by how a user relates to a specific campaign. The same user can be a GM in one campaign and a Player in another.
+
+| Role | Abbreviation | How it is assigned |
+|---|---|---|
+| Game Master | GM | Automatically assigned to the user who **creates** the campaign. |
+| Player | P | Assigned when a user **joins a campaign by invitation**. |
+| User | U | Any user, regardless of their role in any campaign. Applies to features available to everyone. |
+
+### Campaign Role Assignment
+
+| Situation | Role in that campaign |
+|---|---|
+| User creates a campaign | GM (full editor access) |
+| User is invited to a campaign | Player (read-only, except own PC sheets) |
+
+### Access Matrix
+
+| Action | Any User (U) | GM (in their campaign) | Player (in a shared campaign) |
+|---|---|---|---|
+| Read public reference data (spells, items, monsters) | ✅ | ✅ | ✅ |
+| Create/edit own character sheets (personal library) | ✅ | ✅ | ✅ |
+| Create and manage a campaign | ✅ | ✅ | ✅ |
+| Edit campaign content (notes, roster, settings) | — | ✅ | ✗ |
+| Read campaign content (notes, roster) | — | ✅ | ✅ |
+| Invite players to a campaign | — | ✅ | ✗ |
+| Edit own Player Character sheet within a campaign | — | ✅ | ✅ |
+| Edit other characters' sheets within a campaign | — | ✅ | ✗ |
+| Create/edit custom content (spells, monsters, items) | — | ✅ | ✗ |
+
+## Connectivity Phases
+
+The application is designed to be rolled out in three phases of increasing connectivity:
+
+### Phase 1 — Offline / Local
+- All data is stored locally on the device.
+- A pre-loaded seed database provides reference content (spells, items, monsters).
+- Users can create and manage their own content locally.
+
+### Phase 2 — Online, Public Data
+- Connection to a backend server to fetch public, immutable reference data.
+- Examples: official spell lists, item catalogs, monster stat blocks.
+- No user account required. Read-only sync of public content.
+
+### Phase 3 — Online, Connected with Sync
+- User authentication (registration and login).
+- Data synchronization across devices.
+- Campaign sharing and access management (editor, reader, no access).
+- Role management within a shared campaign.
+
+## Supported Game Systems
+
+The app will launch with **D&D 5e** as the primary supported system, including compatible systems that share its core mechanics (e.g. Pathfinder, Starfinder).
+
+Additional game systems may be added in the future. The list is intentionally open-ended and will be prioritized based on demand and community feedback. Each new system will be scoped in a dedicated PRD when the time comes.
+
+## Application Structure
+
+The app is organized around three main sections accessible from the home screen:
+
+```
+Home
+├── Campaign
+│   ├── CampaignList
+│   ├── CampaignCreate
+│   └── CampaignDetail
+│       ├── NoteList / NoteCreate
+│       └── CharacterSheetList / CharacterSheetSelector
+├── CharacterSheet
+│   ├── CharacterSheetList
+│   ├── CharacterSheetCreate
+│   └── CharacterSheetDetail
+└── Rules
+    ├── SpellList / SpellDetail
+    ├── ItemList / ItemDetail
+    └── MonsterList / MonsterDetail
+```
+
+## Non-Functional Requirements
+
+- **Offline-first**: core features must work without a network connection.
+- **Cross-platform**: Android, iOS, and Desktop (via Kotlin Multiplatform + Compose Multiplatform).
+- **Performance**: list screens must load within 300ms on mid-range devices.
+- **Data safety**: user-created content must never be lost due to a sync conflict; conflicts must be resolved non-destructively.

--- a/docs/prd/PRD-000-VISION.md
+++ b/docs/prd/PRD-000-VISION.md
@@ -22,32 +22,36 @@ Managing a TTRPG session involves juggling a large amount of information: spell 
 
 Roles are **not fixed account types** — they are **per-campaign roles** determined by how a user relates to a specific campaign. The same user can be a GM in one campaign and a Player in another.
 
-| Role | Abbreviation | How it is assigned |
-|---|---|---|
-| Game Master | GM | Automatically assigned to the user who **creates** the campaign. |
-| Player | P | Assigned when a user **joins a campaign by invitation**. |
-| User | U | Any user, regardless of their role in any campaign. Applies to features available to everyone. |
+| Role        | Abbreviation | How it is assigned                                                                             |
+|-------------|--------------|------------------------------------------------------------------------------------------------|
+| Game Master | GM           | Automatically assigned to the user who **creates** the campaign.                               |
+| Player      | P            | Assigned when a user **joins a campaign by invitation**.                                       |
+| User        | U            | Any user, regardless of their role in any campaign. Applies to features available to everyone. |
 
 ### Campaign Role Assignment
 
-| Situation | Role in that campaign |
-|---|---|
-| User creates a campaign | GM (full editor access) |
-| User is invited to a campaign | Player (read-only, except own PC sheets) |
+| Situation                                       | Role in that campaign                                                     |
+|-------------------------------------------------|---------------------------------------------------------------------------|
+| User creates a campaign                         | GM / owner (full access)                                                  |
+| User is invited as co-GM, or promoted by the GM | Co-GM (same as GM, except cannot delete the campaign or remove the owner) |
+| User is invited as a player                     | Player (read-only, except own PC sheets)                                  |
 
 ### Access Matrix
 
-| Action | Any User (U) | GM (in their campaign) | Player (in a shared campaign) |
-|---|---|---|---|
-| Read public reference data (spells, items, monsters) | ✅ | ✅ | ✅ |
-| Create/edit own character sheets (personal library) | ✅ | ✅ | ✅ |
-| Create and manage a campaign | ✅ | ✅ | ✅ |
-| Edit campaign content (notes, roster, settings) | — | ✅ | ✗ |
-| Read campaign content (notes, roster) | — | ✅ | ✅ |
-| Invite players to a campaign | — | ✅ | ✗ |
-| Edit own Player Character sheet within a campaign | — | ✅ | ✅ |
-| Edit other characters' sheets within a campaign | — | ✅ | ✗ |
-| Create/edit custom content (spells, monsters, items) | — | ✅ | ✗ |
+| Action                                               | Any User (U) | GM (owner) | Co-GM | Player |
+|------------------------------------------------------|--------------|------------|------|-----|
+| Read public reference data (spells, items, monsters) | ✅            | ✅          | ✅    | ✅   |
+| Create/edit own character sheets (personal library)  | ✅            | ✅          | ✅    | ✅   |
+| Create a campaign                                    | ✅            | ✅          | ✅    | ✅   |
+| Edit campaign content (notes, roster, settings)      | —            | ✅          | ✅    | ✗   |
+| View secret folders and items                        | —            | ✅          | ✅    | ✗   |
+| Read visible campaign content (notes, roster)        | —            | ✅          | ✅    | ✅   |
+| Invite players or co-GMs                             | —            | ✅          | ✅    | ✗   |
+| Promote / demote members                             | —            | ✅          | ✅     | ✗   |
+| Edit own PC sheet within a campaign                  | —            | ✅          | ✅    | ✅   |
+| Edit other characters' sheets within a campaign      | —            | ✅          | ✅    | ✗   |
+| Delete the campaign                                  | —            | ✅          | ✗    | ✗   |
+| Remove the GM (owner) from the campaign              | —            | ✗          | ✗    | ✗   |
 
 ## Connectivity Phases
 

--- a/docs/prd/PRD-000-VISION.md
+++ b/docs/prd/PRD-000-VISION.md
@@ -40,19 +40,19 @@ Roles are **not fixed account types** — they are **per-campaign roles** determ
 ### Access Matrix
 
 | Action                                               | Any User (U) | GM (owner) | Co-GM | Player |
-|------------------------------------------------------|--------------|------------|------|-----|
-| Read public reference data (spells, items, monsters) | ✅            | ✅          | ✅    | ✅   |
-| Create/edit own character sheets (personal library)  | ✅            | ✅          | ✅    | ✅   |
-| Create a campaign                                    | ✅            | ✅          | ✅    | ✅   |
-| Edit campaign content (notes, roster, settings)      | —            | ✅          | ✅    | ✗   |
-| View secret folders and items                        | —            | ✅          | ✅    | ✗   |
-| Read visible campaign content (notes, roster)        | —            | ✅          | ✅    | ✅   |
-| Invite players or co-GMs                             | —            | ✅          | ✅    | ✗   |
-| Promote / demote members                             | —            | ✅          | ✅     | ✗   |
-| Edit own PC sheet within a campaign                  | —            | ✅          | ✅    | ✅   |
-| Edit other characters' sheets within a campaign      | —            | ✅          | ✅    | ✗   |
-| Delete the campaign                                  | —            | ✅          | ✗    | ✗   |
-| Remove the GM (owner) from the campaign              | —            | ✗          | ✗    | ✗   |
+|------------------------------------------------------|--------------|------------|-------|--------|
+| Read public reference data (spells, items, monsters) | ✅            | ✅          | ✅     | ✅      |
+| Create/edit own character sheets (personal library)  | ✅            | ✅          | ✅     | ✅      |
+| Create a campaign                                    | ✅            | ✅          | ✅     | ✅      |
+| Edit campaign content (notes, roster, settings)      | —            | ✅          | ✅     | ✗      |
+| View secret folders and items                        | —            | ✅          | ✅     | ✗      |
+| Read visible campaign content (notes, roster)        | —            | ✅          | ✅     | ✅      |
+| Invite players or co-GMs                             | —            | ✅          | ✅     | ✗      |
+| Promote / demote members                             | —            | ✅          | ✅     | ✗      |
+| Edit own PC sheet within a campaign                  | —            | ✅          | ✅     | ✅      |
+| Edit other characters' sheets within a campaign      | —            | ✅          | ✅     | ✗      |
+| Delete the campaign                                  | —            | ✅          | ✗     | ✗      |
+| Remove the GM (owner) from the campaign              | —            | ✗          | ✗     | ✗      |
 
 ## Connectivity Phases
 

--- a/docs/prd/PRD-000-VISION.md
+++ b/docs/prd/PRD-000-VISION.md
@@ -25,6 +25,7 @@ Roles are **not fixed account types** — they are **per-campaign roles** determ
 | Role        | Abbreviation | How it is assigned                                                                             |
 |-------------|--------------|------------------------------------------------------------------------------------------------|
 | Game Master | GM           | Automatically assigned to the user who **creates** the campaign.                               |
+| Co-GM       | Co-GM        | Assigned when a user is **invited as a co-GM** or **promoted** by a GM.                        |
 | Player      | P            | Assigned when a user **joins a campaign by invitation**.                                       |
 | User        | U            | Any user, regardless of their role in any campaign. Applies to features available to everyone. |
 

--- a/docs/prd/PRD-001-REFERENCE-DATA.md
+++ b/docs/prd/PRD-001-REFERENCE-DATA.md
@@ -1,0 +1,125 @@
+# PRD-001 — Reference Data (Spells, Items, Monsters)
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+## Overview
+
+Three reference modules — **Spellbook**, **Item List**, and **Bestiary** — allow users to browse, search, and filter the official D&D 5e content catalog. They share the same core pattern: a searchable, filterable list leading to a detail view, with advanced features for personal curation and custom content creation.
+
+## Goals
+
+- Give every user fast access to the full rules reference during a session.
+- Allow all users to organize content into personal named lists.
+- Support offline access from day one.
+
+## Shared Pattern
+
+All three modules follow the same structure:
+
+```
+[Module]List
+├── Search bar (full-text)
+├── Filter panel (module-specific filters)
+└── [Module]Detail
+```
+
+---
+
+## 1. Spellbook
+
+### Filters
+- Spell level (0–9)
+- School of magic (Abjuration, Conjuration, Divination, Enchantment, Evocation, Illusion, Necromancy, Transmutation)
+- Casting class (Wizard, Cleric, Druid, etc.)
+
+### User Stories
+
+| As a… | I want to… | So that…                                                   |
+|---|---|------------------------------------------------------------|
+| User | Browse and search the full spell list | I can quickly look up a spell during a session             |
+| User | Filter spells by level and school | I can narrow down relevant options                         |
+| User | Add a spell to a personal named list (grimoire) | I can organize spells for a specific character or campaign |
+| User | Create a custom spell | I can use homebrew content                                 |
+| User | Export a spell / import a shared spell | I can exchange homebrew content with others                |
+
+### Functional Requirements
+
+**Phase 1 — MVP (Offline)**
+- Display a scrollable list of all spells from the local seed database.
+- Full-text search on name and description.
+- Filter by level and school of magic.
+- View spell detail (name, level, school, casting time, range, components, duration, description).
+
+**Phase 2 — Online Public Data**
+- Sync the spell catalog from the public backend (read-only).
+
+**Phase 3 — Advanced**
+- Create, edit, and delete personal named spell lists (grimoires).
+- Create, edit, and delete custom spells.
+- Export a spell as a shareable format; import a spell shared by another user.
+
+---
+
+## 2. Item List
+
+### Filters
+- Item type (Weapon, Armor, Potion, Wondrous Item, etc.)
+- Rarity (Common, Uncommon, Rare, Very Rare, Legendary, Artifact)
+
+### User Stories
+
+| As a… | I want to… | So that…                                     |
+|-------|---|----------------------------------------------|
+| User  | Browse and search the full item catalog | I can look up item stats and descriptions    |
+| User  | Filter items by type and rarity | I can find relevant loot for my session      |
+| User  | Add items to a personal named list | I can track loot or prepare a shop inventory |
+| User  | Create a custom item | I can use homebrew items                     |
+| User  | Export and import items | I can share custom items with others         |
+
+### Functional Requirements
+
+Same structure as Spellbook. Filters specific to items as listed above.
+
+Item detail includes: name, type, rarity, description, weight, value, attunement requirement.
+
+---
+
+## 3. Bestiary
+
+### Filters
+- Monster type (Beast, Undead, Humanoid, Dragon, Fiend, etc.)
+- Challenge Rating (CR 0 to CR 30)
+
+### User Stories
+
+| As a… | I want to… | So that…                          |
+|---|---|-----------------------------------|
+| User | Browse and search the full monster catalog | I can look up stat blocks quickly |
+| User | Filter by type and CR | I can find appropriate encounters |
+| User | Create a custom monster or NPC | I can use homebrew creatures      |
+| User | Add monsters to a personal list | I can prepare an encounter roster |
+| User | Export and import monsters | I can share custom creatures      |
+
+### Functional Requirements
+
+Same structure as Spellbook. Filters specific to monsters as listed above.
+
+Monster detail includes: name, type, size, alignment, AC, HP, speed, ability scores, skills, senses, languages, CR, traits, actions, reactions, legendary actions.
+
+---
+
+## Non-Functional Requirements
+
+- List screens must render at least 200 items smoothly with search/filter applied in under 300ms.
+- All data must be available offline (seeded locally on first launch).
+- Custom entries must be clearly distinguished from official content in the UI.
+
+## Out of Scope
+
+- Interactive spell slot tracking or combat automation.
+- Automatic CR balancing for encounter building (may be addressed in a future PRD).
+
+## Open Questions
+
+- Which official data source will be used for the seed database (SRD JSON, Open5e API, manual curation)?
+- Should personal named lists be shareable between users (e.g., sharing a grimoire with a party)?

--- a/docs/prd/PRD-001-REFERENCE-DATA.md
+++ b/docs/prd/PRD-001-REFERENCE-DATA.md
@@ -34,13 +34,13 @@ All three modules follow the same structure:
 
 ### User Stories
 
-| As a… | I want to… | So that…                                                   |
-|---|---|------------------------------------------------------------|
-| User | Browse and search the full spell list | I can quickly look up a spell during a session             |
-| User | Filter spells by level and school | I can narrow down relevant options                         |
-| User | Add a spell to a personal named list (grimoire) | I can organize spells for a specific character or campaign |
-| User | Create a custom spell | I can use homebrew content                                 |
-| User | Export a spell / import a shared spell | I can exchange homebrew content with others                |
+| As a… | I want to…                                      | So that…                                                   |
+|-------|-------------------------------------------------|------------------------------------------------------------|
+| User  | Browse and search the full spell list           | I can quickly look up a spell during a session             |
+| User  | Filter spells by level and school               | I can narrow down relevant options                         |
+| User  | Add a spell to a personal named list (grimoire) | I can organize spells for a specific character or campaign |
+| User  | Create a custom spell                           | I can use homebrew content                                 |
+| User  | Export a spell / import a shared spell          | I can exchange homebrew content with others                |
 
 ### Functional Requirements
 
@@ -68,13 +68,13 @@ All three modules follow the same structure:
 
 ### User Stories
 
-| As a… | I want to… | So that…                                     |
-|-------|---|----------------------------------------------|
+| As a… | I want to…                              | So that…                                     |
+|-------|-----------------------------------------|----------------------------------------------|
 | User  | Browse and search the full item catalog | I can look up item stats and descriptions    |
-| User  | Filter items by type and rarity | I can find relevant loot for my session      |
-| User  | Add items to a personal named list | I can track loot or prepare a shop inventory |
-| User  | Create a custom item | I can use homebrew items                     |
-| User  | Export and import items | I can share custom items with others         |
+| User  | Filter items by type and rarity         | I can find relevant loot for my session      |
+| User  | Add items to a personal named list      | I can track loot or prepare a shop inventory |
+| User  | Create a custom item                    | I can use homebrew items                     |
+| User  | Export and import items                 | I can share custom items with others         |
 
 ### Functional Requirements
 
@@ -92,13 +92,13 @@ Item detail includes: name, type, rarity, description, weight, value, attunement
 
 ### User Stories
 
-| As a… | I want to… | So that…                          |
-|---|---|-----------------------------------|
-| User | Browse and search the full monster catalog | I can look up stat blocks quickly |
-| User | Filter by type and CR | I can find appropriate encounters |
-| User | Create a custom monster or NPC | I can use homebrew creatures      |
-| User | Add monsters to a personal list | I can prepare an encounter roster |
-| User | Export and import monsters | I can share custom creatures      |
+| As a… | I want to…                                 | So that…                          |
+|-------|--------------------------------------------|-----------------------------------|
+| User  | Browse and search the full monster catalog | I can look up stat blocks quickly |
+| User  | Filter by type and CR                      | I can find appropriate encounters |
+| User  | Create a custom monster or NPC             | I can use homebrew creatures      |
+| User  | Add monsters to a personal list            | I can prepare an encounter roster |
+| User  | Export and import monsters                 | I can share custom creatures      |
 
 ### Functional Requirements
 

--- a/docs/prd/PRD-001-REFERENCE-DATA.md
+++ b/docs/prd/PRD-001-REFERENCE-DATA.md
@@ -4,13 +4,17 @@
 
 ## Overview
 
-Three reference modules — **Spellbook**, **Item List**, and **Bestiary** — allow users to browse, search, and filter the official D&D 5e content catalog. They share the same core pattern: a searchable, filterable list leading to a detail view, with advanced features for personal curation and custom content creation.
+Three reference modules — **Spellbook**, **Item List**, and **Bestiary** — allow users to browse, search, and filter the official D&D 5e content catalog. They share the same core pattern: a searchable, filterable list leading to a detail view, with CRUD for custom entries.
+
+These modules are **game-system-specific** (D&D 5e). For system-agnostic content like personal notes, see [PRD-004 — Notes](PRD-004-NOTES.md).
 
 ## Goals
 
 - Give every user fast access to the full rules reference during a session.
-- Allow all users to organize content into personal named lists.
+- Allow all users to organize content into personal named lists of the same type.
 - Support offline access from day one.
+
+> **Scope note**: At this stage, all entities are independent. Lists can only group entities of the **same type** (e.g. a grimoire = a named list of spells). Cross-entity relationships — such as linking a spell to a character sheet or attaching items to a campaign — will be addressed in a later phase.
 
 ## Shared Pattern
 
@@ -105,8 +109,6 @@ Item detail includes: name, type, rarity, description, weight, value, attunement
 Same structure as Spellbook. Filters specific to monsters as listed above.
 
 Monster detail includes: name, type, size, alignment, AC, HP, speed, ability scores, skills, senses, languages, CR, traits, actions, reactions, legendary actions.
-
----
 
 ## Non-Functional Requirements
 

--- a/docs/prd/PRD-001-REFERENCE-DATA.md
+++ b/docs/prd/PRD-001-REFERENCE-DATA.md
@@ -1,12 +1,16 @@
-# PRD-001 — Reference Data (Spells, Items, Monsters)
+# PRD-001 — Reference Data (Overview)
 
 > **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
 
 ## Overview
 
-Three reference modules — **Spellbook**, **Item List**, and **Bestiary** — allow users to browse, search, and filter the official D&D 5e content catalog. They share the same core pattern: a searchable, filterable list leading to a detail view, with CRUD for custom entries.
+Three reference modules allow users to browse, search, and filter the official D&D 5e content catalog. These modules are **game-system-specific** (D&D 5e). For system-agnostic content like personal notes, see [PRD-004 — Notes](PRD-004-NOTES.md).
 
-These modules are **game-system-specific** (D&D 5e). For system-agnostic content like personal notes, see [PRD-004 — Notes](PRD-004-NOTES.md).
+| Module    | PRD                                           |
+|-----------|-----------------------------------------------|
+| Spellbook | [PRD-001a — Spellbook](PRD-001a-SPELLBOOK.md) |
+| Item List | [PRD-001b — Item List](PRD-001b-ITEM-LIST.md) |
+| Bestiary  | [PRD-001c — Bestiary](PRD-001c-BESTIARY.md)   |
 
 ## Goals
 
@@ -27,88 +31,12 @@ All three modules follow the same structure:
 └── [Module]Detail
 ```
 
----
+And the same phase breakdown:
 
-## 1. Spellbook
-
-### Filters
-- Spell level (0–9)
-- School of magic (Abjuration, Conjuration, Divination, Enchantment, Evocation, Illusion, Necromancy, Transmutation)
-- Casting class (Wizard, Cleric, Druid, etc.)
-
-### User Stories
-
-| As a… | I want to…                                      | So that…                                                   |
-|-------|-------------------------------------------------|------------------------------------------------------------|
-| User  | Browse and search the full spell list           | I can quickly look up a spell during a session             |
-| User  | Filter spells by level and school               | I can narrow down relevant options                         |
-| User  | Add a spell to a personal named list (grimoire) | I can organize spells for a specific character or campaign |
-| User  | Create a custom spell                           | I can use homebrew content                                 |
-| User  | Export a spell / import a shared spell          | I can exchange homebrew content with others                |
-
-### Functional Requirements
-
-**Phase 1 — MVP (Offline)**
-- Display a scrollable list of all spells from the local seed database.
-- Full-text search on name and description.
-- Filter by level and school of magic.
-- View spell detail (name, level, school, casting time, range, components, duration, description).
-
-**Phase 2 — Online Public Data**
-- Sync the spell catalog from the public backend (read-only).
-
-**Phase 3 — Advanced**
-- Create, edit, and delete personal named spell lists (grimoires).
-- Create, edit, and delete custom spells.
-- Export a spell as a shareable format; import a spell shared by another user.
-
----
-
-## 2. Item List
-
-### Filters
-- Item type (Weapon, Armor, Potion, Wondrous Item, etc.)
-- Rarity (Common, Uncommon, Rare, Very Rare, Legendary, Artifact)
-
-### User Stories
-
-| As a… | I want to…                              | So that…                                     |
-|-------|-----------------------------------------|----------------------------------------------|
-| User  | Browse and search the full item catalog | I can look up item stats and descriptions    |
-| User  | Filter items by type and rarity         | I can find relevant loot for my session      |
-| User  | Add items to a personal named list      | I can track loot or prepare a shop inventory |
-| User  | Create a custom item                    | I can use homebrew items                     |
-| User  | Export and import items                 | I can share custom items with others         |
-
-### Functional Requirements
-
-Same structure as Spellbook. Filters specific to items as listed above.
-
-Item detail includes: name, type, rarity, description, weight, value, attunement requirement.
-
----
-
-## 3. Bestiary
-
-### Filters
-- Monster type (Beast, Undead, Humanoid, Dragon, Fiend, etc.)
-- Challenge Rating (CR 0 to CR 30)
-
-### User Stories
-
-| As a… | I want to…                                 | So that…                          |
-|-------|--------------------------------------------|-----------------------------------|
-| User  | Browse and search the full monster catalog | I can look up stat blocks quickly |
-| User  | Filter by type and CR                      | I can find appropriate encounters |
-| User  | Create a custom monster or NPC             | I can use homebrew creatures      |
-| User  | Add monsters to a personal list            | I can prepare an encounter roster |
-| User  | Export and import monsters                 | I can share custom creatures      |
-
-### Functional Requirements
-
-Same structure as Spellbook. Filters specific to monsters as listed above.
-
-Monster detail includes: name, type, size, alignment, AC, HP, speed, ability scores, skills, senses, languages, CR, traits, actions, reactions, legendary actions.
+- **Phase 1**: Seed database, search, filters, detail view.
+- **Phase 2**: Create and manage personal named lists locally.
+- **Phase 3**: Sync catalog from public backend (read-only).
+- **Phase 4**: Sync personal lists across devices. Custom entries, export/import.
 
 ## Non-Functional Requirements
 

--- a/docs/prd/PRD-001a-SPELLBOOK.md
+++ b/docs/prd/PRD-001a-SPELLBOOK.md
@@ -1,0 +1,44 @@
+# PRD-001a — Spellbook
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+Refer to [PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md) for the shared pattern, goals, and non-functional requirements.
+
+## Filters
+
+- Spell level (0–9)
+- School of magic (Abjuration, Conjuration, Divination, Enchantment, Evocation, Illusion, Necromancy, Transmutation)
+- Casting class (Wizard, Cleric, Druid, Bard, Paladin, Ranger, Sorcerer, Warlock…)
+
+## User Stories
+
+| As a… | I want to…                                      | So that…                                                   |
+|-------|-------------------------------------------------|------------------------------------------------------------|
+| User  | Browse and search the full spell list           | I can quickly look up a spell during a session             |
+| User  | Filter spells by level, school, and class       | I can narrow down relevant options                         |
+| User  | Add a spell to a personal named list (grimoire) | I can organize spells for a specific character or campaign |
+| User  | Create a custom spell                           | I can use homebrew content                                 |
+| User  | Export a spell / import a shared spell          | I can exchange homebrew content with others                |
+
+## Functional Requirements
+
+### Phase 1 — MVP (Offline)
+
+- Display a scrollable list of all spells from the local seed database.
+- Full-text search on name and description.
+- Filter by level, school of magic, and casting class.
+- View spell detail: name, level, school, casting time, range, components, duration, description.
+
+### Phase 2 — Local Lists
+
+- Create, edit, and delete personal named spell lists (grimoires) stored locally.
+
+### Phase 3 — Online Public Data
+
+- Sync the spell catalog from the public backend (read-only).
+
+### Phase 4 — Advanced
+
+- Sync personal grimoires across devices.
+- Create, edit, and delete custom spells.
+- Export a spell as a shareable format; import a spell shared by another user.

--- a/docs/prd/PRD-001b-ITEM-LIST.md
+++ b/docs/prd/PRD-001b-ITEM-LIST.md
@@ -1,0 +1,43 @@
+# PRD-001b — Item List
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+Refer to [PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md) for the shared pattern, goals, and non-functional requirements.
+
+## Filters
+
+- Item type (Weapon, Armor, Potion, Wondrous Item, Tool, etc.)
+- Rarity (Common, Uncommon, Rare, Very Rare, Legendary, Artifact)
+
+## User Stories
+
+| As a… | I want to…                              | So that…                                     |
+|-------|-----------------------------------------|----------------------------------------------|
+| User  | Browse and search the full item catalog | I can look up item stats and descriptions    |
+| User  | Filter items by type and rarity         | I can find relevant loot for my session      |
+| User  | Add items to a personal named list      | I can track loot or prepare a shop inventory |
+| User  | Create a custom item                    | I can use homebrew items                     |
+| User  | Export and import items                 | I can share custom items with others         |
+
+## Functional Requirements
+
+### Phase 1 — MVP (Offline)
+
+- Display a scrollable list of all items from the local seed database.
+- Full-text search on name and description.
+- Filter by item type and rarity.
+- View item detail: name, type, rarity, description, weight, value, attunement requirement.
+
+### Phase 2 — Local Lists
+
+- Create, edit, and delete personal named item lists stored locally.
+
+### Phase 3 — Online Public Data
+
+- Sync the item catalog from the public backend (read-only).
+
+### Phase 4 — Advanced
+
+- Sync personal item lists across devices.
+- Create, edit, and delete custom items.
+- Export an item as a shareable format; import an item shared by another user.

--- a/docs/prd/PRD-001c-BESTIARY.md
+++ b/docs/prd/PRD-001c-BESTIARY.md
@@ -1,0 +1,43 @@
+# PRD-001c — Bestiary
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+Refer to [PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md) for the shared pattern, goals, and non-functional requirements.
+
+## Filters
+
+- Monster type (Beast, Undead, Humanoid, Dragon, Fiend, Construct, Elemental, etc.)
+- Challenge Rating (CR 0 to CR 30)
+
+## User Stories
+
+| As a… | I want to…                                 | So that…                          |
+|-------|--------------------------------------------|-----------------------------------|
+| User  | Browse and search the full monster catalog | I can look up stat blocks quickly |
+| User  | Filter by type and CR                      | I can find appropriate encounters |
+| User  | Create a custom monster or NPC             | I can use homebrew creatures      |
+| User  | Add monsters to a personal list            | I can prepare an encounter roster |
+| User  | Export and import monsters                 | I can share custom creatures      |
+
+## Functional Requirements
+
+### Phase 1 — MVP (Offline)
+
+- Display a scrollable list of all monsters from the local seed database.
+- Full-text search on name and description.
+- Filter by monster type and CR.
+- View monster detail: name, type, size, alignment, AC, HP, speed, ability scores, skills, senses, languages, CR, traits, actions, reactions, legendary actions.
+
+### Phase 2 — Local Lists
+
+- Create, edit, and delete personal named monster lists stored locally.
+
+### Phase 3 — Online Public Data
+
+- Sync the monster catalog from the public backend (read-only).
+
+### Phase 4 — Advanced
+
+- Sync personal monster lists across devices.
+- Create, edit, and delete custom monsters and NPCs.
+- Export a monster as a shareable format; import a monster shared by another user.

--- a/docs/prd/PRD-002-CHARACTER-SHEET.md
+++ b/docs/prd/PRD-002-CHARACTER-SHEET.md
@@ -1,0 +1,102 @@
+# PRD-002 — Character Sheet
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+## Overview
+
+The Character Sheet module allows users to create, view, edit, and delete character sheets for both Player Characters (PCs) and Non-Player Characters (NPCs). It serves as the central record for a character's identity, stats, abilities, and inventory.
+
+At this stage, character sheets live in the user's personal library and are independent of any campaign.
+Campaign integration (attaching sheets to a campaign, sharing with other players, access control) is a later phase covered in [PRD-003 — Campaigns](PRD-003-CAMPAIGNS.md).
+
+## Goals
+
+- Provide a complete digital character sheet that replaces paper sheets.
+- Support both PCs and NPCs in the same personal library.
+- Work fully offline.
+
+## User Stories
+
+| As a… | I want to… | So that… |
+|---|---|---|
+| User | Create a new character sheet (PC or NPC) | I have a digital record for my character |
+| User | Edit my character sheet at any time | I can update stats, HP, inventory, etc. during a session |
+| User | Delete a character sheet I own | I can remove characters I no longer use |
+
+**Phase 3 — Campaign integration (see PRD-003)**
+
+| As a… | I want to…                                         | So that…                             |
+|-------|----------------------------------------------------|--------------------------------------|
+| GM    | Attach a character sheet to a campaign I own       | My campaign has a full roster        |
+| User  | View character sheets shared with me in a campaign | I can see relevant party or NPC info |
+
+## Functional Requirements
+
+### Phase 1 — MVP (Offline)
+
+**General Info**
+- Character name, player name
+- Race / Ancestry
+- Class(es) and level
+- Background
+- Alignment
+
+**Ability Scores & Modifiers**
+- The six core stats: Strength, Dexterity, Constitution, Intelligence, Wisdom, Charisma
+- Auto-calculated modifiers from scores
+
+**Combat Stats**
+- Armor Class (AC)
+- Initiative
+- Speed
+- Current HP, Maximum HP, Temporary HP
+- Hit Dice
+
+**Skills & Proficiencies**
+- Saving throws (with proficiency toggle)
+- Skill list with proficiency and expertise toggles
+- Passive Perception (auto-calculated)
+- Proficiency bonus (auto-calculated from level)
+- Languages and other proficiencies
+
+**Features & Traits**
+- Class features
+- Racial traits
+- Background feature
+- Feats
+
+**Inventory**
+- List of items as free-form text entries (name only)
+- _Linking items from the Item module to a character sheet is a later-phase feature_
+- Currency (CP, SP, EP, GP, PP)
+- Carrying capacity (auto-calculated from Strength)
+
+**Spells (if applicable)**
+- Spellcasting ability, spell save DC, spell attack bonus
+- Spell slots (per level, current/max)
+- Prepared/known spells as free-form text entries (name only)
+- _Linking spells from the Spellbook module to a character sheet is a later-phase feature_
+
+**Notes**
+- Free-text field for backstory, session notes, roleplaying notes
+
+### Phase 3 — Online with Sync
+
+- Sync character sheets across devices.
+- Attach a character sheet to a campaign and share it with other campaign members (see PRD-003).
+
+## Non-Functional Requirements
+
+- Edits must be auto-saved locally to prevent data loss.
+- The sheet must be usable on small screens (mobile) without horizontal scrolling.
+- Auto-calculated fields (modifier, proficiency bonus, passive perception, etc.) must update immediately on input change.
+
+## Out of Scope
+
+- Automated level-up wizard (choosing spells, features) — may be addressed in a future PRD.
+- Combat tracker / initiative order — may be addressed in a future PRD.
+- Support for non-D&D 5e character sheet formats in this iteration.
+
+## Open Questions
+
+- Should NPCs use the same sheet format as PCs, or a simplified stat block format?

--- a/docs/prd/PRD-002-CHARACTER-SHEET.md
+++ b/docs/prd/PRD-002-CHARACTER-SHEET.md
@@ -17,11 +17,11 @@ Campaign integration (attaching sheets to a campaign, sharing with other players
 
 ## User Stories
 
-| As a… | I want to… | So that… |
-|---|---|---|
-| User | Create a new character sheet (PC or NPC) | I have a digital record for my character |
-| User | Edit my character sheet at any time | I can update stats, HP, inventory, etc. during a session |
-| User | Delete a character sheet I own | I can remove characters I no longer use |
+| As a… | I want to…                               | So that…                                                 |
+|-------|------------------------------------------|----------------------------------------------------------|
+| User  | Create a new character sheet (PC or NPC) | I have a digital record for my character                 |
+| User  | Edit my character sheet at any time      | I can update stats, HP, inventory, etc. during a session |
+| User  | Delete a character sheet I own           | I can remove characters I no longer use                  |
 
 **Phase 3 — Campaign integration (see PRD-003)**
 

--- a/docs/prd/PRD-003-CAMPAIGNS.md
+++ b/docs/prd/PRD-003-CAMPAIGNS.md
@@ -25,7 +25,7 @@ The Campaign module allows a GM to create and manage a campaign, attach resource
 | GM     | Promote a player to co-GM                                | I can elevate a trusted player to help manage the campaign            |
 | Player | View a campaign I've been invited to                     | I can see campaign info and my character sheet                        |
 | GM     | Give an item to a player by adding it to their inventory | I can reward loot without requiring manual entry on the player's side |
-| GM     | Add and browse session notes _(Phase 2)_                 | I can track what happened in previous sessions                        |
+| GM     | Attach notes to a campaign _(Phase 2)_                   | I can track what happened in previous sessions                        |
 | GM     | Mark a note or resource as Secret _(Future)_             | Players cannot see it until I choose to reveal it                     |
 | GM     | Organize notes and resources into folders _(Future)_     | I can separate secret GM content from player-facing content           |
 | GM     | Reveal a secret note or resource to players _(Future)_   | I can progressively share information as the story unfolds            |
@@ -47,11 +47,11 @@ The Campaign module allows a GM to create and manage a campaign, attach resource
 
 ### Phase 2 — Session Notes
 
-**Session Notes**
-- Create a note with a title and free-text body.
-- List all notes for the campaign, sorted by creation date (most recent first).
-- Edit and delete notes.
-- Support linking to an external URL (e.g. a Google Doc or Notion page) as an alternative to in-app notes.
+Notes are defined as standalone entities in [PRD-001](PRD-001-REFERENCE-DATA.md). In this phase, a note can be attached to a campaign, turning it into a session note.
+
+- Attach/detach an existing note to a campaign.
+- List all notes attached to the campaign, sorted by last modified date.
+- Notes remain in the user's personal library even when detached from a campaign.
 
 ### Phase 3 — Online with Sync
 

--- a/docs/prd/PRD-003-CAMPAIGNS.md
+++ b/docs/prd/PRD-003-CAMPAIGNS.md
@@ -47,7 +47,7 @@ The Campaign module allows a GM to create and manage a campaign, attach resource
 
 ### Phase 2 — Session Notes
 
-Notes are defined as standalone entities in [PRD-001](PRD-001-REFERENCE-DATA.md). In this phase, a note can be attached to a campaign, turning it into a session note.
+Notes are defined as standalone entities in [PRD-004 — Notes](PRD-004-NOTES.md). In this phase, a note can be attached to a campaign, turning it into a session note.
 
 - Attach/detach an existing note to a campaign.
 - List all notes attached to the campaign, sorted by last modified date.

--- a/docs/prd/PRD-003-CAMPAIGNS.md
+++ b/docs/prd/PRD-003-CAMPAIGNS.md
@@ -15,20 +15,20 @@ The Campaign module allows a GM to create and manage a campaign, attach resource
 
 ## User Stories
 
-| As a…  | I want to…                                               | So that…                                                              |
-|--------|----------------------------------------------------------|-----------------------------------------------------------------------|
-| GM     | Create a campaign with a name and description            | I have a central place to organize my session content                 |
-| GM     | Edit and delete my campaigns                             | I can keep my campaign list clean                                     |
-| GM     | Attach characters, NPCs, and monsters to a campaign      | I can access all relevant entities quickly during play                |
-| GM     | Share a campaign with specific players                   | My players can access their characters and campaign info              |
-| GM     | Invite another user as co-GM                             | I can share campaign management responsibilities                      |
-| GM     | Promote a player to co-GM                                | I can elevate a trusted player to help manage the campaign            |
-| Player | View a campaign I've been invited to                     | I can see campaign info and my character sheet                        |
-| GM     | Give an item to a player by adding it to their inventory | I can reward loot without requiring manual entry on the player's side |
-| GM     | Attach notes to a campaign _(Phase 2)_                   | I can track what happened in previous sessions                        |
-| GM     | Mark a note or resource as Secret _(Future)_             | Players cannot see it until I choose to reveal it                     |
-| GM     | Organize notes and resources into folders _(Future)_     | I can separate secret GM content from player-facing content           |
-| GM     | Reveal a secret note or resource to players _(Future)_   | I can progressively share information as the story unfolds            |
+| As a…  | I want to…                                                          | So that…                                                              |
+|--------|---------------------------------------------------------------------|-----------------------------------------------------------------------|
+| GM     | Create a campaign with a name and description                       | I have a central place to organize my session content                 |
+| GM     | Edit and delete my campaigns                                        | I can keep my campaign list clean                                     |
+| GM     | Attach characters, NPCs, and monsters to a campaign                 | I can access all relevant entities quickly during play                |
+| GM     | Share a link to invite other users as players to a campaign         | My players can access their characters and campaign info              |
+| GM     | Share a link to invite other users as co-GMs to a campaign          | I can share campaign management responsibilities                      |
+| GM     | Promote a player to co-GM                                           | I can elevate a trusted player to help manage the campaign            |
+| Player | View a campaign I've been invited to                                | I can see campaign info and my character sheet                        |
+| GM     | Give an item to a player by adding it to their inventory            | I can reward loot without requiring manual entry on the player's side |
+| GM     | Attach notes to a campaign _(Phase 2)_                              | I can track what happened in previous sessions                        |
+| GM     | Mark a note or resource as Secret _(Future)_                        | Players cannot see it until I choose to reveal it                     |
+| GM     | Organize notes and resources into folders _(Future)_                | I can separate secret GM content from player-facing content           |
+| GM     | Reveal a secret note or resource to players _(Future)_              | I can progressively share information as the story unfolds            |
 | Player | See only the notes and resources the GM has made visible _(Future)_ | I only discover what my character would know               |
 
 ## Functional Requirements

--- a/docs/prd/PRD-003-CAMPAIGNS.md
+++ b/docs/prd/PRD-003-CAMPAIGNS.md
@@ -25,11 +25,11 @@ The Campaign module allows a GM to create and manage a campaign, attach resource
 | GM     | Promote a player to co-GM                                | I can elevate a trusted player to help manage the campaign            |
 | Player | View a campaign I've been invited to                     | I can see campaign info and my character sheet                        |
 | GM     | Give an item to a player by adding it to their inventory | I can reward loot without requiring manual entry on the player's side |
-| GM     | Add and browse session notes                             | I can track what happened in previous sessions                        |
-| GM     | Mark a note or resource as Secret                        | Players cannot see it until I choose to reveal it                     |
-| GM     | Organize notes and resources into folders                | I can separate secret GM content from player-facing content           |
-| GM     | Reveal a secret note or resource to players              | I can progressively share information as the story unfolds            |
-| Player | See only the notes and resources the GM has made visible | I only discover what my character would know                          |
+| GM     | Add and browse session notes _(Phase 2)_                 | I can track what happened in previous sessions                        |
+| GM     | Mark a note or resource as Secret _(Future)_             | Players cannot see it until I choose to reveal it                     |
+| GM     | Organize notes and resources into folders _(Future)_     | I can separate secret GM content from player-facing content           |
+| GM     | Reveal a secret note or resource to players _(Future)_   | I can progressively share information as the story unfolds            |
+| Player | See only the notes and resources the GM has made visible _(Future)_ | I only discover what my character would know               |
 
 ## Functional Requirements
 
@@ -44,18 +44,14 @@ The Campaign module allows a GM to create and manage a campaign, attach resource
 - Attach/detach character sheets (PCs and NPCs) from the campaign roster.
 - View the list of attached characters directly from the campaign detail screen.
 
+
+### Phase 2 — Session Notes
+
 **Session Notes**
 - Create a note with a title and free-text body.
 - List all notes for the campaign, sorted by creation date (most recent first).
 - Edit and delete notes.
 - Support linking to an external URL (e.g. a Google Doc or Notion page) as an alternative to in-app notes.
-
-**Secret Folders**
-- Notes and resources can be organized into folders.
-- Each folder (and individual item) has a visibility setting: **Secret** (GM only) or **Visible** (all campaign members).
-- The GM can toggle the visibility of any folder or item at any time.
-- Secret content is completely hidden from Players — they cannot see its existence.
-- By default, newly created notes and resources are **Secret**.
 
 ### Phase 3 — Online with Sync
 
@@ -72,9 +68,14 @@ Campaign roles and their permissions:
 - Any user can create a campaign; the creator is automatically the **GM** (owner).
 - The GM and co-GMs can invite users as Players or co-GMs via username or email.
 - The GM can promote any Player to co-GM, or demote a co-GM back to Player.
-- Secret folders and items are invisible to Players; co-GMs have full visibility.
 - The GM can revoke any member's access at any time.
-- Sync all campaign data (notes, roster, visibility state, roles) across devices in real time.
+- Sync all campaign data (notes, roles) across devices in real time.
+
+**Secret Folders (Future)**
+- Notes and resources can be organized into folders with a visibility setting: **Secret** (GM and co-GMs only) or **Visible** (all campaign members).
+- The GM can toggle the visibility of any folder or item at any time.
+- Secret content is completely hidden from Players — they cannot see its existence.
+- By default, newly created notes and resources are **Secret**.
 
 **Item Assignment (Future)**
 - The GM can assign an item from the Item catalog (or a custom item) directly to a Player's inventory.

--- a/docs/prd/PRD-003-CAMPAIGNS.md
+++ b/docs/prd/PRD-003-CAMPAIGNS.md
@@ -1,0 +1,104 @@
+# PRD-003 — Campaigns
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+## Overview
+
+The Campaign module allows a GM to create and manage a campaign, attach resources (characters, monsters, notes), and — when online — share the campaign with players with granular access control.
+
+## Goals
+
+- Give GMs a central workspace to organize everything related to a campaign.
+- Allow attaching and navigating all campaign resources from a single screen.
+- Enable sharing a campaign with players and controlling their level of access.
+- Allow GMs to keep some notes and resources secret from players.
+
+## User Stories
+
+| As a…  | I want to…                                               | So that…                                                              |
+|--------|----------------------------------------------------------|-----------------------------------------------------------------------|
+| GM     | Create a campaign with a name and description            | I have a central place to organize my session content                 |
+| GM     | Edit and delete my campaigns                             | I can keep my campaign list clean                                     |
+| GM     | Attach characters, NPCs, and monsters to a campaign      | I can access all relevant entities quickly during play                |
+| GM     | Share a campaign with specific players                   | My players can access their characters and campaign info              |
+| GM     | Invite another user as co-GM                             | I can share campaign management responsibilities                      |
+| GM     | Promote a player to co-GM                                | I can elevate a trusted player to help manage the campaign            |
+| Player | View a campaign I've been invited to                     | I can see campaign info and my character sheet                        |
+| GM     | Give an item to a player by adding it to their inventory | I can reward loot without requiring manual entry on the player's side |
+| GM     | Add and browse session notes                             | I can track what happened in previous sessions                        |
+| GM     | Mark a note or resource as Secret                        | Players cannot see it until I choose to reveal it                     |
+| GM     | Organize notes and resources into folders                | I can separate secret GM content from player-facing content           |
+| GM     | Reveal a secret note or resource to players              | I can progressively share information as the story unfolds            |
+| Player | See only the notes and resources the GM has made visible | I only discover what my character would know                          |
+
+## Functional Requirements
+
+### Phase 1 — MVP (Offline)
+
+**Campaign CRUD**
+- Create a campaign with: name, description, game system (e.g. D&D 5e).
+- Edit and delete a campaign.
+- List all campaigns owned by the user.
+
+**Attached Resources**
+- Attach/detach character sheets (PCs and NPCs) from the campaign roster.
+- View the list of attached characters directly from the campaign detail screen.
+
+**Session Notes**
+- Create a note with a title and free-text body.
+- List all notes for the campaign, sorted by creation date (most recent first).
+- Edit and delete notes.
+- Support linking to an external URL (e.g. a Google Doc or Notion page) as an alternative to in-app notes.
+
+**Secret Folders**
+- Notes and resources can be organized into folders.
+- Each folder (and individual item) has a visibility setting: **Secret** (GM only) or **Visible** (all campaign members).
+- The GM can toggle the visibility of any folder or item at any time.
+- Secret content is completely hidden from Players — they cannot see its existence.
+- By default, newly created notes and resources are **Secret**.
+
+### Phase 3 — Online with Sync
+
+**Sharing & Access Control**
+
+Campaign roles and their permissions:
+
+| Role           | How assigned                                                 | Access                                                                        |
+|----------------|--------------------------------------------------------------|-------------------------------------------------------------------------------|
+| **GM** (owner) | Creates the campaign                                         | Full access: edit campaign, notes, roster, secret folders, manage all members |
+| **Co-GM**      | Invited directly as co-GM, or promoted from Player by the GM | Same access as GM, except cannot delete the campaign or remove the owner      |
+| **Player**     | Invited by the GM or a co-GM                                 | Read-only access to visible content; can create and edit own PC sheet(s)      |
+
+- Any user can create a campaign; the creator is automatically the **GM** (owner).
+- The GM and co-GMs can invite users as Players or co-GMs via username or email.
+- The GM can promote any Player to co-GM, or demote a co-GM back to Player.
+- Secret folders and items are invisible to Players; co-GMs have full visibility.
+- The GM can revoke any member's access at any time.
+- Sync all campaign data (notes, roster, visibility state, roles) across devices in real time.
+
+**Item Assignment (Future)**
+- The GM can assign an item from the Item catalog (or a custom item) directly to a Player's inventory.
+- The Player receives a notification and the item appears in their character sheet's inventory.
+- The GM can optionally add a note when assigning the item (e.g. "Found in the chest in room 4").
+
+**Notifications (future consideration)**
+- Notify invited players when they are added to a campaign.
+- Notify the GM when a player accepts or declines an invitation.
+
+## Non-Functional Requirements
+
+- A campaign and all its notes must remain accessible offline after the initial sync.
+- Deleting a campaign must not delete the attached character sheets (they remain in the user's personal library).
+- Access control changes must propagate to other devices within a reasonable time (target: < 60 seconds).
+
+## Out of Scope
+
+- Real-time collaborative editing of notes (e.g. Google Docs-style concurrent editing).
+- In-app map or encounter board tools.
+- Campaign templates or pre-built adventure modules.
+
+## Open Questions
+
+- Should notes support rich text formatting (markdown, bold, lists) or plain text only?
+- Should the campaign detail show a combined activity feed (notes + roster changes)?
+- What happens to a shared campaign when the owning GM deletes their account?

--- a/docs/prd/PRD-004-NOTES.md
+++ b/docs/prd/PRD-004-NOTES.md
@@ -4,8 +4,8 @@
 
 ## Overview
 
-The Notes module allows users to create, browse, search, and manage free-form personal notes. It is **game-system-agnostic** and follows the same list/detail/CRUD pattern as the reference data modules (PRD-001).
-Notes are standalone entities at this stage; attaching them to a campaign is a later-phase cross-entity relationship (see PRD-003).
+The Notes module allows users to create, browse, search, and manage free-form personal notes. It is **game-system-agnostic** and follows the same list/detail/CRUD pattern as the reference data modules ([PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md)).
+Notes are standalone entities at this stage; attaching them to a campaign is a later-phase cross-entity relationship (see [PRD-003 — Campaigns](PRD-003-CAMPAIGNS.md)).
 
 The Notes module also serves as the foundation for the Generators module (PRD-005): generated content (NPCs, names, plants, etc.) is saved as notes and managed through the same pattern.
 

--- a/docs/prd/PRD-004-NOTES.md
+++ b/docs/prd/PRD-004-NOTES.md
@@ -7,7 +7,7 @@
 The Notes module allows users to create, browse, search, and manage free-form personal notes. It is **game-system-agnostic** and follows the same list/detail/CRUD pattern as the reference data modules ([PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md)).
 Notes are standalone entities at this stage; attaching them to a campaign is a later-phase cross-entity relationship (see [PRD-003 — Campaigns](PRD-003-CAMPAIGNS.md)).
 
-The Notes module also serves as the foundation for the Generators module (PRD-005): generated content (NPCs, names, plants, etc.) is saved as notes and managed through the same pattern.
+The Notes module also serves as the foundation for the Generators module ([PRD-005](PRD-005-GENERATORS.md)): generated content (NPCs, names, plants, etc.) is saved as notes and managed through the same pattern.
 
 ## Goals
 
@@ -23,13 +23,20 @@ The Notes module also serves as the foundation for the Generators module (PRD-00
 | User  | Browse and search my notes          | I can quickly find a note I wrote previously     |
 | User  | Edit a note                         | I can update or correct its content              |
 | User  | Delete a note                       | I can remove notes I no longer need              |
+| User  | Organise my notes into named lists  | I can group related notes together               |
 
 **Later phase — Campaign integration (see PRD-003)**
 
 | As a… | I want to…                    | So that…                                                      |
 |-------|-------------------------------|---------------------------------------------------------------|
-| User  | Attach a note to a campaign   | I can organize session notes within their campaign context    |
+| User  | Attach a note to a campaign   | I can organise session notes within their campaign context    |
 | User  | Detach a note from a campaign | The note returns to my personal library without being deleted |
+
+**Future — Cross-entity references**
+
+| As a… | I want to…                                                                  | So that…                                               |
+|-------|-----------------------------------------------------------------------------|--------------------------------------------------------|
+| User  | Reference another note, creature, character, or resource from within a note | I can build a connected knowledge base for my campaign |
 
 ## Functional Requirements
 
@@ -41,10 +48,22 @@ The Notes module also serves as the foundation for the Generators module (PRD-00
 - Edit and delete notes.
 - Support linking to an external URL as an alternative to a written body (e.g. a Google Doc, Notion page).
 
+### Phase 2 — Local Lists
+
+- Create, edit, and delete personal named lists of notes stored locally.
+
 ### Phase 3 — Campaign integration
 
 - Attach an existing note to a campaign (see PRD-003).
 - Notes remain in the user's personal library even when detached from a campaign.
+
+### Future — Cross-entity references
+
+> The exact interaction model (simple navigable link vs. inline display) is to be decided during design. This feature requires all referenced entity types to be available and synced first.
+
+- Within a note body, reference any other entity: another note, a monster, a character sheet, a spell, an item, etc.
+- Referenced entities are navigable from within the note.
+- **Visibility consistency**: a reference to a secret or restricted entity must respect that entity's access rules — users who cannot access the entity should not be able to navigate to it or infer its content from the reference.
 
 ## Non-Functional Requirements
 
@@ -60,3 +79,4 @@ The Notes module also serves as the foundation for the Generators module (PRD-00
 
 - Should notes support tags or categories for personal organisation?
 - Should there be a maximum note length?
+- Cross-entity references: simple navigable link or inline display? (to be decided during design)

--- a/docs/prd/PRD-004-NOTES.md
+++ b/docs/prd/PRD-004-NOTES.md
@@ -1,0 +1,62 @@
+# PRD-004 — Notes
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+## Overview
+
+The Notes module allows users to create, browse, search, and manage free-form personal notes. It is **game-system-agnostic** and follows the same list/detail/CRUD pattern as the reference data modules (PRD-001).
+Notes are standalone entities at this stage; attaching them to a campaign is a later-phase cross-entity relationship (see PRD-003).
+
+The Notes module also serves as the foundation for the Generators module (PRD-005): generated content (NPCs, names, plants, etc.) is saved as notes and managed through the same pattern.
+
+## Goals
+
+- Provide a simple, fast note-taking tool usable during any session, regardless of game system.
+- Keep notes fully accessible offline.
+- Establish the base list/search/CRUD pattern reused by the Generators module.
+
+## User Stories
+
+| As a… | I want to…                          | So that…                                         |
+|-------|-------------------------------------|--------------------------------------------------|
+| User  | Create a note with a title and body | I can write down anything relevant to my session |
+| User  | Browse and search my notes          | I can quickly find a note I wrote previously     |
+| User  | Edit a note                         | I can update or correct its content              |
+| User  | Delete a note                       | I can remove notes I no longer need              |
+
+**Later phase — Campaign integration (see PRD-003)**
+
+| As a… | I want to…                    | So that…                                                      |
+|-------|-------------------------------|---------------------------------------------------------------|
+| User  | Attach a note to a campaign   | I can organize session notes within their campaign context    |
+| User  | Detach a note from a campaign | The note returns to my personal library without being deleted |
+
+## Functional Requirements
+
+### Phase 1 — MVP (Offline)
+
+- Create a note with a title and a free-text body.
+- List all personal notes, sorted by last modified date (most recent first).
+- Full-text search on title and body.
+- Edit and delete notes.
+- Support linking to an external URL as an alternative to a written body (e.g. a Google Doc, Notion page).
+
+### Phase 3 — Campaign integration
+
+- Attach an existing note to a campaign (see PRD-003).
+- Notes remain in the user's personal library even when detached from a campaign.
+
+## Non-Functional Requirements
+
+- Notes must load and save instantly on-device (no perceptible delay).
+- The module must work fully offline.
+
+## Out of Scope
+
+- Rich text formatting (bold, lists, headings) — may be considered in a future iteration.
+- Sharing notes directly between users outside of a campaign context.
+
+## Open Questions
+
+- Should notes support tags or categories for personal organisation?
+- Should there be a maximum note length?

--- a/docs/prd/PRD-005-GENERATORS.md
+++ b/docs/prd/PRD-005-GENERATORS.md
@@ -1,0 +1,113 @@
+# PRD-005 — Generators
+
+> **Status**: Draft — Pending technical feasibility study | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+> ⚠️ **This feature is still uncertain.** The LLM-based generation approach (Phase 3 and beyond) requires a dedicated technical feasibility study before committing to an implementation.
+> Phase 1 is the only part considered stable enough to plan concretely.
+
+## Overview
+
+The Generators module helps users quickly get inspiration and ready-to-use content during a session: NPCs, locations, plants, food, magic items, and more.
+
+The approach evolves across phases:
+- **Phase 1**: Curated gallery of pre-written entries — browse, pick, save.
+- **Phase 3**: LLM-powered generation via API, contextually aware of the campaign via MCP.
+- **Future exploration**: Local model running on a separate client, pushing results to the server as notes in the user's account or campaign.
+
+Generated content is saved as **Notes** (see [PRD-004](PRD-004-NOTES.md)) and managed through the same list/search/CRUD pattern.
+
+## Goals
+
+- Help users improvise content instantly during a session.
+- Provide immediately usable, believable results.
+- Allow saving and editing generated content as notes for reuse.
+
+## Example of Categories
+
+| Category             | Fields                                                                              |
+|----------------------|-------------------------------------------------------------------------------------|
+| NPC                  | Name, age, race/ancestry, physical description, personality trait, short background |
+| Place / Organization | Name, short description (tavern, guild, faction, ship…)                             |
+| Plant                | Name, physical description, consumption method, effect                              |
+| Food & Drink         | Name, description, optional effect                                                  |
+| Magic Item           | Name, type, appearance, effect/property                                             |
+
+---
+
+## Phase 1 — Curated Gallery (Offline)
+
+Pre-written entries are bundled in the app and browsed like a gallery. No procedural generation — content is hand-crafted and curated.
+
+### User Stories
+
+| As a… | I want to…                                                   | So that…                                        |
+|-------|--------------------------------------------------------------|-------------------------------------------------|
+| User  | Browse a gallery of pre-written NPCs, locations, items, etc. | I can quickly pick one that fits my scene       |
+| User  | Filter the gallery by category                               | I can narrow down to what I need                |
+| User  | Save an entry to my notes                                    | I can reuse it later or attach it to a campaign |
+| User  | Edit a saved entry                                           | I can adapt it to my specific context           |
+
+### Functional Requirements
+
+- Display a browsable, searchable gallery of curated entries per category.
+- Filter by category (NPC, place, plant, etc.).
+- Save any entry as a Note (PRD-004) with one tap.
+- Edit and delete saved entries.
+- All content bundled locally — no network required.
+
+---
+
+## Phase 3 — LLM Generation via API (Online)
+
+> ⚠️ Requires technical feasibility study.
+
+LLM-based generation using an API. The app exposes campaign context (tone, setting, existing characters, etc.) via **MCP** so generated content is coherent with the ongoing campaign.
+
+### User Stories
+
+| As a… | I want to…                                                    | So that…                                              |
+|-------|---------------------------------------------------------------|-------------------------------------------------------|
+| User  | Generate an NPC or location with one tap                      | I get a fresh, contextually relevant result instantly |
+| User  | Provide context (campaign, tone, setting) to guide generation | The result fits my world rather than feeling generic  |
+| User  | Save the generated result as a note                           | I can reuse or attach it to my campaign               |
+
+### Functional Requirements
+
+- Call the LLM API with a structured prompt and campaign context via MCP.
+- Return a structured result matching the category's field schema.
+- Display the result in the same UI as Phase 1 gallery entries.
+- Save result as a Note (PRD-004).
+- Gracefully degrade to Phase 1 gallery when offline.
+
+---
+
+## Future Exploration — Local Model on External Client
+
+> ⚠️ Highly uncertain. Requires dedicated feasibility study.
+
+A local LLM (e.g. Ollama, llama.cpp) runs on a separate device or machine (not the companion app itself). It generates structured content and pushes the result to the backend server, which delivers it as a note to the user's account or directly into a campaign.
+
+**Open questions for the feasibility study:**
+- What protocol connects the local model to the backend (REST, WebSocket, MCP)?
+- How is authentication and user identity handled between the local client and the server?
+- What guarantees do we have on output format from a local model?
+- What is the latency and UX impact of an async delivery model (note appears after a delay)?
+
+---
+
+## Non-Functional Requirements
+
+- Phase 1 gallery must load and filter in under 300ms, fully offline.
+- Phase 3 API calls must show a loading state; timeout gracefully after 10 seconds.
+- Generated content must always be editable before saving.
+
+## Out of Scope
+
+- Dungeon / map layout generators.
+- Quest or plot hook generators.
+- On-device LLM inference within the companion app itself.
+
+## Open Questions
+
+- Should the Phase 1 gallery be expandable via downloadable content packs (Phase 2)?
+- Should saved generated content be shareable between users?

--- a/docs/prd/PRD-006-DICE.md
+++ b/docs/prd/PRD-006-DICE.md
@@ -1,0 +1,71 @@
+# PRD-006 — Virtual Dice
+
+> **Status**: Draft | **Version**: 0.1 | **Last updated**: 2026-03-15
+
+## Overview
+
+The Virtual Dice module provides a fast, in-session dice rolling tool. It supports all standard TTRPG dice, cumulative multi-dice rolls, and a roll history log.
+
+## Goals
+
+- Provide a reliable, glanceable dice roller usable mid-session without leaving the app.
+- Support cumulative rolling (e.g. 2d6 + 1d4) with a running total.
+- Keep a history of recent rolls for reference and transparency.
+
+## User Stories
+
+| As a… | I want to…                                                | So that…                                                 |
+|-------|-----------------------------------------------------------|----------------------------------------------------------|
+| User  | Tap a die to roll it                                      | I get an instant result                                  |
+| User  | Tap multiple dice to accumulate a total                   | I can resolve complex rolls (e.g. 3d6 + 1d4) in one view |
+| User  | See the individual result of each die alongside the total | I can verify the roll                                    |
+| User  | Reset the current roll                                    | I can start a new roll without navigating away           |
+| User  | Browse my roll history                                    | I can refer back to a previous roll result               |
+| User  | Clear my roll history                                     | I can keep it relevant to the current session            |
+
+## Supported Dice
+
+`d4`, `d6`, `d8`, `d10`, `d12`, `d20`, `d100`
+
+## Functional Requirements
+
+### Dice Rolling
+
+- Display all seven dice types as tappable buttons.
+- Tapping a die adds one roll of that die to the current roll pool.
+- The current roll pool shows each individual die result and the running total.
+- A **Reset** button clears the current roll pool.
+- Rolling is instantaneous with a visual result (animation optional).
+
+### Cumulative Rolling
+
+- Multiple dice can be added to the same roll pool sequentially.
+- Total is updated after each die is added.
+- Each die in the pool shows its individual result (e.g. d20: 14, d6: 3 → Total: 17).
+
+### Roll History
+
+- Each completed roll (before reset) is recorded in a history log.
+- The log entry shows: dice rolled, individual results, total, and timestamp.
+- History is persisted locally across app restarts.
+- The user can manually clear the entire history.
+- History retention policy: TBD (see Open Questions).
+
+## Non-Functional Requirements
+
+- Roll result must appear in under 100ms after tap.
+- History must support at least 500 entries without degrading scroll performance.
+- Dice results must be cryptographically random or use a high-quality PRNG to ensure fairness.
+
+## Out of Scope
+
+- Custom dice notation input (e.g. typing `3d8+5`) — may be added in a future iteration.
+- Dice with custom face labels (e.g. Fate/Fudge dice) — may be added when supporting other game systems.
+- Sharing roll results with other players in real time.
+- 3D dice animation.
+
+## Open Questions
+
+- How long should the roll history be retained? Options: session only, 7 days, indefinitely until manually cleared.
+- Should the history be scoped per campaign session or be a single global log?
+- Should there be a modifier field (e.g. +3 to add a bonus to the total)?


### PR DESCRIPTION
## 📝 Description

Establishes the full PRD baseline for the TTRPG Companion app:

- **PRD-000 — Vision**: app overview, per-campaign roles (GM, co-GM, Player), access matrix, connectivity phases, game systems
- **PRD-001 — Reference Data (Overview)**: shared pattern, goals, NFRs — links to three sub-files:
  - **PRD-001a — Spellbook**: spell catalog, filters (level, school, class), personal grimoires
  - **PRD-001b — Item List**: item catalog, filters (type, rarity), personal lists
  - **PRD-001c — Bestiary**: monster catalog, filters (type, CR), personal lists
- **PRD-002 — Character Sheet**: full D&D 5e sheet (PC & NPC), standalone entity, campaign integration deferred to Phase 3
- **PRD-003 — Campaigns**: CRUD, session notes, secret folders, sharing with role-based access (GM, co-GM, Player)
- **PRD-004 — Notes**: system-agnostic standalone note entity, foundation for the Generators module, future cross-entity references
- **PRD-005 — Generators**: Phase 1 as curated gallery, Phase 3 via LLM API + MCP — pending feasibility study
- **PRD-006 — Dice**: virtual dice roller with cumulative rolls and roll history

Key design decisions documented:
- All entities are independent in Phase 1 — cross-entity relationships come later
- Personal named lists (same-type only) created locally before any sync
- Roles are per-campaign, not per-account (GM = creator, co-GM = invited/promoted, Player = invited)
- Generators marked as uncertain — LLM approach requires dedicated technical study

## 🏷️ Type of change

- [x] `docs` — documentation only

## ✅ Checklist

- [x] The author has proofread the PR
- [x] No sensitive data (secrets, credentials, tokens) committed