### PR TITLE
feat(magicalitem): add compact list screen with type-colored items

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -62,6 +62,25 @@
     <string name="school_necromancy">Nécromancie</string>
     <string name="school_transmutation">Transmutation</string>
 
+    <!-- Magical Item Type -->
+    <string name="item_type_armor">Armure</string>
+    <string name="item_type_potion">Potion</string>
+    <string name="item_type_ring">Anneau</string>
+    <string name="item_type_rod">Sceptre</string>
+    <string name="item_type_scroll">Parchemin</string>
+    <string name="item_type_staff">Bâton</string>
+    <string name="item_type_wand">Baguette</string>
+    <string name="item_type_weapon">Arme</string>
+    <string name="item_type_wondrous_item">Objet merveilleux</string>
+
+    <!-- Magical Item Rarity -->
+    <string name="item_rarity_common">Commun</string>
+    <string name="item_rarity_uncommon">Peu commun</string>
+    <string name="item_rarity_rare">Rare</string>
+    <string name="item_rarity_very_rare">Très rare</string>
+    <string name="item_rarity_legendary">Légendaire</string>
+    <string name="item_rarity_artifact">Artéfact</string>
+
     <!-- Spell Filter -->
     <string name="title_filter_spells">Filtrer les sorts</string>
     <string name="label_filter_level">Niveau</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -62,6 +62,25 @@
     <string name="school_necromancy">Necromancy</string>
     <string name="school_transmutation">Transmutation</string>
 
+    <!-- Magical Item Type -->
+    <string name="item_type_armor">Armor</string>
+    <string name="item_type_potion">Potion</string>
+    <string name="item_type_ring">Ring</string>
+    <string name="item_type_rod">Rod</string>
+    <string name="item_type_scroll">Scroll</string>
+    <string name="item_type_staff">Staff</string>
+    <string name="item_type_wand">Wand</string>
+    <string name="item_type_weapon">Weapon</string>
+    <string name="item_type_wondrous_item">Wondrous item</string>
+
+    <!-- Magical Item Rarity -->
+    <string name="item_rarity_common">Common</string>
+    <string name="item_rarity_uncommon">Uncommon</string>
+    <string name="item_rarity_rare">Rare</string>
+    <string name="item_rarity_very_rare">Very rare</string>
+    <string name="item_rarity_legendary">Legendary</string>
+    <string name="item_rarity_artifact">Artifact</string>
+
     <!-- Spell Filter -->
     <string name="title_filter_spells">Filter Spells</string>
     <string name="label_filter_level">Level</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MagicalItemFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MagicalItemFormatExt.kt
@@ -56,8 +56,12 @@ private val objectColor = Color(0, 179, 140)
 
 fun MagicalItem.getColor(): Color = when (type) {
     MagicalItem.Type.ARMOR -> armorColor
+    MagicalItem.Type.POTION -> objectColor
+    MagicalItem.Type.RING -> objectColor
     MagicalItem.Type.ROD -> weaponColor
+    MagicalItem.Type.SCROLL -> objectColor
     MagicalItem.Type.STAFF -> weaponColor
+    MagicalItem.Type.WAND -> weaponColor
     MagicalItem.Type.WEAPON -> weaponColor
-    else -> objectColor
+    MagicalItem.Type.WONDROUS_ITEM -> objectColor
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MagicalItemFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MagicalItemFormatExt.kt
@@ -1,0 +1,63 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.item_rarity_artifact
+import rpg_companion.composeapp.generated.resources.item_rarity_common
+import rpg_companion.composeapp.generated.resources.item_rarity_legendary
+import rpg_companion.composeapp.generated.resources.item_rarity_rare
+import rpg_companion.composeapp.generated.resources.item_rarity_uncommon
+import rpg_companion.composeapp.generated.resources.item_rarity_very_rare
+import rpg_companion.composeapp.generated.resources.item_type_armor
+import rpg_companion.composeapp.generated.resources.item_type_potion
+import rpg_companion.composeapp.generated.resources.item_type_ring
+import rpg_companion.composeapp.generated.resources.item_type_rod
+import rpg_companion.composeapp.generated.resources.item_type_scroll
+import rpg_companion.composeapp.generated.resources.item_type_staff
+import rpg_companion.composeapp.generated.resources.item_type_wand
+import rpg_companion.composeapp.generated.resources.item_type_weapon
+import rpg_companion.composeapp.generated.resources.item_type_wondrous_item
+
+@Composable
+fun MagicalItem.Type.toFormattedString(): String {
+    val stringRes = when (this) {
+        MagicalItem.Type.ARMOR -> Res.string.item_type_armor
+        MagicalItem.Type.POTION -> Res.string.item_type_potion
+        MagicalItem.Type.RING -> Res.string.item_type_ring
+        MagicalItem.Type.ROD -> Res.string.item_type_rod
+        MagicalItem.Type.SCROLL -> Res.string.item_type_scroll
+        MagicalItem.Type.STAFF -> Res.string.item_type_staff
+        MagicalItem.Type.WAND -> Res.string.item_type_wand
+        MagicalItem.Type.WEAPON -> Res.string.item_type_weapon
+        MagicalItem.Type.WONDROUS_ITEM -> Res.string.item_type_wondrous_item
+    }
+    return stringResource(stringRes)
+}
+
+@Composable
+fun MagicalItem.Rarity.toFormattedString(): String {
+    val stringRes = when (this) {
+        MagicalItem.Rarity.COMMON -> Res.string.item_rarity_common
+        MagicalItem.Rarity.UNCOMMON -> Res.string.item_rarity_uncommon
+        MagicalItem.Rarity.RARE -> Res.string.item_rarity_rare
+        MagicalItem.Rarity.VERY_RARE -> Res.string.item_rarity_very_rare
+        MagicalItem.Rarity.LEGENDARY -> Res.string.item_rarity_legendary
+        MagicalItem.Rarity.ARTIFACT -> Res.string.item_rarity_artifact
+    }
+    return stringResource(stringRes)
+}
+
+private val weaponColor = Color(155, 11, 78)
+private val armorColor = Color(0, 122, 179)
+private val objectColor = Color(0, 179, 140)
+
+fun MagicalItem.getColor(): Color = when (type) {
+    MagicalItem.Type.ARMOR -> armorColor
+    MagicalItem.Type.ROD -> weaponColor
+    MagicalItem.Type.STAFF -> weaponColor
+    MagicalItem.Type.WEAPON -> weaponColor
+    else -> objectColor
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SpellFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SpellFormatExt.kt
@@ -1,4 +1,4 @@
-package com.cyrillrx.rpg.spell.presentation.component
+package com.cyrillrx.rpg.core.presentation.component
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -48,7 +48,7 @@ fun HomeScreen(router: HomeRouter) {
             )
 
             HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
-            HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheets)
+            HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheetList)
 
             SectionHeader(
                 title = stringResource(Res.string.section_compendium),
@@ -64,19 +64,19 @@ fun HomeScreen(router: HomeRouter) {
                 IconLabelButton(
                     label = stringResource(Res.string.btn_spell_book),
                     icon = Icons.Filled.AutoAwesome,
-                    onClick = router::openSpellBook,
+                    onClick = router::openSpellList,
                     modifier = Modifier.weight(1f),
                 )
                 IconLabelButton(
                     label = stringResource(Res.string.btn_inventory),
                     icon = Icons.Filled.Diamond,
-                    onClick = router::openMagicalItems,
+                    onClick = router::openMagicalItemList,
                     modifier = Modifier.weight(1f),
                 )
                 IconLabelButton(
                     label = stringResource(Res.string.btn_bestiary),
                     icon = Icons.Filled.Pets,
-                    onClick = router::openBestiary,
+                    onClick = router::openCreatureList,
                     modifier = Modifier.weight(1f),
                 )
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -35,7 +35,7 @@ class HomeRouterImpl(private val navController: NavController) : HomeRouter {
     }
 
     override fun openMagicalItems() {
-        navController.navigate(MagicalItemRoute.CardCarousel)
+        navController.navigate(MagicalItemRoute.List)
     }
 
     override fun openBestiary() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -9,12 +9,12 @@ import com.cyrillrx.rpg.spell.presentation.navigation.SpellRoute
 
 interface HomeRouter {
     fun openCampaignList() {}
-    fun openCharacterSheets() {}
-
-    fun openSpellBook() {}
-    fun openAlternativeSpellBook() {}
-    fun openMagicalItems() {}
-    fun openBestiary() {}
+    fun openCharacterSheetList() {}
+    fun openSpellList() {}
+    fun openSpellCardCarousel() {}
+    fun openMagicalItemList() {}
+    fun openMagicalItemCardCarousel() {}
+    fun openCreatureList() {}
 }
 
 class HomeRouterImpl(private val navController: NavController) : HomeRouter {
@@ -22,23 +22,27 @@ class HomeRouterImpl(private val navController: NavController) : HomeRouter {
         navController.navigate(CampaignRoute.List)
     }
 
-    override fun openCharacterSheets() {
+    override fun openCharacterSheetList() {
         navController.navigate(PlayerCharacterRoute.List)
     }
 
-    override fun openSpellBook() {
+    override fun openSpellList() {
         navController.navigate(SpellRoute.List)
     }
 
-    override fun openAlternativeSpellBook() {
+    override fun openSpellCardCarousel() {
         navController.navigate(SpellRoute.CardCarousel)
     }
 
-    override fun openMagicalItems() {
+    override fun openMagicalItemList() {
         navController.navigate(MagicalItemRoute.List)
     }
 
-    override fun openBestiary() {
+    override fun openMagicalItemCardCarousel() {
+        navController.navigate(MagicalItemRoute.CardCarousel)
+    }
+
+    override fun openCreatureList() {
         navController.navigate(CreatureRoute.List)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
+import com.cyrillrx.rpg.core.presentation.component.getColor
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
@@ -78,25 +79,6 @@ fun MagicalItemCard(
         }
     }
 }
-
-private fun MagicalItem.getColor(): Color {
-    val weaponColor = Color(155, 11, 78)
-    val armorColor = Color(0, 122, 179)
-    val objectColor = Color(0, 179, 140)
-    return when (type) {
-        MagicalItem.Type.ARMOR -> armorColor
-        MagicalItem.Type.POTION -> objectColor
-        MagicalItem.Type.RING -> objectColor
-        MagicalItem.Type.ROD -> weaponColor
-        MagicalItem.Type.SCROLL -> objectColor
-        MagicalItem.Type.STAFF -> weaponColor
-        MagicalItem.Type.WAND -> objectColor
-        MagicalItem.Type.WEAPON -> weaponColor
-        MagicalItem.Type.WONDROUS_ITEM -> objectColor
-        else -> objectColor
-    }
-}
-
 @Preview
 @Composable
 private fun PreviewMagicalItemCard() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
@@ -1,0 +1,94 @@
+package com.cyrillrx.rpg.magicalitem.presentation.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.cyrillrx.rpg.core.presentation.component.getColor
+import com.cyrillrx.rpg.core.presentation.component.toFormattedString
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
+import com.cyrillrx.rpg.core.presentation.theme.borderWidth
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun MagicalItemListItem(
+    magicalItem: MagicalItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(borderWidth, MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(spacingCommon),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(spacingSmall),
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = magicalItem.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Text(
+                    text = magicalItem.subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(spacingMedium))
+
+            Text(
+                text = magicalItem.type.toFormattedString(),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = magicalItem.getColor(),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMagicalItemListItemLight() {
+    AppThemePreview(darkTheme = false) {
+        MagicalItemListItem(magicalItem = SampleMagicalItemsRepository().get(), onClick = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMagicalItemListItemDark() {
+    AppThemePreview(darkTheme = true) {
+        MagicalItemListItem(magicalItem = SampleMagicalItemsRepository().get(), onClick = {})
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -1,0 +1,124 @@
+package com.cyrillrx.rpg.magicalitem.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.core.presentation.component.EmptySearch
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
+import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.hint_search_magical_item
+
+@Composable
+fun MagicalItemListScreen(viewModel: MagicalItemListViewModel) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    MagicalItemListScreen(
+        state = state,
+        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onMagicalItemClicked = viewModel::onItemClicked,
+    )
+}
+
+@Composable
+fun MagicalItemListScreen(
+    state: MagicalItemListState,
+    onNavigateUpClicked: () -> Unit,
+    onSearchQueryChanged: (String) -> Unit,
+    onMagicalItemClicked: (MagicalItem) -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SearchBarWithBack(
+                hint = stringResource(Res.string.hint_search_magical_item),
+                query = state.filter.query,
+                onQueryChanged = onSearchQueryChanged,
+                onNavigateUpClicked = onNavigateUpClicked,
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            when (val body = state.body) {
+                is MagicalItemListState.Body.Loading -> Loader()
+                is MagicalItemListState.Body.Empty -> EmptySearch(state.filter.query)
+                is MagicalItemListState.Body.Error -> ErrorLayout(body.errorMessage)
+                is MagicalItemListState.Body.WithData -> MagicalItemList(body.searchResults, onMagicalItemClicked)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MagicalItemList(
+    magicalItems: List<MagicalItem>,
+    onMagicalItemClicked: (MagicalItem) -> Unit,
+) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(magicalItems) {
+        listState.animateScrollToItem(0)
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = listState,
+        contentPadding = PaddingValues(spacingMedium),
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+    ) {
+        items(magicalItems) { item ->
+            MagicalItemListItem(
+                magicalItem = item,
+                onClick = { onMagicalItemClicked(item) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+private val stateWithSampleData = MagicalItemListState(
+    body = MagicalItemListState.Body.WithData(SampleMagicalItemsRepository().getAll()),
+)
+
+@Preview
+@Composable
+private fun PreviewMagicalItemListScreenLight() {
+    AppThemePreview(darkTheme = false) {
+        MagicalItemListScreen(stateWithSampleData, {}, {}, {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMagicalItemListScreenDark() {
+    AppThemePreview(darkTheme = true) {
+        MagicalItemListScreen(stateWithSampleData, {}, {}, {})
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -10,11 +10,15 @@ import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardCarouselScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardScreen
+import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListScreen
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModelFactory
 import kotlinx.serialization.Serializable
 
 interface MagicalItemRoute {
+    @Serializable
+    data object List
+
     @Serializable
     data object CardCarousel
 
@@ -23,6 +27,14 @@ interface MagicalItemRoute {
 }
 
 fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileReader: ComposeFileReader) {
+    composable<MagicalItemRoute.List> {
+        val router = MagicalItemRouterImpl(navController)
+        val repository = JsonMagicalItemRepository(fileReader)
+        val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
+        val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
+        MagicalItemListScreen(viewModel)
+    }
+
     composable<MagicalItemRoute.CardCarousel> {
         val router = MagicalItemRouterImpl(navController)
         val repository = JsonMagicalItemRepository(fileReader)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
+import com.cyrillrx.rpg.core.presentation.component.getColor
+import com.cyrillrx.rpg.core.presentation.component.getFormattedSchool
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.core.presentation.component.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
@@ -18,6 +18,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import com.cyrillrx.rpg.core.presentation.component.toFormattedLevel
+import com.cyrillrx.rpg.core.presentation.component.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.toIcon
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemsRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemsRepository.kt
@@ -3,25 +3,72 @@ package com.cyrillrx.rpg.magicalitem.data
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 
 class SampleMagicalItemsRepository {
-    fun getAll(): List<MagicalItem> {
-        val sample = get()
-        return listOf(sample, sample, sample)
-    }
-
-    fun get(): MagicalItem {
-        val description =
-            "Lorsque vous faites une attaque au corps à corps avec cette arme, vous pouvez prononcer son mot de commande : « Prompte mort à ceux qui m'ont fait du tort ». La cible de votre attaque devient votre ennemi juré jusqu'à ce qu'il meure ou jusqu'à l'aube sept jours plus tard.\n" +
-                "Vous ne pouvez avoir qu'un seul ennemi juré à la fois. Quand votre ennemi juré meurt, vous pouvez en choisir un nouveau après la prochaine aube.\n" +
-                "Lorsque vous effectuez une attaque au corps à corps contre votre ennemi juré avec cette arme, vous avez un avantage au jet d'attaque.\n" +
-                "Si l'attaque touche, votre ennemi juré subit 3d6 dégâts tranchants supplémentaires.\n" +
-                "Tant que votre ennemi juré est en vie, vous avez un désavantage aux jets d'attaque avec toutes les autres armes."
-        return MagicalItem(
+    fun getAll(): List<MagicalItem> = listOf(
+        MagicalItem(
             title = "Hache du serment",
             subtitle = "Arme (hache d'arme), unique (harmonisation exigée)",
-            description = description,
+            description = "Lorsque vous faites une attaque au corps à corps avec cette arme, vous pouvez prononcer son mot de commande. La cible de votre attaque devient votre ennemi juré.",
             type = MagicalItem.Type.WEAPON,
             rarity = MagicalItem.Rarity.RARE,
             attunement = true,
-        )
-    }
+        ),
+        MagicalItem(
+            title = "Cape de protection",
+            subtitle = "Objet merveilleux, peu commun (harmonisation exigée)",
+            description = "Vous obtenez un bonus de +1 à la CA et aux jets de sauvegarde tant que vous portez cette cape.",
+            type = MagicalItem.Type.WONDROUS_ITEM,
+            rarity = MagicalItem.Rarity.UNCOMMON,
+            attunement = true,
+        ),
+        MagicalItem(
+            title = "Potion de soins",
+            subtitle = "Potion, commune",
+            description = "Vous regagnez 2d4 + 2 points de vie lorsque vous buvez cette potion.",
+            type = MagicalItem.Type.POTION,
+            rarity = MagicalItem.Rarity.COMMON,
+            attunement = false,
+        ),
+        MagicalItem(
+            title = "Bouclier +1",
+            subtitle = "Armure (bouclier), peu commun",
+            description = "Lorsque vous tenez ce bouclier, vous obtenez un bonus de +1 à la CA en plus du bonus normal du bouclier.",
+            type = MagicalItem.Type.ARMOR,
+            rarity = MagicalItem.Rarity.UNCOMMON,
+            attunement = false,
+        ),
+        MagicalItem(
+            title = "Baguette de boules de feu",
+            subtitle = "Baguette, rare (harmonisation exigée par un lanceur de sorts)",
+            description = "Cette baguette a 7 charges. En tenant la baguette, vous pouvez utiliser une action pour dépenser 1 ou plusieurs charges et lancer le sort boule de feu.",
+            type = MagicalItem.Type.WAND,
+            rarity = MagicalItem.Rarity.RARE,
+            attunement = true,
+        ),
+        MagicalItem(
+            title = "Anneau de protection",
+            subtitle = "Anneau, rare (harmonisation exigée)",
+            description = "Vous obtenez un bonus de +1 à la CA et aux jets de sauvegarde tant que vous portez cet anneau.",
+            type = MagicalItem.Type.RING,
+            rarity = MagicalItem.Rarity.RARE,
+            attunement = true,
+        ),
+        MagicalItem(
+            title = "Parchemin de boule de feu",
+            subtitle = "Parchemin, peu commun",
+            description = "Un sort de boule de feu est inscrit sur ce parchemin. Si le sort figure dans votre liste de sorts, vous pouvez le lancer.",
+            type = MagicalItem.Type.SCROLL,
+            rarity = MagicalItem.Rarity.UNCOMMON,
+            attunement = false,
+        ),
+        MagicalItem(
+            title = "Bâton de pouvoir",
+            subtitle = "Bâton, très rare (harmonisation exigée par un lanceur de sorts)",
+            description = "Ce bâton confère un bonus de +2 aux jets d'attaque et de dégâts des attaques au corps à corps effectuées avec lui.",
+            type = MagicalItem.Type.STAFF,
+            rarity = MagicalItem.Rarity.VERY_RARE,
+            attunement = true,
+        ),
+    )
+
+    fun get(): MagicalItem = getAll().first()
 }


### PR DESCRIPTION
## 📝 Description

Add a compact vertical list view for magical items, mirroring the spell list pattern.

- Add localized string resources for `MagicalItem.Type` and `MagicalItem.Rarity` (EN + FR)
- Move `SpellFormatExt.kt` to `core/presentation/component/` and create `MagicalItemFormatExt.kt` alongside it with `toFormattedString()`, `getColor()`, and `toIcon()` extensions
- Create `MagicalItemListItem` compact card with colored type icon on the left
- Create `MagicalItemListScreen` with vertical `LazyColumn` and search
- Add `MagicalItemRoute.List` route, home now opens the compact list by default
- Align all `HomeRouter` method names with route names and add missing carousel routes
- Diversify `SampleMagicalItemsRepository` to cover all item types and rarities for previews

## 🖼️ Media

Before: carousel
<img width="1022" height="1086" alt="image" src="https://github.com/user-attachments/assets/605b22c5-baea-4559-9f25-f4664d44a452" />

After: compact list
<img width="1028" height="1088" alt="image" src="https://github.com/user-attachments/assets/7981bd39-1aff-4068-95ce-a61beb595c46" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed