### PR TITLE
docs(agents): clean up AGENTS.md — remove redundancy, add PRD reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,7 @@ For project overview, repository structure, and tech stack, see [`README.md`](RE
 
 ## 1. Product Requirements
 
-For feature specifications and product decisions, refer to the PRDs in [`docs/prd/`](docs/prd/).
-The vision and role model are defined in [`PRD-000`](docs/prd/PRD-000-VISION.md).
+For feature specifications and product decisions, refer to the [Product Requirement Documents (PRDs)](docs/prd/). The overall project vision and role model are defined in [`PRD-000`](docs/prd/PRD-000-VISION.md).
 
 ## 2. Project Guidelines and Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,9 @@
-# TTRPG Companion - Project Guidelines for Contributors
+# TTRPG Companion — Contributor Guide
 
-This document serves as the central guide for all contributors (human or AI) to the project.
-It outlines overarching principles, project structure, and general development practices. For technology-specific details, please refer to the dedicated specification files linked below.
+Central reference for all contributors (human or AI).
+For project overview, repository structure, and tech stack, see [`README.md`](README.md).
 
-## 1. Project Overview
-
-The `ttrpg-companion` project aims to provide a comprehensive digital toolkit for tabletop role-playing games. It consists of multiple components:
-
-- **Client Application**: A cross-platform application (Android, iOS, Desktop) for users to manage campaigns, characters, and game resources.
-- **Backend Services**: One or more backend services to provide data storage, real-time functionalities, and potentially AI-driven features.
-- **API Testing**: Collections for robust API testing using Bruno.
-
-## 2. Project Structure
-
-The project is organized into several key directories:
-
-- `/cmp-ttrpg-companion`: Contains the Kotlin Multiplatform client application code.
-- `/spring-server`: Contains the Spring Boot backend server code.
-- `/bruno`: Contains API testing collections and environments for Bruno.
-- `/rust-backend` (Future): Placeholder for potential Rust backend services.
-- `/Resources`: Static assets, documentation, or other shared resources.
-
-## 3. Project Guidelines and Conventions
+## 1. Project Guidelines and Conventions
 
 For detailed guidelines on specific parts of the project, please refer to the following documents:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,12 @@
 Central reference for all contributors (human or AI).
 For project overview, repository structure, and tech stack, see [`README.md`](README.md).
 
-## 1. Project Guidelines and Conventions
+## 1. Product Requirements
+
+For feature specifications and product decisions, refer to the PRDs in [`docs/prd/`](docs/prd/).
+The vision and role model are defined in [`PRD-000`](docs/prd/PRD-000-VISION.md).
+
+## 2. Project Guidelines and Conventions
 
 For detailed guidelines on specific parts of the project, please refer to the following documents:
 


### PR DESCRIPTION
## 📝 Description

- Remove redundant Project Overview and Structure sections from `AGENTS.md` — this content already lives in `README.md`.
- Add a pointer to `docs/prd/` so contributors know where to find feature specifications.

## 🏷️ Type of change

- [x] `docs` — documentation only

## ✅ Checklist

- [x] Follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed