### PR TITLE
docs(project): simplify PR template by removing type checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## 📝 Description
 
-<!-- Title should be formatted as follow: <type>(<scope>): <subject> -->
+<!-- Title should follow Conventional Commits: <type>(<scope>): <subject>. See docs/conventions/GIT_AND_COLLABORATION.md for details. -->
 <!-- Description should answer: What does this PR do and why? -->
 
 ## 🖼️ Media

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,7 @@
 ## 📝 Description
 
-<!-- What does this PR do and why? -->
-
-## 🏷️ Type of change
-
-<!-- Check all that apply. -->
-
-- [ ] `feat` — new feature
-- [ ] `fix` — bug fix
-- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
-- [ ] `style` — formatting only (ktlint, rustfmt…)
-- [ ] `docs` — documentation only
-- [ ] `test` — adding or updating tests
-- [ ] `chore` / `build` / `ci` — tooling, dependencies, configuration
+<!-- Title should be formatted as follow: <type>(<scope>): <subject> -->
+<!-- Description should answer: What does this PR do and why? -->
 
 ## 🖼️ Media
 


### PR DESCRIPTION
## 📝 Description

Removes redundant "Type of change" section from the PR template as the type is already encoded in the PR title.
Also adds an inline comment on the Description section to remind authors of the title format.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed