### PR TITLE
refactor(magicalitem): wire filter to state and rename screen to carousel

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -35,7 +35,7 @@ class HomeRouterImpl(private val navController: NavController) : HomeRouter {
     }
 
     override fun openMagicalItems() {
-        navController.navigate(MagicalItemRoute.List)
+        navController.navigate(MagicalItemRoute.CardCarousel)
     }
 
     override fun openBestiary() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemListState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemListState.kt
@@ -1,10 +1,11 @@
 package com.cyrillrx.rpg.magicalitem.presentation
 
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import org.jetbrains.compose.resources.StringResource
 
 data class MagicalItemListState(
-    val searchQuery: String,
+    val filter: MagicalItemFilter = MagicalItemFilter(),
     val body: Body,
 ) {
     sealed interface Body {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
@@ -29,9 +29,9 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_magical_item
 
 @Composable
-fun MagicalItemListScreen(viewModel: MagicalItemListViewModel) {
+fun MagicalItemCardCarouselScreen(viewModel: MagicalItemListViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    MagicalItemListScreen(
+    MagicalItemCardCarouselScreen(
         state = state,
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
@@ -40,7 +40,7 @@ fun MagicalItemListScreen(viewModel: MagicalItemListViewModel) {
 }
 
 @Composable
-fun MagicalItemListScreen(
+fun MagicalItemCardCarouselScreen(
     state: MagicalItemListState,
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
@@ -61,14 +61,14 @@ fun MagicalItemListScreen(
                 is MagicalItemListState.Body.Loading -> Loader()
                 is MagicalItemListState.Body.Empty -> EmptySearch(state.filter.query)
                 is MagicalItemListState.Body.Error -> ErrorLayout(body.errorMessage)
-                is MagicalItemListState.Body.WithData -> MagicalItemsList(body.searchResults, onMagicalItemClicked)
+                is MagicalItemListState.Body.WithData -> MagicalItemCardCarousel(body.searchResults, onMagicalItemClicked)
             }
         }
     }
 }
 
 @Composable
-private fun MagicalItemsList(
+private fun MagicalItemCardCarousel(
     magicalItems: List<MagicalItem>,
     onMagicalItemClicked: (MagicalItem) -> Unit,
 ) {
@@ -98,16 +98,16 @@ private val stateWithSampleData = MagicalItemListState(
 
 @Preview
 @Composable
-private fun PreviewSpellBookScreenLight() {
+private fun PreviewMagicalItemCardCarouselScreenLight() {
     AppThemePreview(darkTheme = false) {
-        MagicalItemListScreen(stateWithSampleData, {}, {}, {})
+        MagicalItemCardCarouselScreen(stateWithSampleData, {}, {}, {})
     }
 }
 
 @Preview
 @Composable
-private fun PreviewSpellBookScreenDark() {
+private fun PreviewMagicalItemCardCarouselScreenDark() {
     AppThemePreview(darkTheme = true) {
-        MagicalItemListScreen(stateWithSampleData, {}, {}, {})
+        MagicalItemCardCarouselScreen(stateWithSampleData, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -50,7 +50,7 @@ fun MagicalItemListScreen(
         topBar = {
             SearchBarWithBack(
                 hint = stringResource(Res.string.hint_search_magical_item),
-                query = state.searchQuery,
+                query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
             )
@@ -59,7 +59,7 @@ fun MagicalItemListScreen(
         Column(Modifier.padding(paddingValues)) {
             when (val body = state.body) {
                 is MagicalItemListState.Body.Loading -> Loader()
-                is MagicalItemListState.Body.Empty -> EmptySearch(state.searchQuery)
+                is MagicalItemListState.Body.Empty -> EmptySearch(state.filter.query)
                 is MagicalItemListState.Body.Error -> ErrorLayout(body.errorMessage)
                 is MagicalItemListState.Body.WithData -> MagicalItemsList(body.searchResults, onMagicalItemClicked)
             }
@@ -93,7 +93,6 @@ private fun MagicalItemsList(
 }
 
 private val stateWithSampleData = MagicalItemListState(
-    searchQuery = "",
     body = MagicalItemListState.Body.WithData(SampleMagicalItemsRepository().getAll()),
 )
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -8,27 +8,27 @@ import androidx.navigation.toRoute
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardCarouselScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardScreen
-import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListScreen
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModelFactory
 import kotlinx.serialization.Serializable
 
 interface MagicalItemRoute {
     @Serializable
-    data object List
+    data object CardCarousel
 
     @Serializable
     data class Detail(val serializedItem: String)
 }
 
 fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileReader: ComposeFileReader) {
-    composable<MagicalItemRoute.List> {
+    composable<MagicalItemRoute.CardCarousel> {
         val router = MagicalItemRouterImpl(navController)
         val repository = JsonMagicalItemRepository(fileReader)
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
-        MagicalItemListScreen(viewModel)
+        MagicalItemCardCarouselScreen(viewModel)
     }
 
     composable<MagicalItemRoute.Detail> { entry ->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -68,14 +68,16 @@ class MagicalItemListViewModel(
 
     private suspend fun updateData() {
         _state.update { it.copy(body = MagicalItemListState.Body.Loading) }
+
         try {
             val filter = _state.value.filter
             val magicalItems = repository.getAll(filter)
-            if (magicalItems.isEmpty()) {
-                _state.update { it.copy(body = MagicalItemListState.Body.Empty) }
+            val body = if (magicalItems.isEmpty()) {
+                MagicalItemListState.Body.Empty
             } else {
-                _state.update { it.copy(body = MagicalItemListState.Body.WithData(searchResults = magicalItems)) }
+                MagicalItemListState.Body.WithData(searchResults = magicalItems)
             }
+            _state.update { it.copy(body = body) }
         } catch (e: Exception) {
             _state.update { it.copy(body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)) }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -23,12 +23,12 @@ class MagicalItemListViewModel(
 
     private var updateJob: Job? = null
     private val _state: MutableStateFlow<MagicalItemListState> = MutableStateFlow(
-        MagicalItemListState(searchQuery = "", body = MagicalItemListState.Body.Empty),
+        MagicalItemListState(body = MagicalItemListState.Body.Empty),
     )
     val state: StateFlow<MagicalItemListState> = _state.asStateFlow()
 
     init {
-        onSearchQueryChanged(query = "")
+        refreshData()
     }
 
     fun onNavigateUpClicked() {
@@ -36,28 +36,56 @@ class MagicalItemListViewModel(
     }
 
     fun onSearchQueryChanged(query: String) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData(query) }
+        _state.update { it.copy(filter = it.filter.copy(query = query)) }
+        refreshData()
     }
 
     fun onItemClicked(magicalItem: MagicalItem) {
         router.openMagicalItemDetail(magicalItem)
     }
 
-    private suspend fun updateData(query: String) {
+    fun onTypeToggled(type: MagicalItem.Type) {
         _state.update {
-            MagicalItemListState(searchQuery = query, body = MagicalItemListState.Body.Loading)
+            val updatedTypes = it.filter.types.toggled(type)
+            it.copy(filter = it.filter.copy(types = updatedTypes))
         }
+        refreshData()
+    }
+
+    fun onRarityToggled(rarity: MagicalItem.Rarity) {
+        _state.update {
+            val updatedRarities = it.filter.rarities.toggled(rarity)
+            it.copy(filter = it.filter.copy(rarities = updatedRarities))
+        }
+        refreshData()
+    }
+
+    fun onResetFilters() {
+        _state.update {
+            it.copy(filter = MagicalItemFilter(query = it.filter.query))
+        }
+        refreshData()
+    }
+
+    private fun <T> Set<T>.toggled(item: T): Set<T> = if (item in this) this - item else this + item
+
+    private fun refreshData() {
+        updateJob?.cancel()
+        updateJob = viewModelScope.launch { updateData() }
+    }
+
+    private suspend fun updateData() {
+        _state.update { it.copy(body = MagicalItemListState.Body.Loading) }
         try {
-            val filter = MagicalItemFilter(query = query)
+            val filter = _state.value.filter
             val magicalItems = repository.getAll(filter)
             if (magicalItems.isEmpty()) {
-                _state.update { _state.value.copy(body = MagicalItemListState.Body.Empty) }
+                _state.update { it.copy(body = MagicalItemListState.Body.Empty) }
             } else {
-                _state.update { _state.value.copy(body = MagicalItemListState.Body.WithData(searchResults = magicalItems)) }
+                _state.update { it.copy(body = MagicalItemListState.Body.WithData(searchResults = magicalItems)) }
             }
         } catch (e: Exception) {
-            _state.update { _state.value.copy(body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)) }
+            _state.update { it.copy(body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.magicalitem.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
@@ -66,8 +67,6 @@ class MagicalItemListViewModel(
         }
         refreshData()
     }
-
-    private fun <T> Set<T>.toggled(item: T): Set<T> = if (item in this) this - item else this + item
 
     private fun refreshData() {
         updateJob?.cancel()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -37,8 +37,7 @@ class MagicalItemListViewModel(
     }
 
     fun onSearchQueryChanged(query: String) {
-        _state.update { it.copy(filter = it.filter.copy(query = query)) }
-        refreshData()
+        updateFilter { it.copy(query = query) }
     }
 
     fun onItemClicked(magicalItem: MagicalItem) {
@@ -46,25 +45,19 @@ class MagicalItemListViewModel(
     }
 
     fun onTypeToggled(type: MagicalItem.Type) {
-        _state.update {
-            val updatedTypes = it.filter.types.toggled(type)
-            it.copy(filter = it.filter.copy(types = updatedTypes))
-        }
-        refreshData()
+        updateFilter { it.copy(types = it.types.toggled(type)) }
     }
 
     fun onRarityToggled(rarity: MagicalItem.Rarity) {
-        _state.update {
-            val updatedRarities = it.filter.rarities.toggled(rarity)
-            it.copy(filter = it.filter.copy(rarities = updatedRarities))
-        }
-        refreshData()
+        updateFilter { it.copy(rarities = it.rarities.toggled(rarity)) }
     }
 
     fun onResetFilters() {
-        _state.update {
-            it.copy(filter = MagicalItemFilter(query = it.filter.query))
-        }
+        updateFilter { MagicalItemFilter(query = it.query) }
+    }
+
+    private fun updateFilter(transform: (MagicalItemFilter) -> MagicalItemFilter) {
+        _state.update { it.copy(filter = transform(it.filter)) }
         refreshData()
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -67,10 +67,10 @@ class MagicalItemListViewModel(
     }
 
     private suspend fun updateData() {
+        val filter = _state.value.filter
         _state.update { it.copy(body = MagicalItemListState.Body.Loading) }
 
         try {
-            val filter = _state.value.filter
             val magicalItems = repository.getAll(filter)
             val body = if (magicalItems.isEmpty()) {
                 MagicalItemListState.Body.Empty

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
@@ -72,10 +72,10 @@ class SpellBookViewModel(
     }
 
     private suspend fun updateData() {
+        val filter = _state.value.filter
         _state.update { it.copy(body = SpellListState.Body.Loading) }
 
         try {
-            val filter = _state.value.filter
             val spells = repository.getAll(filter)
             val body = if (spells.isEmpty()) {
                 SpellListState.Body.Empty

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.spell.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
@@ -75,8 +76,6 @@ class SpellBookViewModel(
         }
         refreshData()
     }
-
-    private fun <T> Set<T>.toggled(item: T): Set<T> = if (item in this) this - item else this + item
 
     private fun refreshData() {
         updateJob?.cancel()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
@@ -77,11 +77,12 @@ class SpellBookViewModel(
         try {
             val filter = _state.value.filter
             val spells = repository.getAll(filter)
-            if (spells.isEmpty()) {
-                _state.update { it.copy(body = SpellListState.Body.Empty) }
+            val body = if (spells.isEmpty()) {
+                SpellListState.Body.Empty
             } else {
-                _state.update { it.copy(body = SpellListState.Body.WithData(spells)) }
+                SpellListState.Body.WithData(spells)
             }
+            _state.update { it.copy(body = body) }
         } catch (e: Exception) {
             _state.update { it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
@@ -38,8 +38,7 @@ class SpellBookViewModel(
     }
 
     fun onSearchQueryChanged(query: String) {
-        _state.update { it.copy(filter = it.filter.copy(query = query)) }
-        refreshData()
+        updateFilter { it.copy(query = query) }
     }
 
     fun onSpellClicked(spell: Spell) {
@@ -47,33 +46,23 @@ class SpellBookViewModel(
     }
 
     fun onLevelToggled(level: Int) {
-        _state.update {
-            val updatedLevels = it.filter.levels.toggled(level)
-            it.copy(filter = it.filter.copy(levels = updatedLevels))
-        }
-        refreshData()
+        updateFilter { it.copy(levels = it.levels.toggled(level)) }
     }
 
     fun onSchoolToggled(school: Spell.School) {
-        _state.update {
-            val updatedSchools = it.filter.schools.toggled(school)
-            it.copy(filter = it.filter.copy(schools = updatedSchools))
-        }
-        refreshData()
+        updateFilter { it.copy(schools = it.schools.toggled(school)) }
     }
 
     fun onClassToggled(playerClass: PlayerCharacter.Class) {
-        _state.update {
-            val updatedClasses = it.filter.playerClasses.toggled(playerClass)
-            it.copy(filter = it.filter.copy(playerClasses = updatedClasses))
-        }
-        refreshData()
+        updateFilter { it.copy(playerClasses = it.playerClasses.toggled(playerClass)) }
     }
 
     fun onResetFilters() {
-        _state.update {
-            it.copy(filter = SpellFilter(query = it.filter.query))
-        }
+        updateFilter { SpellFilter(query = it.query) }
+    }
+
+    private fun updateFilter(transform: (SpellFilter) -> SpellFilter) {
+        _state.update { it.copy(filter = transform(it.filter)) }
         refreshData()
     }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/domain/CollectionExt.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/domain/CollectionExt.kt
@@ -1,0 +1,3 @@
+package com.cyrillrx.rpg.core.domain
+
+fun <T> Set<T>.toggled(item: T): Set<T> = if (item in this) this - item else this + item

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -1,10 +1,13 @@
 package com.cyrillrx.rpg.magicalitem.domain
 
-class MagicalItemFilter(
-    private val query: String = "",
-    private val types: Set<MagicalItem.Type> = emptySet(),
-    private val rarities: Set<MagicalItem.Rarity> = emptySet(),
+data class MagicalItemFilter(
+    val query: String = "",
+    val types: Set<MagicalItem.Type> = emptySet(),
+    val rarities: Set<MagicalItem.Rarity> = emptySet(),
 ) {
+    val hasActiveFilters: Boolean
+        get() = types.isNotEmpty() || rarities.isNotEmpty()
+
     fun matches(item: MagicalItem): Boolean {
         return (types.isEmpty() || types.contains(item.type)) &&
             (rarities.isEmpty() || rarities.contains(item.rarity)) &&


### PR DESCRIPTION
## Description

Prepare the magical item module for the upcoming compact list view and filter features, and reduce code duplication across ViewModels.

- Convert `MagicalItemFilter` to a data class with public fields (same pattern as `SpellFilter`)
- Replace `searchQuery` with `filter: MagicalItemFilter` in state
- Add filter toggle methods to ViewModel (`onTypeToggled`, `onRarityToggled`, `onResetFilters`)
- Rename `MagicalItemListScreen` to `MagicalItemCardCarouselScreen` to free the `List` route for the upcoming compact list view
- Extract `Set<T>.toggled()` to `shared/core/domain/CollectionExt.kt` to remove duplication between `SpellBookViewModel` and `MagicalItemListViewModel`
- Extract `updateFilter` helper in both ViewModels to reduce filter update boilerplate
- Simplify `updateData` body assignment in both ViewModels

## Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed