### PR TITLE
feat(spell): add filter bottom sheet to spell screens

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -4,6 +4,8 @@
     <string name="app_name">TTRPG Companion</string>
 
     <string name="btn_back">Retour</string>
+    <string name="btn_filter">Filtrer</string>
+    <string name="btn_reset_all">Tout effacer</string>
     <string name="btn_more">Plus</string>
 
     <!--  Home  -->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -61,4 +61,10 @@
     <string name="school_illusion">Illusion</string>
     <string name="school_necromancy">Nécromancie</string>
     <string name="school_transmutation">Transmutation</string>
+
+    <!-- Spell Filter -->
+    <string name="title_filter_spells">Filtrer les sorts</string>
+    <string name="label_filter_level">Niveau</string>
+    <string name="label_filter_class">Classe</string>
+    <string name="label_filter_school">Ecole</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="app_name">TTRPG Companion</string>
 
     <string name="btn_back">Back</string>
+    <string name="btn_filter">Filter</string>
+    <string name="btn_reset_all">Reset All</string>
     <string name="btn_more">More</string>
 
     <!--  Home  -->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -62,4 +62,10 @@
     <string name="school_necromancy">Necromancy</string>
     <string name="school_transmutation">Transmutation</string>
 
+    <!-- Spell Filter -->
+    <string name="title_filter_spells">Filter Spells</string>
+    <string name="label_filter_level">Level</string>
+    <string name="label_filter_class">Class</string>
+    <string name="label_filter_school">School</string>
+
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SearchBarWithBack.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SearchBarWithBack.kt
@@ -3,19 +3,25 @@ package com.cyrillrx.rpg.core.presentation.component
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_back
+import rpg_companion.composeapp.generated.resources.btn_filter
 
 @Composable
 fun SearchBarWithBack(
@@ -23,6 +29,8 @@ fun SearchBarWithBack(
     query: String,
     onQueryChanged: (String) -> Unit,
     onNavigateUpClicked: () -> Unit,
+    onFilterClicked: (() -> Unit)? = null,
+    hasActiveFilters: Boolean = false,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -40,7 +48,24 @@ fun SearchBarWithBack(
             hint = hint,
             query = query,
             onQueryChanged = onQueryChanged,
+            modifier = Modifier
+                .weight(1f)
+                .widthIn(max = 400.dp)
+                .minimumInteractiveComponentSize(),
         )
+        if (onFilterClicked != null) {
+            IconButton(onClick = onFilterClicked) {
+                Icon(
+                    imageVector = Icons.Default.Tune,
+                    contentDescription = stringResource(Res.string.btn_filter),
+                    tint = if (hasActiveFilters) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellListState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellListState.kt
@@ -1,10 +1,11 @@
 package com.cyrillrx.rpg.spell.presentation
 
 import com.cyrillrx.rpg.spell.domain.Spell
+import com.cyrillrx.rpg.spell.domain.SpellFilter
 import org.jetbrains.compose.resources.StringResource
 
 data class SpellListState(
-    val searchQuery: String,
+    val filter: SpellFilter = SpellFilter(),
     val body: Body,
 ) {
     sealed interface Body {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/DndFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/DndFormatExt.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.core.presentation.theme.Red900
 import com.cyrillrx.rpg.spell.domain.Spell
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
@@ -44,7 +45,7 @@ import rpg_companion.composeapp.generated.resources.spell_level_8th
 import rpg_companion.composeapp.generated.resources.spell_level_9th
 import rpg_companion.composeapp.generated.resources.spell_level_cantrip
 
-fun Spell.getColor(): Color = Color(173, 29, 29)
+fun Spell.getColor(): Color = Red900
 
 @Composable
 fun Spell.getFormattedSchool() =

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/DndFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/DndFormatExt.kt
@@ -1,0 +1,114 @@
+package com.cyrillrx.rpg.spell.presentation.component
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Flare
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.outlined.Dangerous
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.spell.domain.Spell
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.class_bard
+import rpg_companion.composeapp.generated.resources.class_cleric
+import rpg_companion.composeapp.generated.resources.class_druid
+import rpg_companion.composeapp.generated.resources.class_paladin
+import rpg_companion.composeapp.generated.resources.class_ranger
+import rpg_companion.composeapp.generated.resources.class_sorcerer
+import rpg_companion.composeapp.generated.resources.class_warlock
+import rpg_companion.composeapp.generated.resources.class_wizard
+import rpg_companion.composeapp.generated.resources.formatted_spell_school_level
+import rpg_companion.composeapp.generated.resources.school_abjuration
+import rpg_companion.composeapp.generated.resources.school_conjuration
+import rpg_companion.composeapp.generated.resources.school_divination
+import rpg_companion.composeapp.generated.resources.school_enchantment
+import rpg_companion.composeapp.generated.resources.school_evocation
+import rpg_companion.composeapp.generated.resources.school_illusion
+import rpg_companion.composeapp.generated.resources.school_necromancy
+import rpg_companion.composeapp.generated.resources.school_transmutation
+import rpg_companion.composeapp.generated.resources.spell_level_1st
+import rpg_companion.composeapp.generated.resources.spell_level_2nd
+import rpg_companion.composeapp.generated.resources.spell_level_3rd
+import rpg_companion.composeapp.generated.resources.spell_level_4th
+import rpg_companion.composeapp.generated.resources.spell_level_5th
+import rpg_companion.composeapp.generated.resources.spell_level_6th
+import rpg_companion.composeapp.generated.resources.spell_level_7th
+import rpg_companion.composeapp.generated.resources.spell_level_8th
+import rpg_companion.composeapp.generated.resources.spell_level_9th
+import rpg_companion.composeapp.generated.resources.spell_level_cantrip
+
+fun Spell.getColor(): Color = Color(173, 29, 29)
+
+@Composable
+fun Spell.getFormattedSchool() =
+    stringResource(Res.string.formatted_spell_school_level, getSchool(), level)
+
+@Composable
+fun Spell.getSchool(): String {
+    return schools.map { it.toFormattedString() }.joinToString(", ")
+}
+
+@Composable
+fun Spell.School.toFormattedString(): String {
+    val stringRes = when (this) {
+        Spell.School.ABJURATION -> Res.string.school_abjuration
+        Spell.School.CONJURATION -> Res.string.school_conjuration
+        Spell.School.DIVINATION -> Res.string.school_divination
+        Spell.School.ENCHANTMENT -> Res.string.school_enchantment
+        Spell.School.EVOCATION -> Res.string.school_evocation
+        Spell.School.ILLUSION -> Res.string.school_illusion
+        Spell.School.NECROMANCY -> Res.string.school_necromancy
+        Spell.School.TRANSMUTATION -> Res.string.school_transmutation
+    }
+    return stringResource(stringRes)
+}
+
+fun Spell.School?.toIcon(): ImageVector = when (this) {
+    Spell.School.ABJURATION -> Icons.Filled.Shield
+    Spell.School.CONJURATION -> Icons.Filled.Flare
+    Spell.School.DIVINATION -> Icons.Filled.Visibility
+    Spell.School.ENCHANTMENT -> Icons.Filled.Psychology
+    Spell.School.EVOCATION -> Icons.Filled.Bolt
+    Spell.School.ILLUSION -> Icons.Filled.AutoAwesome
+    Spell.School.NECROMANCY -> Icons.Outlined.Dangerous
+    Spell.School.TRANSMUTATION -> Icons.Filled.SwapHoriz
+    null -> Icons.Filled.AutoAwesome
+}
+
+@Composable
+fun PlayerCharacter.Class.toFormattedString(): String {
+    val stringRes = when (this) {
+        PlayerCharacter.Class.BARD -> Res.string.class_bard
+        PlayerCharacter.Class.CLERIC -> Res.string.class_cleric
+        PlayerCharacter.Class.DRUID -> Res.string.class_druid
+        PlayerCharacter.Class.PALADIN -> Res.string.class_paladin
+        PlayerCharacter.Class.RANGER -> Res.string.class_ranger
+        PlayerCharacter.Class.SORCERER -> Res.string.class_sorcerer
+        PlayerCharacter.Class.WARLOCK -> Res.string.class_warlock
+        PlayerCharacter.Class.WIZARD -> Res.string.class_wizard
+    }
+    return stringResource(stringRes)
+}
+
+@Composable
+fun Spell.toFormattedLevel(): String = stringResource(
+    when (level) {
+        0 -> Res.string.spell_level_cantrip
+        1 -> Res.string.spell_level_1st
+        2 -> Res.string.spell_level_2nd
+        3 -> Res.string.spell_level_3rd
+        4 -> Res.string.spell_level_4th
+        5 -> Res.string.spell_level_5th
+        6 -> Res.string.spell_level_6th
+        7 -> Res.string.spell_level_7th
+        8 -> Res.string.spell_level_8th
+        else -> Res.string.spell_level_9th
+    },
+)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
@@ -31,15 +31,6 @@ import com.cyrillrx.rpg.spell.domain.Spell
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.formatted_spell_school_level
-import rpg_companion.composeapp.generated.resources.school_abjuration
-import rpg_companion.composeapp.generated.resources.school_conjuration
-import rpg_companion.composeapp.generated.resources.school_divination
-import rpg_companion.composeapp.generated.resources.school_enchantment
-import rpg_companion.composeapp.generated.resources.school_evocation
-import rpg_companion.composeapp.generated.resources.school_illusion
-import rpg_companion.composeapp.generated.resources.school_necromancy
-import rpg_companion.composeapp.generated.resources.school_transmutation
 import rpg_companion.composeapp.generated.resources.spell_casting_time
 import rpg_companion.composeapp.generated.resources.spell_components
 import rpg_companion.composeapp.generated.resources.spell_duration
@@ -165,32 +156,6 @@ private fun SpellGridItem(title: String, subtitle: String, spellColor: Color) {
                 .background(spellColor),
         )
     }
-}
-
-fun Spell.getColor(): Color = Color(173, 29, 29)
-
-@Composable
-fun Spell.getFormattedSchool() =
-    stringResource(Res.string.formatted_spell_school_level, getSchool(), level)
-
-@Composable
-private fun Spell.getSchool(): String {
-    return schools.map { it.toFormattedString() }.joinToString(", ")
-}
-
-@Composable
-fun Spell.School.toFormattedString(): String {
-    val stringRes = when (this) {
-        Spell.School.ABJURATION -> Res.string.school_abjuration
-        Spell.School.CONJURATION -> Res.string.school_conjuration
-        Spell.School.DIVINATION -> Res.string.school_divination
-        Spell.School.ENCHANTMENT -> Res.string.school_enchantment
-        Spell.School.EVOCATION -> Res.string.school_evocation
-        Spell.School.ILLUSION -> Res.string.school_illusion
-        Spell.School.NECROMANCY -> Res.string.school_necromancy
-        Spell.School.TRANSMUTATION -> Res.string.school_transmutation
-    }
-    return stringResource(stringRes)
 }
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -12,8 +12,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -38,6 +42,10 @@ fun SpellCardCarouselScreen(viewModel: SpellBookViewModel, router: SpellRouter) 
         onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onSpellClicked = router::openSpellDetail,
+        onLevelToggled = viewModel::onLevelToggled,
+        onSchoolToggled = viewModel::onSchoolToggled,
+        onClassToggled = viewModel::onClassToggled,
+        onResetFilters = viewModel::onResetFilters,
     )
 }
 
@@ -47,7 +55,13 @@ fun SpellCardCarouselScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onSpellClicked: (Spell) -> Unit,
+    onLevelToggled: (Int) -> Unit,
+    onSchoolToggled: (Spell.School) -> Unit,
+    onClassToggled: (PlayerCharacter.Class) -> Unit,
+    onResetFilters: () -> Unit,
 ) {
+    var showFilterSheet by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             SearchBarWithBack(
@@ -55,6 +69,8 @@ fun SpellCardCarouselScreen(
                 query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
+                onFilterClicked = { showFilterSheet = true },
+                hasActiveFilters = state.filter.hasActiveFilters,
             )
         },
     ) { paddingValues ->
@@ -66,6 +82,17 @@ fun SpellCardCarouselScreen(
                 is SpellListState.Body.WithData -> SpellCardCarousel(body.searchResults, onSpellClicked)
             }
         }
+    }
+
+    if (showFilterSheet) {
+        SpellFilterBottomSheet(
+            filter = state.filter,
+            onLevelToggled = onLevelToggled,
+            onSchoolToggled = onSchoolToggled,
+            onClassToggled = onClassToggled,
+            onResetFilters = onResetFilters,
+            onDismiss = { showFilterSheet = false },
+        )
     }
 }
 
@@ -103,7 +130,7 @@ private val stateWithSampleData = SpellListState(
 @Composable
 fun PreviewSpellCardCarouselScreenLight() {
     AppThemePreview(darkTheme = false) {
-        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {})
+        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -111,6 +138,6 @@ fun PreviewSpellCardCarouselScreenLight() {
 @Composable
 fun PreviewSpellCardCarouselScreenDark() {
     AppThemePreview(darkTheme = true) {
-        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {})
+        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -52,7 +52,7 @@ fun SpellCardCarouselScreen(
         topBar = {
             SearchBarWithBack(
                 hint = stringResource(Res.string.hint_search_spell),
-                query = state.searchQuery,
+                query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
             )
@@ -61,7 +61,7 @@ fun SpellCardCarouselScreen(
         Column(Modifier.padding(paddingValues)) {
             when (val body = state.body) {
                 is SpellListState.Body.Loading -> Loader()
-                is SpellListState.Body.Empty -> EmptySearch(state.searchQuery)
+                is SpellListState.Body.Empty -> EmptySearch(state.filter.query)
                 is SpellListState.Body.Error -> ErrorLayout(body.errorMessage)
                 is SpellListState.Body.WithData -> SpellCardCarousel(body.searchResults, onSpellClicked)
             }
@@ -96,7 +96,6 @@ private fun SpellCardCarousel(
 }
 
 private val stateWithSampleData = SpellListState(
-    searchQuery = "",
     body = SpellListState.Body.WithData(SampleSpellRepository().getAll()),
 )
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -30,14 +30,6 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_reset_all
-import rpg_companion.composeapp.generated.resources.class_bard
-import rpg_companion.composeapp.generated.resources.class_cleric
-import rpg_companion.composeapp.generated.resources.class_druid
-import rpg_companion.composeapp.generated.resources.class_paladin
-import rpg_companion.composeapp.generated.resources.class_ranger
-import rpg_companion.composeapp.generated.resources.class_sorcerer
-import rpg_companion.composeapp.generated.resources.class_warlock
-import rpg_companion.composeapp.generated.resources.class_wizard
 import rpg_companion.composeapp.generated.resources.label_filter_class
 import rpg_companion.composeapp.generated.resources.label_filter_level
 import rpg_companion.composeapp.generated.resources.label_filter_school
@@ -130,21 +122,6 @@ fun SpellFilterBottomSheet(
             }
         }
     }
-}
-
-@Composable
-private fun PlayerCharacter.Class.toFormattedString(): String {
-    val stringRes = when (this) {
-        PlayerCharacter.Class.BARD -> Res.string.class_bard
-        PlayerCharacter.Class.CLERIC -> Res.string.class_cleric
-        PlayerCharacter.Class.DRUID -> Res.string.class_druid
-        PlayerCharacter.Class.PALADIN -> Res.string.class_paladin
-        PlayerCharacter.Class.RANGER -> Res.string.class_ranger
-        PlayerCharacter.Class.SORCERER -> Res.string.class_sorcerer
-        PlayerCharacter.Class.WARLOCK -> Res.string.class_warlock
-        PlayerCharacter.Class.WIZARD -> Res.string.class_wizard
-    }
-    return stringResource(stringRes)
 }
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -1,0 +1,174 @@
+package com.cyrillrx.rpg.spell.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.spell.domain.Spell
+import com.cyrillrx.rpg.spell.domain.SpellFilter
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_reset_all
+import rpg_companion.composeapp.generated.resources.class_bard
+import rpg_companion.composeapp.generated.resources.class_cleric
+import rpg_companion.composeapp.generated.resources.class_druid
+import rpg_companion.composeapp.generated.resources.class_paladin
+import rpg_companion.composeapp.generated.resources.class_ranger
+import rpg_companion.composeapp.generated.resources.class_sorcerer
+import rpg_companion.composeapp.generated.resources.class_warlock
+import rpg_companion.composeapp.generated.resources.class_wizard
+import rpg_companion.composeapp.generated.resources.label_filter_class
+import rpg_companion.composeapp.generated.resources.label_filter_level
+import rpg_companion.composeapp.generated.resources.label_filter_school
+import rpg_companion.composeapp.generated.resources.title_filter_spells
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun SpellFilterBottomSheet(
+    filter: SpellFilter,
+    onLevelToggled: (Int) -> Unit,
+    onSchoolToggled: (Spell.School) -> Unit,
+    onClassToggled: (PlayerCharacter.Class) -> Unit,
+    onResetFilters: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacingCommon)
+                .padding(bottom = spacingLarge),
+            verticalArrangement = Arrangement.spacedBy(spacingCommon),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(Res.string.title_filter_spells),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                TextButton(onClick = onResetFilters) {
+                    Text(text = stringResource(Res.string.btn_reset_all))
+                }
+            }
+
+            // Level
+            Text(
+                text = stringResource(Res.string.label_filter_level),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                (0..9).forEach { level ->
+                    FilterChip(
+                        selected = level in filter.levels,
+                        onClick = { onLevelToggled(level) },
+                        label = { Text(text = level.toString()) },
+                    )
+                }
+            }
+
+            // Class
+            Text(
+                text = stringResource(Res.string.label_filter_class),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                PlayerCharacter.Class.entries.forEach { playerClass ->
+                    FilterChip(
+                        selected = playerClass in filter.playerClasses,
+                        onClick = { onClassToggled(playerClass) },
+                        label = { Text(text = playerClass.toFormattedString()) },
+                    )
+                }
+            }
+
+            // School
+            Text(
+                text = stringResource(Res.string.label_filter_school),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                Spell.School.entries.forEach { school ->
+                    FilterChip(
+                        selected = school in filter.schools,
+                        onClick = { onSchoolToggled(school) },
+                        label = { Text(text = school.toFormattedString()) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerCharacter.Class.toFormattedString(): String {
+    val stringRes = when (this) {
+        PlayerCharacter.Class.BARD -> Res.string.class_bard
+        PlayerCharacter.Class.CLERIC -> Res.string.class_cleric
+        PlayerCharacter.Class.DRUID -> Res.string.class_druid
+        PlayerCharacter.Class.PALADIN -> Res.string.class_paladin
+        PlayerCharacter.Class.RANGER -> Res.string.class_ranger
+        PlayerCharacter.Class.SORCERER -> Res.string.class_sorcerer
+        PlayerCharacter.Class.WARLOCK -> Res.string.class_warlock
+        PlayerCharacter.Class.WIZARD -> Res.string.class_wizard
+    }
+    return stringResource(stringRes)
+}
+
+@Preview
+@Composable
+private fun PreviewSpellFilterBottomSheetLight() {
+    val sampleFilter = SpellFilter(
+        levels = setOf(0, 3),
+        playerClasses = setOf(PlayerCharacter.Class.SORCERER),
+        schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
+    )
+    AppThemePreview(darkTheme = false) {
+        SpellFilterBottomSheet(sampleFilter, {}, {}, {}, {}, {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSpellFilterBottomSheetDark() {
+    val sampleFilter = SpellFilter(
+        levels = setOf(0, 3),
+        playerClasses = setOf(PlayerCharacter.Class.SORCERER),
+        schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
+    )
+    AppThemePreview(darkTheme = true) {
+        SpellFilterBottomSheet(sampleFilter, {}, {}, {}, {}, {})
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
@@ -8,15 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.Flare
-import androidx.compose.material.icons.filled.Psychology
-import androidx.compose.material.icons.filled.Shield
-import androidx.compose.material.icons.filled.SwapHoriz
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.outlined.Dangerous
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -25,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
@@ -37,19 +27,7 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.domain.Spell
-import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.spell_level_1st
-import rpg_companion.composeapp.generated.resources.spell_level_2nd
-import rpg_companion.composeapp.generated.resources.spell_level_3rd
-import rpg_companion.composeapp.generated.resources.spell_level_4th
-import rpg_companion.composeapp.generated.resources.spell_level_5th
-import rpg_companion.composeapp.generated.resources.spell_level_6th
-import rpg_companion.composeapp.generated.resources.spell_level_7th
-import rpg_companion.composeapp.generated.resources.spell_level_8th
-import rpg_companion.composeapp.generated.resources.spell_level_9th
-import rpg_companion.composeapp.generated.resources.spell_level_cantrip
 
 @Composable
 fun SpellListItem(
@@ -117,41 +95,13 @@ fun SpellListItem(
 
             // Level
             Text(
-                text = formattedLevel(spell.level),
+                text = spell.toFormattedLevel(),
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,
             )
         }
     }
-}
-
-@Composable
-private fun formattedLevel(level: Int): String = stringResource(
-    when (level) {
-        0 -> Res.string.spell_level_cantrip
-        1 -> Res.string.spell_level_1st
-        2 -> Res.string.spell_level_2nd
-        3 -> Res.string.spell_level_3rd
-        4 -> Res.string.spell_level_4th
-        5 -> Res.string.spell_level_5th
-        6 -> Res.string.spell_level_6th
-        7 -> Res.string.spell_level_7th
-        8 -> Res.string.spell_level_8th
-        else -> Res.string.spell_level_9th
-    },
-)
-
-private fun Spell.School?.toIcon(): ImageVector = when (this) {
-    Spell.School.ABJURATION -> Icons.Filled.Shield
-    Spell.School.CONJURATION -> Icons.Filled.Flare
-    Spell.School.DIVINATION -> Icons.Filled.Visibility
-    Spell.School.ENCHANTMENT -> Icons.Filled.Psychology
-    Spell.School.EVOCATION -> Icons.Filled.Bolt
-    Spell.School.ILLUSION -> Icons.Filled.AutoAwesome
-    Spell.School.NECROMANCY -> Icons.Outlined.Dangerous
-    Spell.School.TRANSMUTATION -> Icons.Filled.SwapHoriz
-    null -> Icons.Filled.AutoAwesome
 }
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -13,9 +13,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -42,6 +46,10 @@ fun SpellListScreen(viewModel: SpellBookViewModel, router: SpellRouter) {
         onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onSpellClicked = router::openSpellDetail,
+        onLevelToggled = viewModel::onLevelToggled,
+        onSchoolToggled = viewModel::onSchoolToggled,
+        onClassToggled = viewModel::onClassToggled,
+        onResetFilters = viewModel::onResetFilters,
     )
 }
 
@@ -51,7 +59,13 @@ fun SpellListScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onSpellClicked: (Spell) -> Unit,
+    onLevelToggled: (Int) -> Unit,
+    onSchoolToggled: (Spell.School) -> Unit,
+    onClassToggled: (PlayerCharacter.Class) -> Unit,
+    onResetFilters: () -> Unit,
 ) {
+    var showFilterSheet by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             SearchBarWithBack(
@@ -59,6 +73,8 @@ fun SpellListScreen(
                 query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
+                onFilterClicked = { showFilterSheet = true },
+                hasActiveFilters = state.filter.hasActiveFilters,
             )
         },
     ) { paddingValues ->
@@ -75,6 +91,17 @@ fun SpellListScreen(
                 is SpellListState.Body.WithData -> SpellList(body.searchResults, onSpellClicked)
             }
         }
+    }
+
+    if (showFilterSheet) {
+        SpellFilterBottomSheet(
+            filter = state.filter,
+            onLevelToggled = onLevelToggled,
+            onSchoolToggled = onSchoolToggled,
+            onClassToggled = onClassToggled,
+            onResetFilters = onResetFilters,
+            onDismiss = { showFilterSheet = false },
+        )
     }
 }
 
@@ -112,7 +139,7 @@ private val stateWithSampleData = SpellListState(
 @Composable
 fun PreviewSpellBookPeekScreenLight() {
     AppThemePreview(darkTheme = false) {
-        SpellListScreen(stateWithSampleData, {}, {}, {})
+        SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -120,6 +147,6 @@ fun PreviewSpellBookPeekScreenLight() {
 @Composable
 fun PreviewSpellBookPeekScreenDark() {
     AppThemePreview(darkTheme = true) {
-        SpellListScreen(stateWithSampleData, {}, {}, {})
+        SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -56,7 +56,7 @@ fun SpellListScreen(
         topBar = {
             SearchBarWithBack(
                 hint = stringResource(Res.string.hint_search_spell),
-                query = state.searchQuery,
+                query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
             )
@@ -70,7 +70,7 @@ fun SpellListScreen(
         ) {
             when (val body = state.body) {
                 is SpellListState.Body.Loading -> Loader()
-                is SpellListState.Body.Empty -> EmptySearch(state.searchQuery)
+                is SpellListState.Body.Empty -> EmptySearch(state.filter.query)
                 is SpellListState.Body.Error -> ErrorLayout(body.errorMessage)
                 is SpellListState.Body.WithData -> SpellList(body.searchResults, onSpellClicked)
             }
@@ -105,7 +105,6 @@ private fun SpellList(
 }
 
 private val stateWithSampleData = SpellListState(
-    searchQuery = "",
     body = SpellListState.Body.WithData(SampleSpellRepository().getAll()),
 )
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.spell.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
@@ -23,12 +24,12 @@ class SpellBookViewModel(
 
     private var updateJob: Job? = null
     private val _state: MutableStateFlow<SpellListState> = MutableStateFlow(
-        SpellListState(searchQuery = "", body = SpellListState.Body.Empty),
+        SpellListState(body = SpellListState.Body.Empty),
     )
     val state: StateFlow<SpellListState> = _state.asStateFlow()
 
     init {
-        onSearchQueryChanged(query = "")
+        refreshData()
     }
 
     fun onNavigateUpClicked() {
@@ -36,29 +37,66 @@ class SpellBookViewModel(
     }
 
     fun onSearchQueryChanged(query: String) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData(query) }
+        _state.update { it.copy(filter = it.filter.copy(query = query)) }
+        refreshData()
     }
 
     fun onSpellClicked(spell: Spell) {
         router.openSpellDetail(spell)
     }
 
-    private suspend fun updateData(query: String) {
+    fun onLevelToggled(level: Int) {
         _state.update {
-            SpellListState(searchQuery = query, body = SpellListState.Body.Loading)
+            val current = it.filter.levels
+            val updated = if (level in current) current - level else current + level
+            it.copy(filter = it.filter.copy(levels = updated))
         }
+        refreshData()
+    }
+
+    fun onSchoolToggled(school: Spell.School) {
+        _state.update {
+            val current = it.filter.schools
+            val updated = if (school in current) current - school else current + school
+            it.copy(filter = it.filter.copy(schools = updated))
+        }
+        refreshData()
+    }
+
+    fun onClassToggled(playerClass: PlayerCharacter.Class) {
+        _state.update {
+            val current = it.filter.playerClasses
+            val updated = if (playerClass in current) current - playerClass else current + playerClass
+            it.copy(filter = it.filter.copy(playerClasses = updated))
+        }
+        refreshData()
+    }
+
+    fun onResetFilters() {
+        _state.update {
+            it.copy(filter = SpellFilter(query = it.filter.query))
+        }
+        refreshData()
+    }
+
+    private fun refreshData() {
+        updateJob?.cancel()
+        updateJob = viewModelScope.launch { updateData() }
+    }
+
+    private suspend fun updateData() {
+        _state.update { it.copy(body = SpellListState.Body.Loading) }
 
         try {
-            val filter = SpellFilter(query = query)
+            val filter = _state.value.filter
             val spells = repository.getAll(filter)
             if (spells.isEmpty()) {
-                _state.update { _state.value.copy(body = SpellListState.Body.Empty) }
+                _state.update { it.copy(body = SpellListState.Body.Empty) }
             } else {
-                _state.update { _state.value.copy(body = SpellListState.Body.WithData(spells)) }
+                _state.update { it.copy(body = SpellListState.Body.WithData(spells)) }
             }
         } catch (e: Exception) {
-            _state.update { _state.value.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
+            _state.update { it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
@@ -47,27 +47,24 @@ class SpellBookViewModel(
 
     fun onLevelToggled(level: Int) {
         _state.update {
-            val current = it.filter.levels
-            val updated = if (level in current) current - level else current + level
-            it.copy(filter = it.filter.copy(levels = updated))
+            val updatedLevels = it.filter.levels.toggled(level)
+            it.copy(filter = it.filter.copy(levels = updatedLevels))
         }
         refreshData()
     }
 
     fun onSchoolToggled(school: Spell.School) {
         _state.update {
-            val current = it.filter.schools
-            val updated = if (school in current) current - school else current + school
-            it.copy(filter = it.filter.copy(schools = updated))
+            val updatedSchools = it.filter.schools.toggled(school)
+            it.copy(filter = it.filter.copy(schools = updatedSchools))
         }
         refreshData()
     }
 
     fun onClassToggled(playerClass: PlayerCharacter.Class) {
         _state.update {
-            val current = it.filter.playerClasses
-            val updated = if (playerClass in current) current - playerClass else current + playerClass
-            it.copy(filter = it.filter.copy(playerClasses = updated))
+            val updatedClasses = it.filter.playerClasses.toggled(playerClass)
+            it.copy(filter = it.filter.copy(playerClasses = updatedClasses))
         }
         refreshData()
     }
@@ -78,6 +75,8 @@ class SpellBookViewModel(
         }
         refreshData()
     }
+
+    private fun <T> Set<T>.toggled(item: T): Set<T> = if (item in this) this - item else this + item
 
     private fun refreshData() {
         updateJob?.cancel()

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -2,12 +2,15 @@ package com.cyrillrx.rpg.spell.domain
 
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
 
-class SpellFilter(
-    private val query: String = "",
-    private val schools: Set<Spell.School> = emptySet(),
-    private val playerClasses: Set<PlayerCharacter.Class> = emptySet(),
-    private val levels: Set<Int> = emptySet(),
+data class SpellFilter(
+    val query: String = "",
+    val schools: Set<Spell.School> = emptySet(),
+    val playerClasses: Set<PlayerCharacter.Class> = emptySet(),
+    val levels: Set<Int> = emptySet(),
 ) {
+    val hasActiveFilters: Boolean
+        get() = schools.isNotEmpty() || playerClasses.isNotEmpty() || levels.isNotEmpty()
+
     fun matches(spell: Spell): Boolean {
         return (schools.isEmpty() || spell.schools.any { schools.contains(it) }) &&
             (playerClasses.isEmpty() || spell.availableClasses.any { playerClasses.contains(it) }) &&

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ For detailed feature specifications, see the [PRDs](prd/).
 
 > Bring current implementations to a production-ready state. - [PRD-001](prd/PRD-001-REFERENCE-DATA.md)
 
-- [ ] Complete Spellbook filters (school, class) - [PRD-001a](prd/PRD-001a-SPELLBOOK.md)
+- [x] Complete Spellbook filters (school, class) - [PRD-001a](prd/PRD-001a-SPELLBOOK.md)
 - [ ] Complete Inventory filters (type, rarity) - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
 - [ ] Complete Bestiary filters (type, CR) - [PRD-001c](prd/PRD-001c-BESTIARY.md)
 


### PR DESCRIPTION
## 📝 Description

Add a filter bottom sheet to the Spellbook screens (list and carousel), allowing users to filter spells by level, class, and school.
The filter button is integrated into the shared `SearchBarWithBack` component, and its icon tint indicates whether filters are active.

Also
- Refactors `SpellFilter` into a data class with public fields so it can be used directly in UI state
- Extracts all D&D formatting extensions (`toFormattedString`, `toIcon`, `toFormattedLevel`) into a shared `DndFormatExt.kt` file.

## 🏷️ Type of change

- [x] `feat` - new feature
- [x] `refactor` - code change that neither fixes a bug nor adds a feature
- [x] `docs` - documentation only

## 🖼️ Media

<img width="1020" height="232" alt="image" src="https://github.com/user-attachments/assets/d1c2f3c8-49d6-453a-98f3-e1ad2e6cf6da" />

<img width="1028" height="836" alt="image" src="https://github.com/user-attachments/assets/ce9de879-8488-4e3c-86b1-7115c635faa7" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed