### PR TITLE
docs(conventions): add ui commit type to distinguish visual changes from refactors

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -14,7 +14,10 @@ description: Stage and commit current changes following the project's Convention
 
 Follow **Conventional Commits**: `<type>(<scope>): <subject>`
 
-**Types**: `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`, `ci`, `build`, `perf`, `security`
+**Types**: `feat`, `fix`, `ui`, `refactor`, `style`, `docs`, `test`, `chore`, `ci`, `build`, `perf`, `security`
+- `feat` — new user-facing functionality
+- `ui` — visible UI change that is not a new feature (removing an icon, adjusting layout, tweaking a component)
+- `refactor` — internal restructuring with no visible change to the user
 
 **Scope**: component affected — use short names already present in the git log (e.g. `spell`, `home`, `campaign`, `creature`, `magicalitem`, `character`, `agents`, `roadmap`, `prd`, `compose-app`, `spring-server`)
 

--- a/docs/conventions/GIT_AND_COLLABORATION.md
+++ b/docs/conventions/GIT_AND_COLLABORATION.md
@@ -23,7 +23,10 @@ We follow **Conventional Commits** to keep the history clean and to allow automa
 <body>
 ```
 
-- **Types**: `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`, `ci`, `build` (and potentially `perf`, `security`).
+- **Types**: `feat`, `fix`, `ui`, `refactor`, `style`, `docs`, `test`, `chore`, `ci`, `build` (and potentially `perf`, `security`).
+  - `feat` — new user-facing functionality
+  - `ui` — visible UI change that is not a new feature (e.g. removing an icon, adjusting layout, tweaking a component)
+  - `refactor` — internal code restructuring with **no visible change** to the user
 - **Scope**: The component affected (e.g., `project`, `compose-app`, `server-auth`, `bruno-api`, `agents`, `prd`).
 - **Subject**: Use the imperative, present tense: "change" not "changed" nor "changes". Don't capitalize the first letter. No dot (.) at the end.
 
@@ -37,6 +40,7 @@ Here are some examples of valid commit messages:
 - docs(pdr): add product requirement document to describe spell filtering 
 - docs(agents): add co-authorship rule to AGENTS.md
 - style(compose-app): format `CampaignListScreen.kt` with ktlint
+- ui(spell): remove trailing chevron from spell list item
 - refactor(spring-server): extract common logging logic to a utility class
 - test(bruno-api): add E2E test for user registration flow
 - build(compose-app): update gradle wrapper to 8.x


### PR DESCRIPTION
## 📝 Description

Introduces the `ui` commit type to disambiguate between:
- `feat` - new user-facing functionality
- `ui` - visible UI change that is not a new feature (removing an icon, adjusting layout, tweaking a component)
- `refactor` - internal restructuring with **no visible change** to the user

Updated in both `GIT_AND_COLLABORATION.md` (canonical definition + example) and `.claude/commands/commit.md` (AI commit command guidance).

## 🏷️ Type of change

- [x] `docs` — documentation only

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed