### PR TITLE
docs(project): add root README and enrich companion app README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# TTRPG Companion
+
+A digital toolkit for tabletop role-playing game sessions. Designed for Game Masters and players alike, it provides campaign management, character sheets, rules references, and in-session utilities — offline-first, cross-platform.
+
+## Repository Structure
+
+| Directory              | Description                                             |
+|------------------------|---------------------------------------------------------|
+| `cmp-ttrpg-companion/` | Kotlin Multiplatform client app (Android, iOS, Desktop) |
+| `spring-server/`       | Spring Boot backend server (REST API, PostgreSQL)       |
+| `bruno/`               | API testing collections (Bruno)                         |
+| `docs/`                | Project documentation (conventions, PRDs, specs)        |
+| `Resources/`           | Shared static assets                                    |
+
+## Tech Stack
+
+| Component     | Stack                                                                  |
+|---------------|------------------------------------------------------------------------|
+| **Client**    | Kotlin Multiplatform · Compose Multiplatform · SQLDelight · Coroutines |
+| **Server**    | Kotlin · Spring Boot · PostgreSQL · Spring Data JPA                    |
+| **API Tests** | Bruno                                                                  |
+
+## Documentation
+
+| Document                                 | Description                                      |
+|------------------------------------------|--------------------------------------------------|
+| [`AGENTS.md`](AGENTS.md)                 | Central contributor guide — start here           |
+| [`docs/conventions/`](docs/conventions/) | Coding, Git, and technology-specific conventions |
+| [`docs/prd/`](docs/prd/)                 | Product Requirement Documents                    |
+
+### Conventions
+
+| File                                                                        | Description                                |
+|-----------------------------------------------------------------------------|--------------------------------------------|
+| [`CODING_CONVENTIONS.md`](docs/conventions/CODING_CONVENTIONS.md)           | Clean Code principles (all technologies)   |
+| [`GIT_AND_COLLABORATION.md`](docs/conventions/GIT_AND_COLLABORATION.md)     | Commit format, branching, CI policies      |
+| [`KMP_CONVENTIONS.md`](docs/conventions/KMP_CONVENTIONS.md)                 | KMP/Compose Multiplatform architecture     |
+| [`SPRING_BOOT_CONVENTIONS.md`](docs/conventions/SPRING_BOOT_CONVENTIONS.md) | Spring Boot architecture and Kotlin idioms |
+| [`RUST_CONVENTIONS.md`](docs/conventions/RUST_CONVENTIONS.md)               | Rust conventions (future)                  |
+| [`BRUNO_CONVENTIONS.md`](docs/conventions/BRUNO_CONVENTIONS.md)             | API testing with Bruno                     |
+
+### Product Requirements
+
+| PRD                                              | Feature                                                                                                                                            |
+|--------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`PRD-000`](docs/prd/PRD-000-VISION.md)          | Vision, roles, connectivity phases                                                                                                                 |
+| [`PRD-001`](docs/prd/PRD-001-REFERENCE-DATA.md)  | Reference data — [Spellbook](docs/prd/PRD-001a-SPELLBOOK.md) · [Items](docs/prd/PRD-001b-ITEM-LIST.md) · [Bestiary](docs/prd/PRD-001c-BESTIARY.md) |
+| [`PRD-002`](docs/prd/PRD-002-CHARACTER-SHEET.md) | Character sheets                                                                                                                                   |
+| [`PRD-003`](docs/prd/PRD-003-CAMPAIGNS.md)       | Campaigns                                                                                                                                          |
+| [`PRD-004`](docs/prd/PRD-004-NOTES.md)           | Notes                                                                                                                                              |
+| [`PRD-005`](docs/prd/PRD-005-GENERATORS.md)      | Generators                                                                                                                                         |
+| [`PRD-006`](docs/prd/PRD-006-DICE.md)            | Virtual dice                                                                                                                                       |
+
+## Getting Started
+
+### Client (KMP)
+
+```bash
+cd cmp-ttrpg-companion
+./gradlew build
+```
+
+### Server (Spring Boot)
+
+```bash
+cd spring-server
+./gradlew bootRun
+```
+
+> Requires a running PostgreSQL instance. Configure connection in `application.yml`.
+
+### API Tests (Bruno)
+
+Open the `bruno/` directory in the [Bruno](https://www.usebruno.com/) app and select the appropriate environment (`local` or `production`).

--- a/cmp-ttrpg-companion/README.md
+++ b/cmp-ttrpg-companion/README.md
@@ -1,19 +1,63 @@
-# TTRPG Companion
+# TTRPG Companion — Client App
 
-TTRPG Companion is a multiplatform application designed to assist tabletop role-playing game (TTRPG) players and game masters.
-It provides features such as campaign management, character sheets, spell books, bestiaries, and inventory management.
+Cross-platform client application for the TTRPG Companion project, built with Kotlin Multiplatform and Compose Multiplatform. Targets Android, iOS, and Desktop (JVM).
+
+For project-wide guidelines, see [`AGENTS.md`](../AGENTS.md).
 
 ## Features
 
 - **Campaign Management**: Create and manage your TTRPG campaigns.
-- **Character Sheets**: Create and manage character sheets for your players.
-- **Spell Book**: Access a comprehensive spell book for various TTRPG systems.
-- **Bestiary**: Browse and manage a bestiary of creatures.
-- **Inventory Management**: Keep track of magical items and other inventory.
+- **Character Sheets**: Create and manage character sheets for PCs and NPCs.
+- **Spellbook**: Browse, search, and filter the D&D 5e spell catalog.
+- **Bestiary**: Browse and manage a bestiary of creatures and NPCs.
+- **Item List**: Access and manage magical items and equipment.
+- **Virtual Dice**: Roll d4 to d100 with cumulative rolls and history.
 
-## Technologies Used
+## Tech Stack
 
-- **Kotlin**: The primary programming language used for the application.
-- **Jetpack Compose**: For building the UI.
-- **Gradle**: For project build and dependency management.
-- **Kotlin and Compose Multiplatform**: To support multiple platforms including Android, iOS, and Desktop.
+| Layer                 | Technology                                            |
+|-----------------------|-------------------------------------------------------|
+| Language              | Kotlin (latest stable)                                |
+| UI                    | Compose Multiplatform                                 |
+| Architecture          | Clean Architecture · MVVM · Unidirectional Data Flow  |
+| Local Database        | SQLDelight                                            |
+| Async                 | Kotlin Coroutines · Flow                              |
+| Dependency Injection  | Manual DI (no external DI library)                    |
+| Dependency Management | Gradle Version Catalogs (`gradle/libs.versions.toml`) |
+| Code Formatting       | ktlint                                                |
+
+## Platforms
+
+| Platform | Target              |
+|----------|---------------------|
+| Android  | `androidMain`       |
+| iOS      | `iosMain`           |
+| Desktop  | `desktopMain` (JVM) |
+
+## Build & Run
+
+```bash
+# Build all targets
+./gradlew build
+
+# Run on Desktop
+./gradlew desktopRun
+
+# Run Android (requires emulator or device)
+./gradlew installDebug
+
+# Check formatting
+./gradlew ktlintCheck
+
+# Auto-fix formatting
+./gradlew ktlintFormat
+```
+
+## Architecture
+
+The app follows Clean Architecture split across two modules:
+
+- **`shared/core`**: Domain layer (entities, use cases) and Data layer (SQLDelight repositories). Pure Kotlin, no framework dependencies.
+- **`composeApp`**: Presentation layer — ViewModels and Compose UI screens.
+
+See [`KMP_CONVENTIONS.md`](../docs/conventions/KMP_CONVENTIONS.md) for detailed architectural guidelines.


### PR DESCRIPTION
## 📝 Description

- Add `README.md` at the monorepo root as the main entry point: project overview, repository structure, tech stack per component, and navigation tables linking all conventions and PRDs
- Enrich `cmp-ttrpg-companion/README.md` with the full KMP tech stack (SQLDelight, manual DI, ktlint, Coroutines), platform targets, build commands, and architecture overview

## 🏷️ Type of change

- [x] `docs` — documentation only

## ✅ Checklist

- [x] The author has proofread the PR
- [x] No sensitive data (secrets, credentials, tokens) committed