### PR TITLE
refactor(creature): wire filter to state and rename screen to detail list

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_campaign
+import kotlin.coroutines.cancellation.CancellationException
 
 class CampaignListViewModel(
     private val router: CampaignRouter,
@@ -55,6 +56,8 @@ class CampaignListViewModel(
             } else {
                 _state.update { _state.value.copy(body = CampaignListState.Body.WithData(campaigns)) }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             _state.update { _state.value.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_characters
+import kotlin.coroutines.cancellation.CancellationException
 
 class PlayerCharacterListViewModel(
     private val router: PlayerCharacterRouter,
@@ -59,6 +60,8 @@ class PlayerCharacterListViewModel(
             } else {
                 _state.update { _state.value.copy(body = PlayerCharacterListState.Body.WithData(characters)) }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             _state.update { _state.value.copy(body = PlayerCharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureListState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureListState.kt
@@ -1,10 +1,11 @@
 package com.cyrillrx.rpg.creature.presentation
 
 import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.CreatureFilter
 import org.jetbrains.compose.resources.StringResource
 
 data class CreatureListState(
-    val searchQuery: String,
+    val filter: CreatureFilter = CreatureFilter(),
     val body: Body,
 ) {
     sealed interface Body {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailListScreen.kt
@@ -26,9 +26,9 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_creature
 
 @Composable
-fun CreatureListScreen(viewModel: CreatureListViewModel) {
+fun CreatureDetailListScreen(viewModel: CreatureListViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    CreatureListScreen(
+    CreatureDetailListScreen(
         state = state,
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
@@ -37,7 +37,7 @@ fun CreatureListScreen(viewModel: CreatureListViewModel) {
 }
 
 @Composable
-fun CreatureListScreen(
+fun CreatureDetailListScreen(
     state: CreatureListState,
     onSearchQueryChanged: (String) -> Unit,
     onCreatureClicked: (Creature) -> Unit,
@@ -82,12 +82,12 @@ private fun CreatureList(
 
 @Preview
 @Composable
-private fun PreviewCreatureListScreen() {
+private fun PreviewCreatureDetailListScreen() {
     val creatures = SampleCreatureRepository().getAll()
     val state = CreatureListState(
         body = CreatureListState.Body.WithData(creatures),
     )
     AppThemePreview(darkTheme = false) {
-        CreatureListScreen(state, {}, {}, {})
+        CreatureDetailListScreen(state, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -47,7 +47,7 @@ fun CreatureListScreen(
         topBar = {
             SearchBarWithBack(
                 hint = stringResource(Res.string.hint_search_creature),
-                query = state.searchQuery,
+                query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
             )
@@ -56,7 +56,7 @@ fun CreatureListScreen(
         Column(Modifier.padding(paddingValues)) {
             when (val body = state.body) {
                 is CreatureListState.Body.Loading -> Loader()
-                is CreatureListState.Body.Empty -> EmptySearch(state.searchQuery)
+                is CreatureListState.Body.Empty -> EmptySearch(state.filter.query)
                 is CreatureListState.Body.Error -> ErrorLayout(body.errorMessage)
                 is CreatureListState.Body.WithData -> CreatureList(body.searchResults, onCreatureClicked)
             }
@@ -85,7 +85,6 @@ private fun CreatureList(
 private fun PreviewCreatureListScreen() {
     val creatures = SampleCreatureRepository().getAll()
     val state = CreatureListState(
-        searchQuery = "",
         body = CreatureListState.Body.WithData(creatures),
     )
     AppThemePreview(darkTheme = false) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -5,24 +5,24 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
-import com.cyrillrx.rpg.creature.presentation.component.CreatureListScreen
+import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailListScreen
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModelFactory
 import kotlinx.serialization.Serializable
 
 interface CreatureRoute {
     @Serializable
-    data object List
+    data object DetailList
 
     @Serializable
     data class Detail(val serializedCreature: String)
 }
 
 fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repository: CreatureRepository) {
-    composable<CreatureRoute.List> {
+    composable<CreatureRoute.DetailList> {
         val router = CreatureRouterImpl(navController)
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
-        CreatureListScreen(viewModel)
+        CreatureDetailListScreen(viewModel)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_creatures
+import kotlin.coroutines.cancellation.CancellationException
 
 class CreatureListViewModel(
     private val router: CreatureRouter,
@@ -78,6 +79,8 @@ class CreatureListViewModel(
                 CreatureListState.Body.WithData(searchResults = creatures)
             }
             _state.update { it.copy(body = body) }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             _state.update { it.copy(body = CreatureListState.Body.Error(errorMessage = Res.string.error_while_loading_creatures)) }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.creature.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureFilter
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
@@ -23,12 +24,12 @@ class CreatureListViewModel(
 
     private var updateJob: Job? = null
     private val _state: MutableStateFlow<CreatureListState> = MutableStateFlow(
-        CreatureListState(searchQuery = "", body = CreatureListState.Body.Empty),
+        CreatureListState(body = CreatureListState.Body.Empty),
     )
     val state: StateFlow<CreatureListState> = _state.asStateFlow()
 
     init {
-        onSearchQueryChanged(query = "")
+        refreshData()
     }
 
     fun onNavigateUpClicked() {
@@ -36,28 +37,49 @@ class CreatureListViewModel(
     }
 
     fun onSearchQueryChanged(query: String) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData(query) }
+        updateFilter { it.copy(query = query) }
     }
 
     fun onCreatureClicked(creature: Creature) {
         router.openCreatureDetail(creature)
     }
 
-    private suspend fun updateData(query: String) {
-        _state.update {
-            CreatureListState(searchQuery = query, body = CreatureListState.Body.Loading)
-        }
+    fun onTypeToggled(type: Creature.Type) {
+        updateFilter { it.copy(types = it.types.toggled(type)) }
+    }
+
+    fun onChallengeRatingToggled(cr: Float) {
+        updateFilter { it.copy(challengeRatings = it.challengeRatings.toggled(cr)) }
+    }
+
+    fun onResetFilters() {
+        updateFilter { CreatureFilter(query = it.query) }
+    }
+
+    private fun updateFilter(transform: (CreatureFilter) -> CreatureFilter) {
+        _state.update { it.copy(filter = transform(it.filter)) }
+        refreshData()
+    }
+
+    private fun refreshData() {
+        updateJob?.cancel()
+        updateJob = viewModelScope.launch { updateData() }
+    }
+
+    private suspend fun updateData() {
+        val filter = _state.value.filter
+        _state.update { it.copy(body = CreatureListState.Body.Loading) }
+
         try {
-            val filter = CreatureFilter(query = query)
             val creatures = repository.getAll(filter)
-            if (creatures.isEmpty()) {
-                _state.update { _state.value.copy(body = CreatureListState.Body.Empty) }
+            val body = if (creatures.isEmpty()) {
+                CreatureListState.Body.Empty
             } else {
-                _state.update { _state.value.copy(body = CreatureListState.Body.WithData(searchResults = creatures)) }
+                CreatureListState.Body.WithData(searchResults = creatures)
             }
+            _state.update { it.copy(body = body) }
         } catch (e: Exception) {
-            _state.update { _state.value.copy(body = CreatureListState.Body.Error(errorMessage = Res.string.error_while_loading_creatures)) }
+            _state.update { it.copy(body = CreatureListState.Body.Error(errorMessage = Res.string.error_while_loading_creatures)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -15,6 +15,7 @@ interface HomeRouter {
     fun openMagicalItemList() {}
     fun openMagicalItemCardCarousel() {}
     fun openCreatureList() {}
+    fun openCreatureDetailList() {}
 }
 
 class HomeRouterImpl(private val navController: NavController) : HomeRouter {
@@ -43,6 +44,10 @@ class HomeRouterImpl(private val navController: NavController) : HomeRouter {
     }
 
     override fun openCreatureList() {
-        navController.navigate(CreatureRoute.List)
+        navController.navigate(CreatureRoute.DetailList)
+    }
+
+    override fun openCreatureDetailList() {
+        navController.navigate(CreatureRoute.DetailList)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_magical_items
+import kotlin.coroutines.cancellation.CancellationException
 
 class MagicalItemListViewModel(
     private val router: MagicalItemRouter,
@@ -78,6 +79,8 @@ class MagicalItemListViewModel(
                 MagicalItemListState.Body.WithData(searchResults = magicalItems)
             }
             _state.update { it.copy(body = body) }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             _state.update { it.copy(body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)) }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_spells
+import kotlin.coroutines.cancellation.CancellationException
 
 class SpellBookViewModel(
     private val router: SpellRouter,
@@ -83,6 +84,8 @@ class SpellBookViewModel(
                 SpellListState.Body.WithData(spells)
             }
             _state.update { it.copy(body = body) }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             _state.update { it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
         }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
@@ -5,8 +5,7 @@ data class CreatureFilter(
     val types: Set<Creature.Type> = emptySet(),
     val challengeRatings: Set<Float> = emptySet(),
 ) {
-    val hasActiveFilters: Boolean
-        get() = types.isNotEmpty() || challengeRatings.isNotEmpty()
+    val hasActiveFilters: Boolean = types.isNotEmpty() || challengeRatings.isNotEmpty()
 
     fun matches(creature: Creature): Boolean {
         return (types.isEmpty() || types.contains(creature.type)) &&

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
@@ -1,10 +1,13 @@
 package com.cyrillrx.rpg.creature.domain
 
-class CreatureFilter(
-    private val query: String = "",
-    private val types: Set<Creature.Type> = emptySet(),
-    private val challengeRatings: Set<Float> = emptySet(),
+data class CreatureFilter(
+    val query: String = "",
+    val types: Set<Creature.Type> = emptySet(),
+    val challengeRatings: Set<Float> = emptySet(),
 ) {
+    val hasActiveFilters: Boolean
+        get() = types.isNotEmpty() || challengeRatings.isNotEmpty()
+
     fun matches(creature: Creature): Boolean {
         return (types.isEmpty() || types.contains(creature.type)) &&
             (challengeRatings.isEmpty() || challengeRatings.contains(creature.challengeRating)) &&

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -5,8 +5,7 @@ data class MagicalItemFilter(
     val types: Set<MagicalItem.Type> = emptySet(),
     val rarities: Set<MagicalItem.Rarity> = emptySet(),
 ) {
-    val hasActiveFilters: Boolean
-        get() = types.isNotEmpty() || rarities.isNotEmpty()
+    val hasActiveFilters: Boolean = types.isNotEmpty() || rarities.isNotEmpty()
 
     fun matches(item: MagicalItem): Boolean {
         return (types.isEmpty() || types.contains(item.type)) &&

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -8,8 +8,7 @@ data class SpellFilter(
     val playerClasses: Set<PlayerCharacter.Class> = emptySet(),
     val levels: Set<Int> = emptySet(),
 ) {
-    val hasActiveFilters: Boolean
-        get() = schools.isNotEmpty() || playerClasses.isNotEmpty() || levels.isNotEmpty()
+    val hasActiveFilters: Boolean = schools.isNotEmpty() || playerClasses.isNotEmpty() || levels.isNotEmpty()
 
     fun matches(spell: Spell): Boolean {
         return (schools.isEmpty() || spell.schools.any { schools.contains(it) }) &&


### PR DESCRIPTION
## 📝 Description

Prepare the creature module for the upcoming compact list view and filter features, and fix a coroutine bug across all ViewModels.

- Convert `CreatureFilter` to a data class with public fields and `hasActiveFilters`
- Replace `searchQuery` with `filter: CreatureFilter` in state
- Add filter toggle methods to ViewModel (`onTypeToggled`, `onChallengeRatingToggled`, `onResetFilters`) using the `updateFilter` pattern
- Rename `CreatureListScreen` to `CreatureDetailListScreen` to free the `List` route for the upcoming compact list view
- Add `openCreatureDetailList()` to `HomeRouter`
- Simplify `hasActiveFilters` to direct property initializer in all 3 filter classes
- Fix `CancellationException` being swallowed by `catch (e: Exception)` in all 5 ViewModels — now properly rethrown to avoid false error states during job cancellation

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed