### PR TITLE
feat(home): revamp HomeScreen with IconLabelButton row and SectionHeader

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -6,6 +6,9 @@
     <string name="btn_back">Retour</string>
     <string name="btn_more">Plus</string>
 
+    <!--  Home  -->
+    <string name="section_compendium">Compendium</string>
+
     <!--  Campaign  -->
     <string name="title_campaign_list">Campagnes</string>
     <string name="title_create_campaign">Nouvelle Campagne</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,9 @@
     <string name="btn_back">Back</string>
     <string name="btn_more">More</string>
 
+    <!--  Home  -->
+    <string name="section_compendium">Compendium</string>
+
     <!--  Campaign  -->
     <string name="title_campaign_list">Campaigns</string>
     <string name="title_create_campaign">New Campaign</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Theme.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Theme.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.core.presentation.theme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
@@ -65,6 +66,12 @@ fun AppThemePreview(
     val colors = if (darkTheme) DarkColors else LightColors
     AppTheme(
         darkTheme = darkTheme,
-        content = { Box(modifier = Modifier.background(colors.primaryContainer)) { content() } },
+        content = {
+            Box(
+                modifier = Modifier
+                    .background(colors.background)
+                    .padding(spacingMedium),
+            ) { content() }
+        },
     )
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CompendiumButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CompendiumButton.kt
@@ -59,16 +59,21 @@ fun CompendiumButton(
     }
 }
 
+@Composable
+private fun CompendiumButtonPreview() {
+    CompendiumButton(
+        label = "Spellbook",
+        icon = Icons.Filled.AutoAwesome,
+        onClick = {},
+        modifier = Modifier.width(100.dp),
+    )
+}
+
 @Preview
 @Composable
 private fun PreviewCompendiumButtonLight() {
     AppThemePreview(darkTheme = false) {
-        CompendiumButton(
-            label = "Spellbook",
-            icon = Icons.Filled.AutoAwesome,
-            onClick = {},
-            modifier = Modifier.width(100.dp),
-        )
+        CompendiumButtonPreview()
     }
 }
 
@@ -76,11 +81,6 @@ private fun PreviewCompendiumButtonLight() {
 @Composable
 private fun PreviewCompendiumButtonDark() {
     AppThemePreview(darkTheme = true) {
-        CompendiumButton(
-            label = "Spellbook",
-            icon = Icons.Filled.AutoAwesome,
-            onClick = {},
-            modifier = Modifier.width(100.dp),
-        )
+        CompendiumButtonPreview()
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CompendiumButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CompendiumButton.kt
@@ -1,0 +1,86 @@
+package com.cyrillrx.rpg.home.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun CompendiumButton(
+    label: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.aspectRatio(1f),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(spacingMedium),
+        ) {
+            Icon(
+                imageVector = icon,
+                tint = MaterialTheme.colorScheme.primary,
+                contentDescription = label,
+                modifier = Modifier
+                    .size(32.dp)
+                    .padding(bottom = spacingSmall),
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompendiumButtonLight() {
+    AppThemePreview(darkTheme = false) {
+        CompendiumButton(
+            label = "Spellbook",
+            icon = Icons.Filled.AutoAwesome,
+            onClick = {},
+            modifier = Modifier.width(100.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompendiumButtonDark() {
+    AppThemePreview(darkTheme = true) {
+        CompendiumButton(
+            label = "Spellbook",
+            icon = Icons.Filled.AutoAwesome,
+            onClick = {},
+            modifier = Modifier.width(100.dp),
+        )
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeButton.kt
@@ -7,7 +7,9 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun HomeButton(text: String, onClick: () -> Unit) {
@@ -18,5 +20,21 @@ fun HomeButton(text: String, onClick: () -> Unit) {
             .padding(PaddingValues(spacingMedium)),
     ) {
         Text(text = text)
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeButtonLight() {
+    AppThemePreview(darkTheme = false) {
+        HomeButton(text = "Campaigns", onClick = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeButtonDark() {
+    AppThemePreview(darkTheme = true) {
+        HomeButton(text = "Campaigns", onClick = {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeButton.kt
@@ -23,11 +23,16 @@ fun HomeButton(text: String, onClick: () -> Unit) {
     }
 }
 
+@Composable
+fun HomeButtonPreview() {
+    HomeButton(text = "Campaigns", onClick = {})
+}
+
 @Preview
 @Composable
 private fun PreviewHomeButtonLight() {
     AppThemePreview(darkTheme = false) {
-        HomeButton(text = "Campaigns", onClick = {})
+        HomeButtonPreview()
     }
 }
 
@@ -35,6 +40,6 @@ private fun PreviewHomeButtonLight() {
 @Composable
 private fun PreviewHomeButtonDark() {
     AppThemePreview(darkTheme = true) {
-        HomeButton(text = "Campaigns", onClick = {})
+        HomeButtonPreview()
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -49,7 +49,10 @@ fun HomeScreen(router: HomeRouter) {
             HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
             HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheets)
 
-            SectionHeader(title = "Compendium")
+            SectionHeader(
+                title = "Compendium",
+                modifier = Modifier.padding(spacingCommon),
+            )
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(spacingCommon),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -61,19 +61,19 @@ fun HomeScreen(router: HomeRouter) {
                     .fillMaxWidth()
                     .padding(horizontal = spacingCommon),
             ) {
-                CompendiumButton(
+                IconLabelButton(
                     label = stringResource(Res.string.btn_spell_book),
                     icon = Icons.Filled.AutoAwesome,
                     onClick = router::openSpellBook,
                     modifier = Modifier.weight(1f),
                 )
-                CompendiumButton(
+                IconLabelButton(
                     label = stringResource(Res.string.btn_inventory),
                     icon = Icons.Filled.Diamond,
                     onClick = router::openMagicalItems,
                     modifier = Modifier.weight(1f),
                 )
-                CompendiumButton(
+                IconLabelButton(
                     label = stringResource(Res.string.btn_bestiary),
                     icon = Icons.Filled.Pets,
                     onClick = router::openBestiary,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -49,11 +49,7 @@ fun HomeScreen(router: HomeRouter) {
             HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
             HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheets)
 
-            Text(
-                text = "Compendium",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(horizontal = spacingCommon, vertical = spacingCommon),
-            )
+            SectionHeader(title = "Compendium")
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(spacingCommon),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -1,9 +1,15 @@
 package com.cyrillrx.rpg.home.presentation
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Diamond
+import androidx.compose.material.icons.filled.Pets
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -11,13 +17,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.app_name
-import rpg_companion.composeapp.generated.resources.btn_alternative_spell_book
 import rpg_companion.composeapp.generated.resources.btn_bestiary
 import rpg_companion.composeapp.generated.resources.btn_campaign_list
 import rpg_companion.composeapp.generated.resources.btn_character_sheets
@@ -43,12 +49,37 @@ fun HomeScreen(router: HomeRouter) {
             HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
             HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheets)
 
-            HorizontalDivider()
+            Text(
+                text = "Compendium",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = spacingCommon, vertical = spacingCommon),
+            )
 
-            HomeButton(stringResource(Res.string.btn_spell_book), router::openSpellBook)
-            HomeButton(stringResource(Res.string.btn_alternative_spell_book), router::openAlternativeSpellBook)
-            HomeButton(stringResource(Res.string.btn_bestiary), router::openBestiary)
-            HomeButton(stringResource(Res.string.btn_inventory), router::openMagicalItems)
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacingCommon),
+            ) {
+                CompendiumButton(
+                    label = stringResource(Res.string.btn_spell_book),
+                    icon = Icons.Filled.AutoAwesome,
+                    onClick = router::openSpellBook,
+                    modifier = Modifier.weight(1f),
+                )
+                CompendiumButton(
+                    label = stringResource(Res.string.btn_inventory),
+                    icon = Icons.Filled.Diamond,
+                    onClick = router::openMagicalItems,
+                    modifier = Modifier.weight(1f),
+                )
+                CompendiumButton(
+                    label = stringResource(Res.string.btn_bestiary),
+                    icon = Icons.Filled.Pets,
+                    onClick = router::openBestiary,
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -29,6 +29,7 @@ import rpg_companion.composeapp.generated.resources.btn_campaign_list
 import rpg_companion.composeapp.generated.resources.btn_character_sheets
 import rpg_companion.composeapp.generated.resources.btn_inventory
 import rpg_companion.composeapp.generated.resources.btn_spell_book
+import rpg_companion.composeapp.generated.resources.section_compendium
 
 @Composable
 fun HomeScreen(router: HomeRouter) {
@@ -50,7 +51,7 @@ fun HomeScreen(router: HomeRouter) {
             HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheets)
 
             SectionHeader(
-                title = "Compendium",
+                title = stringResource(Res.string.section_compendium),
                 modifier = Modifier.padding(spacingCommon),
             )
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/IconLabelButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/IconLabelButton.kt
@@ -25,7 +25,7 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun CompendiumButton(
+fun IconLabelButton(
     label: String,
     icon: ImageVector,
     onClick: () -> Unit,
@@ -60,8 +60,8 @@ fun CompendiumButton(
 }
 
 @Composable
-private fun CompendiumButtonPreview() {
-    CompendiumButton(
+private fun IconLabelButtonPreview() {
+    IconLabelButton(
         label = "Spellbook",
         icon = Icons.Filled.AutoAwesome,
         onClick = {},
@@ -71,16 +71,16 @@ private fun CompendiumButtonPreview() {
 
 @Preview
 @Composable
-private fun PreviewCompendiumButtonLight() {
+private fun PreviewIconLabelButtonLight() {
     AppThemePreview(darkTheme = false) {
-        CompendiumButtonPreview()
+        IconLabelButtonPreview()
     }
 }
 
 @Preview
 @Composable
-private fun PreviewCompendiumButtonDark() {
+private fun PreviewIconLabelButtonDark() {
     AppThemePreview(darkTheme = true) {
-        CompendiumButtonPreview()
+        IconLabelButtonPreview()
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
@@ -47,42 +47,40 @@ fun SectionHeaderWithAction(
     }
 }
 
+@Composable
+private fun SectionHeaderPreview() {
+    SectionHeader(title = "Compendium", modifier = Modifier.padding(spacingCommon))
+}
+
 @Preview
 @Composable
 private fun PreviewSectionHeaderLight() {
-    AppThemePreview(darkTheme = false) {
-        SectionHeader(title = "Compendium")
-    }
+    AppThemePreview(darkTheme = false) { SectionHeaderPreview() }
 }
 
 @Preview
 @Composable
 private fun PreviewSectionHeaderDark() {
-    AppThemePreview(darkTheme = true) {
-        SectionHeader(title = "Compendium")
-    }
+    AppThemePreview(darkTheme = true) { SectionHeaderPreview() }
+}
+
+@Composable
+private fun SectionHeaderWithActionPreview() {
+    SectionHeaderWithAction(
+        title = "Compendium",
+        actionLabel = "See all",
+        onActionClick = {},
+    )
 }
 
 @Preview
 @Composable
 private fun PreviewSectionHeaderWithActionLight() {
-    AppThemePreview(darkTheme = false) {
-        SectionHeaderWithAction(
-            title = "Compendium",
-            actionLabel = "See all",
-            onActionClick = {},
-        )
-    }
+    AppThemePreview(darkTheme = false) { SectionHeaderWithActionPreview() }
 }
 
 @Preview
 @Composable
 private fun PreviewSectionHeaderWithActionDark() {
-    AppThemePreview(darkTheme = true) {
-        SectionHeaderWithAction(
-            title = "Compendium",
-            actionLabel = "See all",
-            onActionClick = {},
-        )
-    }
+    AppThemePreview(darkTheme = true) { SectionHeaderWithActionPreview() }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
@@ -1,0 +1,88 @@
+package com.cyrillrx.rpg.home.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun SectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = modifier.padding(spacingCommon),
+    )
+}
+
+@Composable
+fun SectionHeaderWithAction(
+    title: String,
+    actionLabel: String,
+    onActionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = spacingCommon),
+    ) {
+        SectionHeader(title = title, modifier = Modifier)
+        TextButton(onClick = onActionClick) {
+            Text(text = actionLabel)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSectionHeaderLight() {
+    AppThemePreview(darkTheme = false) {
+        SectionHeader(title = "Compendium")
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSectionHeaderDark() {
+    AppThemePreview(darkTheme = true) {
+        SectionHeader(title = "Compendium")
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSectionHeaderWithActionLight() {
+    AppThemePreview(darkTheme = false) {
+        SectionHeaderWithAction(
+            title = "Compendium",
+            actionLabel = "See all",
+            onActionClick = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSectionHeaderWithActionDark() {
+    AppThemePreview(darkTheme = true) {
+        SectionHeaderWithAction(
+            title = "Compendium",
+            actionLabel = "See all",
+            onActionClick = {},
+        )
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
@@ -21,8 +21,8 @@ fun SectionHeader(
 ) {
     Text(
         text = title,
-        style = MaterialTheme.typography.titleMedium,
-        modifier = modifier.padding(spacingCommon),
+        style = MaterialTheme.typography.titleLarge,
+        modifier = modifier,
     )
 }
 
@@ -36,11 +36,9 @@ fun SectionHeaderWithAction(
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(start = spacingCommon),
+        modifier = modifier.fillMaxWidth(),
     ) {
-        SectionHeader(title = title, modifier = Modifier)
+        SectionHeader(title = title)
         TextButton(onClick = onActionClick) {
             Text(text = actionLabel)
         }


### PR DESCRIPTION
## 📝 Description

Revamp the HomeScreen:

- Create `IconLabelButton` composable: square card with icon + label, used in a `Row` for Spellbook, Inventory and Bestiary
- Create `SectionHeader` and `SectionHeaderWithAction`
- Add mission previews to `HomeButton`
- Remove access to the `AlternativeSpellBook` (displayed as a carousel of cards)

## 🏷️ Type of change

- [x] `feat` — new feature

## 🖼️ Media

Before
<img width="1222" height="912" alt="image" src="https://github.com/user-attachments/assets/14d4ce74-b3ce-428a-bea8-e088d5798a8f" />

After
<img width="1226" height="896" alt="image" src="https://github.com/user-attachments/assets/5aa2a214-739c-4f92-8c36-6a288cce8d01" />

## ✅ Checklist

- [x] Follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed