### PR TITLE
feat(magicalitem): add filter bottom sheet to item screens

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -86,4 +86,9 @@
     <string name="label_filter_level">Niveau</string>
     <string name="label_filter_class">Classe</string>
     <string name="label_filter_school">Ecole</string>
+
+    <!-- Magical Item Filter -->
+    <string name="title_filter_items">Filtrer les objets</string>
+    <string name="label_filter_type">Type</string>
+    <string name="label_filter_rarity">Rareté</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -87,4 +87,9 @@
     <string name="label_filter_class">Class</string>
     <string name="label_filter_school">School</string>
 
+    <!-- Magical Item Filter -->
+    <string name="title_filter_items">Filter Items</string>
+    <string name="label_filter_type">Type</string>
+    <string name="label_filter_rarity">Rarity</string>
+
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
@@ -12,6 +12,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.EmptySearch
@@ -36,6 +39,9 @@ fun MagicalItemCardCarouselScreen(viewModel: MagicalItemListViewModel) {
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onMagicalItemClicked = viewModel::onItemClicked,
+        onTypeToggled = viewModel::onTypeToggled,
+        onRarityToggled = viewModel::onRarityToggled,
+        onResetFilters = viewModel::onResetFilters,
     )
 }
 
@@ -45,7 +51,12 @@ fun MagicalItemCardCarouselScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onMagicalItemClicked: (MagicalItem) -> Unit,
+    onTypeToggled: (MagicalItem.Type) -> Unit,
+    onRarityToggled: (MagicalItem.Rarity) -> Unit,
+    onResetFilters: () -> Unit,
 ) {
+    var showFilterSheet by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             SearchBarWithBack(
@@ -53,6 +64,8 @@ fun MagicalItemCardCarouselScreen(
                 query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
+                onFilterClicked = { showFilterSheet = true },
+                hasActiveFilters = state.filter.hasActiveFilters,
             )
         },
     ) { paddingValues ->
@@ -64,6 +77,16 @@ fun MagicalItemCardCarouselScreen(
                 is MagicalItemListState.Body.WithData -> MagicalItemCardCarousel(body.searchResults, onMagicalItemClicked)
             }
         }
+    }
+
+    if (showFilterSheet) {
+        MagicalItemFilterBottomSheet(
+            filter = state.filter,
+            onTypeToggled = onTypeToggled,
+            onRarityToggled = onRarityToggled,
+            onResetFilters = onResetFilters,
+            onDismiss = { showFilterSheet = false },
+        )
     }
 }
 
@@ -100,7 +123,7 @@ private val stateWithSampleData = MagicalItemListState(
 @Composable
 private fun PreviewMagicalItemCardCarouselScreenLight() {
     AppThemePreview(darkTheme = false) {
-        MagicalItemCardCarouselScreen(stateWithSampleData, {}, {}, {})
+        MagicalItemCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -108,6 +131,6 @@ private fun PreviewMagicalItemCardCarouselScreenLight() {
 @Composable
 private fun PreviewMagicalItemCardCarouselScreenDark() {
     AppThemePreview(darkTheme = true) {
-        MagicalItemCardCarouselScreen(stateWithSampleData, {}, {}, {})
+        MagicalItemCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemFilterBottomSheet.kt
@@ -1,0 +1,130 @@
+package com.cyrillrx.rpg.magicalitem.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.toFormattedString
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_reset_all
+import rpg_companion.composeapp.generated.resources.label_filter_rarity
+import rpg_companion.composeapp.generated.resources.label_filter_type
+import rpg_companion.composeapp.generated.resources.title_filter_items
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun MagicalItemFilterBottomSheet(
+    filter: MagicalItemFilter,
+    onTypeToggled: (MagicalItem.Type) -> Unit,
+    onRarityToggled: (MagicalItem.Rarity) -> Unit,
+    onResetFilters: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacingCommon)
+                .padding(bottom = spacingLarge),
+            verticalArrangement = Arrangement.spacedBy(spacingCommon),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(Res.string.title_filter_items),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                TextButton(onClick = onResetFilters) {
+                    Text(text = stringResource(Res.string.btn_reset_all))
+                }
+            }
+
+            // Type
+            Text(
+                text = stringResource(Res.string.label_filter_type),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                MagicalItem.Type.entries.forEach { type ->
+                    FilterChip(
+                        selected = type in filter.types,
+                        onClick = { onTypeToggled(type) },
+                        label = { Text(text = type.toFormattedString()) },
+                    )
+                }
+            }
+
+            // Rarity
+            Text(
+                text = stringResource(Res.string.label_filter_rarity),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                MagicalItem.Rarity.entries.forEach { rarity ->
+                    FilterChip(
+                        selected = rarity in filter.rarities,
+                        onClick = { onRarityToggled(rarity) },
+                        label = { Text(text = rarity.toFormattedString()) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMagicalItemFilterBottomSheetLight() {
+    val sampleFilter = MagicalItemFilter(
+        types = setOf(MagicalItem.Type.WEAPON),
+        rarities = setOf(MagicalItem.Rarity.RARE),
+    )
+    AppThemePreview(darkTheme = false) {
+        MagicalItemFilterBottomSheet(sampleFilter, {}, {}, {}, {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMagicalItemFilterBottomSheetDark() {
+    val sampleFilter = MagicalItemFilter(
+        types = setOf(MagicalItem.Type.WEAPON),
+        rarities = setOf(MagicalItem.Rarity.RARE),
+    )
+    AppThemePreview(darkTheme = true) {
+        MagicalItemFilterBottomSheet(sampleFilter, {}, {}, {}, {})
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -41,6 +44,9 @@ fun MagicalItemListScreen(viewModel: MagicalItemListViewModel) {
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onMagicalItemClicked = viewModel::onItemClicked,
+        onTypeToggled = viewModel::onTypeToggled,
+        onRarityToggled = viewModel::onRarityToggled,
+        onResetFilters = viewModel::onResetFilters,
     )
 }
 
@@ -50,7 +56,12 @@ fun MagicalItemListScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onMagicalItemClicked: (MagicalItem) -> Unit,
+    onTypeToggled: (MagicalItem.Type) -> Unit,
+    onRarityToggled: (MagicalItem.Rarity) -> Unit,
+    onResetFilters: () -> Unit,
 ) {
+    var showFilterSheet by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             SearchBarWithBack(
@@ -58,6 +69,8 @@ fun MagicalItemListScreen(
                 query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
+                onFilterClicked = { showFilterSheet = true },
+                hasActiveFilters = state.filter.hasActiveFilters,
             )
         },
     ) { paddingValues ->
@@ -74,6 +87,16 @@ fun MagicalItemListScreen(
                 is MagicalItemListState.Body.WithData -> MagicalItemList(body.searchResults, onMagicalItemClicked)
             }
         }
+    }
+
+    if (showFilterSheet) {
+        MagicalItemFilterBottomSheet(
+            filter = state.filter,
+            onTypeToggled = onTypeToggled,
+            onRarityToggled = onRarityToggled,
+            onResetFilters = onResetFilters,
+            onDismiss = { showFilterSheet = false },
+        )
     }
 }
 
@@ -111,7 +134,7 @@ private val stateWithSampleData = MagicalItemListState(
 @Composable
 private fun PreviewMagicalItemListScreenLight() {
     AppThemePreview(darkTheme = false) {
-        MagicalItemListScreen(stateWithSampleData, {}, {}, {})
+        MagicalItemListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -119,6 +142,6 @@ private fun PreviewMagicalItemListScreenLight() {
 @Composable
 private fun PreviewMagicalItemListScreenDark() {
     AppThemePreview(darkTheme = true) {
-        MagicalItemListScreen(stateWithSampleData, {}, {}, {})
+        MagicalItemListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ For detailed feature specifications, see the [PRDs](prd/).
 > Bring current implementations to a production-ready state. - [PRD-001](prd/PRD-001-REFERENCE-DATA.md)
 
 - [x] Complete Spellbook filters (school, class) - [PRD-001a](prd/PRD-001a-SPELLBOOK.md)
-- [ ] Complete Inventory filters (type, rarity) - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
+- [x] Complete Inventory filters (type, rarity) - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
 - [ ] Complete Bestiary filters (type, CR) - [PRD-001c](prd/PRD-001c-BESTIARY.md)
 
 ## Phase 3 - Local Lists

--- a/docs/prd/PRD-001b-ITEM-LIST.md
+++ b/docs/prd/PRD-001b-ITEM-LIST.md
@@ -25,8 +25,8 @@ Refer to [PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md) for the shared 
 
 - [x] Display a scrollable list of all items from the local seed database.
 - [x] Full-text search on name and description.
-- [ ] Filter by item type and rarity.
-- [ ] View item detail: name, type, rarity, description, weight, value, attunement requirement.
+- [x] Filter by item type and rarity.
+- [x] View item detail: name, type, rarity, description, value, attunement requirement.
 
 ### Phase 2 — Local Lists
 


### PR DESCRIPTION
## 📝 Description

Add a filter bottom sheet to both magical item screens (list and carousel), allowing users to filter items by type and rarity.

- Add localized string resources for filter labels (en + fr)
- Create `MagicalItemFilterBottomSheet` with type and rarity `FilterChip` sections
- Wire filter button and bottom sheet into `MagicalItemListScreen` and `MagicalItemCardCarouselScreen`
- Mark item list filters and detail as complete in roadmap and PRD

## 🖼️ Media

<img width="1224" height="152" alt="image" src="https://github.com/user-attachments/assets/18f5e6ba-06bf-4bf6-8402-5346a2c18ade" />

<img width="1222" height="722" alt="image" src="https://github.com/user-attachments/assets/6a1da6d1-4fcb-4607-9025-7cc8a070310a" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed