### PR TITLE
feat(creature): add compact list, detail screen, and format extensions

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/CreatureFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/CreatureFormatExt.kt
@@ -1,0 +1,101 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AcUnit
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Dangerous
+import androidx.compose.material.icons.filled.Forest
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Pets
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.QuestionMark
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.SmartToy
+import androidx.compose.material.icons.filled.Water
+import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.cyrillrx.rpg.creature.domain.Creature
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.creature_type_aberration
+import rpg_companion.composeapp.generated.resources.creature_type_beast
+import rpg_companion.composeapp.generated.resources.creature_type_celestial
+import rpg_companion.composeapp.generated.resources.creature_type_construct
+import rpg_companion.composeapp.generated.resources.creature_type_dragon
+import rpg_companion.composeapp.generated.resources.creature_type_elemental
+import rpg_companion.composeapp.generated.resources.creature_type_fey
+import rpg_companion.composeapp.generated.resources.creature_type_fiend
+import rpg_companion.composeapp.generated.resources.creature_type_giant
+import rpg_companion.composeapp.generated.resources.creature_type_humanoid
+import rpg_companion.composeapp.generated.resources.creature_type_monstrosity
+import rpg_companion.composeapp.generated.resources.creature_type_ooze
+import rpg_companion.composeapp.generated.resources.creature_type_plant
+import rpg_companion.composeapp.generated.resources.creature_type_undead
+import rpg_companion.composeapp.generated.resources.creature_type_unknown
+
+@Composable
+fun Creature.Type.toFormattedString(): String {
+    val stringRes = when (this) {
+        Creature.Type.ABERRATION -> Res.string.creature_type_aberration
+        Creature.Type.BEAST -> Res.string.creature_type_beast
+        Creature.Type.CELESTIAL -> Res.string.creature_type_celestial
+        Creature.Type.CONSTRUCT -> Res.string.creature_type_construct
+        Creature.Type.DRAGON -> Res.string.creature_type_dragon
+        Creature.Type.ELEMENTAL -> Res.string.creature_type_elemental
+        Creature.Type.FEY -> Res.string.creature_type_fey
+        Creature.Type.FIEND -> Res.string.creature_type_fiend
+        Creature.Type.GIANT -> Res.string.creature_type_giant
+        Creature.Type.HUMANOID -> Res.string.creature_type_humanoid
+        Creature.Type.MONSTROSITY -> Res.string.creature_type_monstrosity
+        Creature.Type.OOZE -> Res.string.creature_type_ooze
+        Creature.Type.PLANT -> Res.string.creature_type_plant
+        Creature.Type.UNDEAD -> Res.string.creature_type_undead
+        Creature.Type.UNKNOWN -> Res.string.creature_type_unknown
+    }
+    return stringResource(stringRes)
+}
+
+fun Creature.Type.toIcon(): ImageVector = when (this) {
+    Creature.Type.ABERRATION -> Icons.Filled.Psychology
+    Creature.Type.BEAST -> Icons.Filled.Pets
+    Creature.Type.CELESTIAL -> Icons.Filled.Bolt
+    Creature.Type.CONSTRUCT -> Icons.Filled.SmartToy
+    Creature.Type.DRAGON -> Icons.Filled.Whatshot
+    Creature.Type.ELEMENTAL -> Icons.Filled.AcUnit
+    Creature.Type.FEY -> Icons.Filled.Forest
+    Creature.Type.FIEND -> Icons.Filled.Dangerous
+    Creature.Type.GIANT -> Icons.Filled.Shield
+    Creature.Type.HUMANOID -> Icons.Filled.Groups
+    Creature.Type.MONSTROSITY -> Icons.Filled.BugReport
+    Creature.Type.OOZE -> Icons.Filled.Water
+    Creature.Type.PLANT -> Icons.Filled.Forest
+    Creature.Type.UNDEAD -> Icons.Filled.Dangerous
+    Creature.Type.UNKNOWN -> Icons.Filled.QuestionMark
+}
+
+private val dragonColor = Color(183, 28, 28)
+private val undeadColor = Color(74, 20, 140)
+private val fiendColor = Color(136, 14, 79)
+private val celestialColor = Color(255, 179, 0)
+private val beastColor = Color(46, 125, 50)
+private val defaultColor = Color(55, 71, 79)
+
+fun Creature.Type.getColor(): Color = when (this) {
+    Creature.Type.DRAGON -> dragonColor
+    Creature.Type.UNDEAD -> undeadColor
+    Creature.Type.FIEND -> fiendColor
+    Creature.Type.CELESTIAL -> celestialColor
+    Creature.Type.BEAST -> beastColor
+    else -> defaultColor
+}
+
+fun Float.toFormattedCR(): String = when (this) {
+    0f -> "0"
+    0.125f -> "1/8"
+    0.25f -> "1/4"
+    0.5f -> "1/2"
+    else -> if (this == this.toLong().toFloat()) this.toLong().toString() else this.toString()
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
@@ -152,10 +152,13 @@ fun Creature.getSubtitle(): String = stringResource(
     alignment.toFormattedString(),
 )
 
-fun Float.toFormattedCR(): String = when (this) {
-    0f -> "0"
-    0.125f -> "1/8"
-    0.25f -> "1/4"
-    0.5f -> "1/2"
-    else -> if (this == this.toLong().toFloat()) this.toLong().toString() else this.toString()
+fun Creature.toFormattedCR(): String {
+    val value = when (challengeRating) {
+        0f -> "0"
+        0.125f -> "1/8"
+        0.25f -> "1/4"
+        0.5f -> "1/2"
+        else -> if (challengeRating == challengeRating.toLong().toFloat()) challengeRating.toLong().toString() else challengeRating.toString()
+    }
+    return "CR $value"
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Water
 import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -95,20 +96,9 @@ fun Creature.Type.toIcon(): ImageVector = when (this) {
     Creature.Type.UNKNOWN -> Icons.Filled.QuestionMark
 }
 
-private val dragonColor = Color(183, 28, 28)
-private val undeadColor = Color(74, 20, 140)
-private val fiendColor = Color(136, 14, 79)
-private val celestialColor = Color(255, 179, 0)
-private val beastColor = Color(46, 125, 50)
-private val defaultColor = Color(55, 71, 79)
-
+@Composable
 fun Creature.Type.getColor(): Color = when (this) {
-    Creature.Type.DRAGON -> dragonColor
-    Creature.Type.UNDEAD -> undeadColor
-    Creature.Type.FIEND -> fiendColor
-    Creature.Type.CELESTIAL -> celestialColor
-    Creature.Type.BEAST -> beastColor
-    else -> defaultColor
+    else -> MaterialTheme.colorScheme.primary
 }
 
 @Composable
@@ -158,7 +148,8 @@ fun Creature.toFormattedCR(): String {
         0.125f -> "1/8"
         0.25f -> "1/4"
         0.5f -> "1/2"
-        else -> if (challengeRating == challengeRating.toLong().toFloat()) challengeRating.toLong().toString() else challengeRating.toString()
+        else -> if (challengeRating == challengeRating.toLong().toFloat()) challengeRating.toLong()
+            .toString() else challengeRating.toString()
     }
     return "CR $value"
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
@@ -17,9 +17,28 @@ import androidx.compose.material.icons.filled.Whatshot
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.cyrillrx.rpg.creature.domain.BaseCreature
 import com.cyrillrx.rpg.creature.domain.Creature
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_evil
+import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_good
+import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_neutral
+import rpg_companion.composeapp.generated.resources.creature_alignment_lawful_evil
+import rpg_companion.composeapp.generated.resources.creature_alignment_lawful_good
+import rpg_companion.composeapp.generated.resources.creature_alignment_lawful_neutral
+import rpg_companion.composeapp.generated.resources.creature_alignment_neutral
+import rpg_companion.composeapp.generated.resources.creature_alignment_neutral_evil
+import rpg_companion.composeapp.generated.resources.creature_alignment_neutral_good
+import rpg_companion.composeapp.generated.resources.creature_alignment_unknown
+import rpg_companion.composeapp.generated.resources.creature_size_gargantuan
+import rpg_companion.composeapp.generated.resources.creature_size_huge
+import rpg_companion.composeapp.generated.resources.creature_size_large
+import rpg_companion.composeapp.generated.resources.creature_size_medium
+import rpg_companion.composeapp.generated.resources.creature_size_small
+import rpg_companion.composeapp.generated.resources.creature_size_tiny
+import rpg_companion.composeapp.generated.resources.creature_size_unknown
+import rpg_companion.composeapp.generated.resources.creature_subtitle
 import rpg_companion.composeapp.generated.resources.creature_type_aberration
 import rpg_companion.composeapp.generated.resources.creature_type_beast
 import rpg_companion.composeapp.generated.resources.creature_type_celestial
@@ -91,6 +110,47 @@ fun Creature.Type.getColor(): Color = when (this) {
     Creature.Type.BEAST -> beastColor
     else -> defaultColor
 }
+
+@Composable
+fun BaseCreature.Size.toFormattedString(): String {
+    val stringRes = when (this) {
+        BaseCreature.Size.TINY -> Res.string.creature_size_tiny
+        BaseCreature.Size.SMALL -> Res.string.creature_size_small
+        BaseCreature.Size.MEDIUM -> Res.string.creature_size_medium
+        BaseCreature.Size.LARGE -> Res.string.creature_size_large
+        BaseCreature.Size.HUGE -> Res.string.creature_size_huge
+        BaseCreature.Size.GARGANTUAN -> Res.string.creature_size_gargantuan
+        BaseCreature.Size.UNKNOWN -> Res.string.creature_size_unknown
+    }
+    return stringResource(stringRes)
+}
+
+// BaseCreature.Alignment
+
+@Composable
+fun BaseCreature.Alignment.toFormattedString(): String {
+    val stringRes = when (this) {
+        BaseCreature.Alignment.LAWFUL_GOOD -> Res.string.creature_alignment_lawful_good
+        BaseCreature.Alignment.NEUTRAL_GOOD -> Res.string.creature_alignment_neutral_good
+        BaseCreature.Alignment.CHAOTIC_GOOD -> Res.string.creature_alignment_chaotic_good
+        BaseCreature.Alignment.LAWFUL_NEUTRAL -> Res.string.creature_alignment_lawful_neutral
+        BaseCreature.Alignment.NEUTRAL -> Res.string.creature_alignment_neutral
+        BaseCreature.Alignment.CHAOTIC_NEUTRAL -> Res.string.creature_alignment_chaotic_neutral
+        BaseCreature.Alignment.LAWFUL_EVIL -> Res.string.creature_alignment_lawful_evil
+        BaseCreature.Alignment.NEUTRAL_EVIL -> Res.string.creature_alignment_neutral_evil
+        BaseCreature.Alignment.CHAOTIC_EVIL -> Res.string.creature_alignment_chaotic_evil
+        BaseCreature.Alignment.UNKNOWN -> Res.string.creature_alignment_unknown
+    }
+    return stringResource(stringRes)
+}
+
+@Composable
+fun Creature.getSubtitle(): String = stringResource(
+    Res.string.creature_subtitle,
+    type.toFormattedString(),
+    size.toFormattedString(),
+    alignment.toFormattedString(),
+)
 
 fun Float.toFormattedCR(): String = when (this) {
     0f -> "0"

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
@@ -1,4 +1,4 @@
-package com.cyrillrx.rpg.core.presentation.component
+package com.cyrillrx.rpg.core.presentation.component.dnd
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AcUnit

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MagicalItemFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MagicalItemFormatExt.kt
@@ -1,4 +1,4 @@
-package com.cyrillrx.rpg.core.presentation.component
+package com.cyrillrx.rpg.core.presentation.component.dnd
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
@@ -1,4 +1,4 @@
-package com.cyrillrx.rpg.core.presentation.component
+package com.cyrillrx.rpg.core.presentation.component.dnd
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
@@ -1,13 +1,19 @@
 package com.cyrillrx.rpg.creature.presentation.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Favorite
+import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -18,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedCR
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
@@ -33,12 +40,17 @@ import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
+private val typeIconSize = 36.dp
+private val typeIconPadding = 8.dp
+
 @Composable
 fun CreatureCompactListItem(
     creature: Creature,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val typeColor = creature.type.getColor()
+
     Card(
         onClick = onClick,
         shape = MaterialTheme.shapes.medium,
@@ -50,14 +62,24 @@ fun CreatureCompactListItem(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(spacingCommon),
         ) {
-            Icon(
-                imageVector = creature.type.toIcon(),
-                contentDescription = null,
-                tint = creature.type.getColor(),
-                modifier = Modifier.size(iconSizeSmall),
-            )
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(typeIconSize + typeIconPadding * 2)
+                    .background(
+                        color = typeColor.copy(alpha = 0.12f),
+                        shape = RoundedCornerShape(spacingMedium),
+                    ),
+            ) {
+                Icon(
+                    imageVector = creature.type.toIcon(),
+                    contentDescription = null,
+                    tint = typeColor,
+                    modifier = Modifier.size(typeIconSize),
+                )
+            }
 
-            Spacer(modifier = Modifier.width(spacingSmall))
+            Spacer(modifier = Modifier.width(spacingMedium))
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(spacingSmall),
@@ -71,12 +93,51 @@ fun CreatureCompactListItem(
                 )
 
                 Text(
-                    text = "${creature.type.toFormattedString()} · ${creature.toFormattedCR()}",
+                    text = "${creature.type.toFormattedString()} · ${creature.size.name.lowercase().replaceFirstChar { it.uppercase() }}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(spacingSmall),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Shield,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(iconSizeSmall),
+                        )
+                        Text(
+                            text = "AC ${creature.armorClass}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(spacingSmall),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Favorite,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(iconSizeSmall),
+                        )
+                        Text(
+                            text = "${creature.maxHitPoints} HP",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.width(spacingMedium))
@@ -85,7 +146,7 @@ fun CreatureCompactListItem(
                 text = creature.toFormattedCR(),
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
-                color = creature.type.getColor(),
+                color = typeColor,
             )
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
@@ -1,0 +1,116 @@
+package com.cyrillrx.rpg.creature.presentation.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.cyrillrx.rpg.core.presentation.component.getColor
+import com.cyrillrx.rpg.core.presentation.component.toFormattedCR
+import com.cyrillrx.rpg.core.presentation.component.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.toIcon
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
+import com.cyrillrx.rpg.core.presentation.theme.borderWidth
+import com.cyrillrx.rpg.core.presentation.theme.iconSizeSmall
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import com.cyrillrx.rpg.creature.domain.Creature
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun CreatureCompactListItem(
+    creature: Creature,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(borderWidth, MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(spacingCommon),
+        ) {
+            Icon(
+                imageVector = creature.type.toIcon(),
+                contentDescription = null,
+                tint = creature.type.getColor(),
+                modifier = Modifier.size(iconSizeSmall),
+            )
+
+            Spacer(modifier = Modifier.width(spacingSmall))
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(spacingSmall),
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = creature.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Text(
+                    text = "${creature.type.toFormattedString()} · CR ${creature.challengeRating.toFormattedCR()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(spacingMedium))
+
+            Text(
+                text = "CR ${creature.challengeRating.toFormattedCR()}",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = creature.type.getColor(),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureCompactListItemLight() {
+    AppThemePreview(darkTheme = false) {
+        Column(verticalArrangement = Arrangement.spacedBy(spacingSmall)) {
+            SampleCreatureRepository().getAll().forEach {
+                CreatureCompactListItem(creature = it, onClick = {})
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureCompactListItemDark() {
+    AppThemePreview(darkTheme = true) {
+        Column(verticalArrangement = Arrangement.spacedBy(spacingSmall)) {
+            SampleCreatureRepository().getAll().forEach {
+                CreatureCompactListItem(creature = it, onClick = {})
+            }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
@@ -71,7 +71,7 @@ fun CreatureCompactListItem(
                 )
 
                 Text(
-                    text = "${creature.type.toFormattedString()} · CR ${creature.challengeRating.toFormattedCR()}",
+                    text = "${creature.type.toFormattedString()} · ${creature.toFormattedCR()}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
@@ -82,7 +82,7 @@ fun CreatureCompactListItem(
             Spacer(modifier = Modifier.width(spacingMedium))
 
             Text(
-                text = "CR ${creature.challengeRating.toFormattedCR()}",
+                text = creature.toFormattedCR(),
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
                 color = creature.type.getColor(),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListItem.kt
@@ -18,10 +18,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import com.cyrillrx.rpg.core.presentation.component.getColor
-import com.cyrillrx.rpg.core.presentation.component.toFormattedCR
-import com.cyrillrx.rpg.core.presentation.component.toFormattedString
-import com.cyrillrx.rpg.core.presentation.component.toIcon
+import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedCR
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.dnd.toIcon
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
@@ -1,0 +1,124 @@
+package com.cyrillrx.rpg.creature.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.core.presentation.component.EmptySearch
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.presentation.CreatureListState
+import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.hint_search_creature
+
+@Composable
+fun CreatureCompactListScreen(viewModel: CreatureListViewModel) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    CreatureCompactListScreen(
+        state = state,
+        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onCreatureClicked = viewModel::onCreatureClicked,
+    )
+}
+
+@Composable
+fun CreatureCompactListScreen(
+    state: CreatureListState,
+    onNavigateUpClicked: () -> Unit,
+    onSearchQueryChanged: (String) -> Unit,
+    onCreatureClicked: (Creature) -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SearchBarWithBack(
+                hint = stringResource(Res.string.hint_search_creature),
+                query = state.filter.query,
+                onQueryChanged = onSearchQueryChanged,
+                onNavigateUpClicked = onNavigateUpClicked,
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            when (val body = state.body) {
+                is CreatureListState.Body.Loading -> Loader()
+                is CreatureListState.Body.Empty -> EmptySearch(state.filter.query)
+                is CreatureListState.Body.Error -> ErrorLayout(body.errorMessage)
+                is CreatureListState.Body.WithData -> CreatureCompactList(body.searchResults, onCreatureClicked)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreatureCompactList(
+    creatures: List<Creature>,
+    onCreatureClicked: (Creature) -> Unit,
+) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(creatures) {
+        listState.animateScrollToItem(0)
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = listState,
+        contentPadding = PaddingValues(spacingMedium),
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+    ) {
+        items(creatures) { creature ->
+            CreatureCompactListItem(
+                creature = creature,
+                onClick = { onCreatureClicked(creature) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+private val stateWithSampleData = CreatureListState(
+    body = CreatureListState.Body.WithData(SampleCreatureRepository().getAll()),
+)
+
+@Preview
+@Composable
+private fun PreviewCreatureCompactListScreenLight() {
+    AppThemePreview(darkTheme = false) {
+        CreatureCompactListScreen(stateWithSampleData, {}, {}, {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureCompactListScreenDark() {
+    AppThemePreview(darkTheme = true) {
+        CreatureCompactListScreen(stateWithSampleData, {}, {}, {})
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
@@ -1,0 +1,51 @@
+package com.cyrillrx.rpg.creature.presentation.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import com.cyrillrx.rpg.creature.domain.Creature
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun CreatureDetailScreen(
+    creature: Creature,
+    onNavigateUpClicked: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SimpleTopBar(
+                title = creature.name,
+                navigateUp = onNavigateUpClicked,
+            )
+        },
+    ) { paddingValues ->
+        CreatureItem(
+            creature = creature,
+            modifier = Modifier
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState()),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureDetailScreenLight() {
+    AppThemePreview(darkTheme = false) {
+        CreatureDetailScreen(creature = SampleCreatureRepository().get(), onNavigateUpClicked = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureDetailScreenDark() {
+    AppThemePreview(darkTheme = true) {
+        CreatureDetailScreen(creature = SampleCreatureRepository().get(), onNavigateUpClicked = {})
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -81,14 +81,22 @@ private fun CreatureList(
     }
 }
 
+private val stateWithSampleData = CreatureListState(
+    body = CreatureListState.Body.WithData(SampleCreatureRepository().getAll()),
+)
+
 @Preview
 @Composable
-private fun PreviewCreatureListScreen() {
-    val creatures = SampleCreatureRepository().getAll()
-    val state = CreatureListState(
-        body = CreatureListState.Body.WithData(creatures),
-    )
+private fun PreviewCreatureListScreenLight() {
     AppThemePreview(darkTheme = false) {
-        CreatureListScreen(state, {}, {}, {})
+        CreatureListScreen(stateWithSampleData, {}, {}, {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureListScreenDark() {
+    AppThemePreview(darkTheme = true) {
+        CreatureListScreen(stateWithSampleData, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.creature.presentation.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -26,9 +27,9 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_creature
 
 @Composable
-fun CreatureDetailListScreen(viewModel: CreatureListViewModel) {
+fun CreatureListScreen(viewModel: CreatureListViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    CreatureDetailListScreen(
+    CreatureListScreen(
         state = state,
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
@@ -37,7 +38,7 @@ fun CreatureDetailListScreen(viewModel: CreatureListViewModel) {
 }
 
 @Composable
-fun CreatureDetailListScreen(
+fun CreatureListScreen(
     state: CreatureListState,
     onSearchQueryChanged: (String) -> Unit,
     onCreatureClicked: (Creature) -> Unit,
@@ -73,7 +74,7 @@ private fun CreatureList(
         items(creatures) { creature ->
             CreatureItem(
                 creature = creature,
-//                modifier = Modifier.clickable { onCreatureClicked(creature) },
+                modifier = Modifier.clickable { onCreatureClicked(creature) },
             )
             HorizontalDivider()
         }
@@ -82,12 +83,12 @@ private fun CreatureList(
 
 @Preview
 @Composable
-private fun PreviewCreatureDetailListScreen() {
+private fun PreviewCreatureListScreen() {
     val creatures = SampleCreatureRepository().getAll()
     val state = CreatureListState(
         body = CreatureListState.Body.WithData(creatures),
     )
     AppThemePreview(darkTheme = false) {
-        CreatureDetailListScreen(state, {}, {}, {})
+        CreatureListScreen(state, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MainStatLayout.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MainStatLayout.kt
@@ -9,46 +9,13 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
-import com.cyrillrx.rpg.creature.domain.BaseCreature
+import com.cyrillrx.rpg.core.presentation.component.dnd.getSubtitle
 import com.cyrillrx.rpg.creature.domain.Creature
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.creature_ac
-import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_evil
-import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_good
-import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_neutral
-import rpg_companion.composeapp.generated.resources.creature_alignment_lawful_evil
-import rpg_companion.composeapp.generated.resources.creature_alignment_lawful_good
-import rpg_companion.composeapp.generated.resources.creature_alignment_lawful_neutral
-import rpg_companion.composeapp.generated.resources.creature_alignment_neutral
-import rpg_companion.composeapp.generated.resources.creature_alignment_neutral_evil
-import rpg_companion.composeapp.generated.resources.creature_alignment_neutral_good
-import rpg_companion.composeapp.generated.resources.creature_alignment_unknown
 import rpg_companion.composeapp.generated.resources.creature_hp
-import rpg_companion.composeapp.generated.resources.creature_size_gargantuan
-import rpg_companion.composeapp.generated.resources.creature_size_huge
-import rpg_companion.composeapp.generated.resources.creature_size_large
-import rpg_companion.composeapp.generated.resources.creature_size_medium
-import rpg_companion.composeapp.generated.resources.creature_size_small
-import rpg_companion.composeapp.generated.resources.creature_size_tiny
-import rpg_companion.composeapp.generated.resources.creature_size_unknown
 import rpg_companion.composeapp.generated.resources.creature_speed
-import rpg_companion.composeapp.generated.resources.creature_subtitle
-import rpg_companion.composeapp.generated.resources.creature_type_aberration
-import rpg_companion.composeapp.generated.resources.creature_type_beast
-import rpg_companion.composeapp.generated.resources.creature_type_celestial
-import rpg_companion.composeapp.generated.resources.creature_type_construct
-import rpg_companion.composeapp.generated.resources.creature_type_dragon
-import rpg_companion.composeapp.generated.resources.creature_type_elemental
-import rpg_companion.composeapp.generated.resources.creature_type_fey
-import rpg_companion.composeapp.generated.resources.creature_type_fiend
-import rpg_companion.composeapp.generated.resources.creature_type_giant
-import rpg_companion.composeapp.generated.resources.creature_type_humanoid
-import rpg_companion.composeapp.generated.resources.creature_type_monstrosity
-import rpg_companion.composeapp.generated.resources.creature_type_ooze
-import rpg_companion.composeapp.generated.resources.creature_type_plant
-import rpg_companion.composeapp.generated.resources.creature_type_undead
-import rpg_companion.composeapp.generated.resources.creature_type_unknown
 
 @Composable
 fun MainStatLayout(
@@ -99,60 +66,5 @@ fun MainStatLayout(
                 append(creature.speed)
             },
         )
-    }
-}
-
-@Composable
-private fun Creature.getSubtitle(): String {
-    return stringResource(Res.string.creature_subtitle, getFormattedType(), getFormattedSize(), getAlignment())
-}
-
-@Composable
-private fun Creature.getFormattedType(): String {
-    return when (type) {
-        Creature.Type.ABERRATION -> stringResource(Res.string.creature_type_aberration)
-        Creature.Type.BEAST -> stringResource(Res.string.creature_type_beast)
-        Creature.Type.CELESTIAL -> stringResource(Res.string.creature_type_celestial)
-        Creature.Type.CONSTRUCT -> stringResource(Res.string.creature_type_construct)
-        Creature.Type.DRAGON -> stringResource(Res.string.creature_type_dragon)
-        Creature.Type.ELEMENTAL -> stringResource(Res.string.creature_type_elemental)
-        Creature.Type.FEY -> stringResource(Res.string.creature_type_fey)
-        Creature.Type.FIEND -> stringResource(Res.string.creature_type_fiend)
-        Creature.Type.GIANT -> stringResource(Res.string.creature_type_giant)
-        Creature.Type.HUMANOID -> stringResource(Res.string.creature_type_humanoid)
-        Creature.Type.MONSTROSITY -> stringResource(Res.string.creature_type_monstrosity)
-        Creature.Type.OOZE -> stringResource(Res.string.creature_type_ooze)
-        Creature.Type.PLANT -> stringResource(Res.string.creature_type_plant)
-        Creature.Type.UNDEAD -> stringResource(Res.string.creature_type_undead)
-        Creature.Type.UNKNOWN -> stringResource(Res.string.creature_type_unknown)
-    }
-}
-
-@Composable
-private fun BaseCreature.getFormattedSize(): String {
-    return when (size) {
-        BaseCreature.Size.TINY -> stringResource(Res.string.creature_size_tiny)
-        BaseCreature.Size.SMALL -> stringResource(Res.string.creature_size_small)
-        BaseCreature.Size.MEDIUM -> stringResource(Res.string.creature_size_medium)
-        BaseCreature.Size.LARGE -> stringResource(Res.string.creature_size_large)
-        BaseCreature.Size.HUGE -> stringResource(Res.string.creature_size_huge)
-        BaseCreature.Size.GARGANTUAN -> stringResource(Res.string.creature_size_gargantuan)
-        BaseCreature.Size.UNKNOWN -> stringResource(Res.string.creature_size_unknown)
-    }
-}
-
-@Composable
-private fun BaseCreature.getAlignment(): String {
-    return when (alignment) {
-        BaseCreature.Alignment.LAWFUL_GOOD -> stringResource(Res.string.creature_alignment_lawful_good)
-        BaseCreature.Alignment.NEUTRAL_GOOD -> stringResource(Res.string.creature_alignment_neutral_good)
-        BaseCreature.Alignment.CHAOTIC_GOOD -> stringResource(Res.string.creature_alignment_chaotic_good)
-        BaseCreature.Alignment.LAWFUL_NEUTRAL -> stringResource(Res.string.creature_alignment_lawful_neutral)
-        BaseCreature.Alignment.NEUTRAL -> stringResource(Res.string.creature_alignment_neutral)
-        BaseCreature.Alignment.CHAOTIC_NEUTRAL -> stringResource(Res.string.creature_alignment_chaotic_neutral)
-        BaseCreature.Alignment.LAWFUL_EVIL -> stringResource(Res.string.creature_alignment_lawful_evil)
-        BaseCreature.Alignment.NEUTRAL_EVIL -> stringResource(Res.string.creature_alignment_neutral_evil)
-        BaseCreature.Alignment.CHAOTIC_EVIL -> stringResource(Res.string.creature_alignment_chaotic_evil)
-        BaseCreature.Alignment.UNKNOWN -> stringResource(Res.string.creature_alignment_unknown)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListScreen
-import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailListScreen
+import com.cyrillrx.rpg.creature.presentation.component.CreatureListScreen
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModelFactory
 import kotlinx.serialization.Serializable
@@ -16,7 +16,7 @@ interface CreatureRoute {
     data object CompactList
 
     @Serializable
-    data object DetailList
+    data object List
 
     @Serializable
     data class Detail(val serializedCreature: String)
@@ -30,10 +30,10 @@ fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repositor
         CreatureCompactListScreen(viewModel)
     }
 
-    composable<CreatureRoute.DetailList> {
+    composable<CreatureRoute.List> {
         val router = CreatureRouterImpl(navController)
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
-        CreatureDetailListScreen(viewModel)
+        CreatureListScreen(viewModel)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListScreen
+import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureListScreen
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModelFactory
@@ -35,5 +38,13 @@ fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repositor
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
         CreatureListScreen(viewModel)
+    }
+
+    composable<CreatureRoute.Detail> { entry ->
+        val args = entry.toRoute<CreatureRoute.Detail>()
+        CreatureDetailScreen(
+            creature = args.serializedCreature.deserialize(),
+            onNavigateUpClicked = { navController.navigateUp() },
+        )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -5,12 +5,16 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailListScreen
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModelFactory
 import kotlinx.serialization.Serializable
 
 interface CreatureRoute {
+    @Serializable
+    data object CompactList
+
     @Serializable
     data object DetailList
 
@@ -19,6 +23,13 @@ interface CreatureRoute {
 }
 
 fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repository: CreatureRepository) {
+    composable<CreatureRoute.CompactList> {
+        val router = CreatureRouterImpl(navController)
+        val viewModelFactory = CreatureListViewModelFactory(router, repository)
+        val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
+        CreatureCompactListScreen(viewModel)
+    }
+
     composable<CreatureRoute.DetailList> {
         val router = CreatureRouterImpl(navController)
         val viewModelFactory = CreatureListViewModelFactory(router, repository)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -2,11 +2,11 @@ package com.cyrillrx.rpg.creature.presentation.navigation
 
 import androidx.navigation.NavController
 import com.cyrillrx.core.data.serialize
-import com.cyrillrx.rpg.creature.domain.BaseCreature
+import com.cyrillrx.rpg.creature.domain.Creature
 
 interface CreatureRouter {
     fun navigateUp()
-    fun openCreatureDetail(creature: BaseCreature)
+    fun openCreatureDetail(creature: Creature)
 }
 
 class CreatureRouterImpl(private val navController: NavController) : CreatureRouter {
@@ -14,7 +14,7 @@ class CreatureRouterImpl(private val navController: NavController) : CreatureRou
         navController.navigateUp()
     }
 
-    override fun openCreatureDetail(creature: BaseCreature) {
+    override fun openCreatureDetail(creature: Creature) {
         navController.navigate(CreatureRoute.Detail(creature.serialize()))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -42,7 +42,8 @@ class CreatureListViewModel(
     }
 
     fun onCreatureClicked(creature: Creature) {
-        router.openCreatureDetail(creature)
+        // TODO : open detail
+        // router.openCreatureDetail(creature)
     }
 
     fun onTypeToggled(type: Creature.Type) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -76,7 +76,7 @@ fun HomeScreen(router: HomeRouter) {
                 IconLabelButton(
                     label = stringResource(Res.string.btn_bestiary),
                     icon = Icons.Filled.Pets,
-                    onClick = router::openCreatureCompactList,
+                    onClick = router::openCreatureList,
                     modifier = Modifier.weight(1f),
                 )
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -76,7 +76,7 @@ fun HomeScreen(router: HomeRouter) {
                 IconLabelButton(
                     label = stringResource(Res.string.btn_bestiary),
                     icon = Icons.Filled.Pets,
-                    onClick = router::openCreatureList,
+                    onClick = router::openCreatureCompactList,
                     modifier = Modifier.weight(1f),
                 )
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -15,7 +15,7 @@ interface HomeRouter {
     fun openMagicalItemList() {}
     fun openMagicalItemCardCarousel() {}
     fun openCreatureCompactList() {}
-    fun openCreatureDetailList() {}
+    fun openCreatureList() {}
 }
 
 class HomeRouterImpl(private val navController: NavController) : HomeRouter {
@@ -47,7 +47,7 @@ class HomeRouterImpl(private val navController: NavController) : HomeRouter {
         navController.navigate(CreatureRoute.CompactList)
     }
 
-    override fun openCreatureDetailList() {
-        navController.navigate(CreatureRoute.DetailList)
+    override fun openCreatureList() {
+        navController.navigate(CreatureRoute.List)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -14,7 +14,7 @@ interface HomeRouter {
     fun openSpellCardCarousel() {}
     fun openMagicalItemList() {}
     fun openMagicalItemCardCarousel() {}
-    fun openCreatureList() {}
+    fun openCreatureCompactList() {}
     fun openCreatureDetailList() {}
 }
 
@@ -43,8 +43,8 @@ class HomeRouterImpl(private val navController: NavController) : HomeRouter {
         navController.navigate(MagicalItemRoute.CardCarousel)
     }
 
-    override fun openCreatureList() {
-        navController.navigate(CreatureRoute.DetailList)
+    override fun openCreatureCompactList() {
+        navController.navigate(CreatureRoute.CompactList)
     }
 
     override fun openCreatureDetailList() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
-import com.cyrillrx.rpg.core.presentation.component.getColor
+import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
@@ -79,6 +79,7 @@ fun MagicalItemCard(
         }
     }
 }
+
 @Preview
 @Composable
 private fun PreviewMagicalItemCard() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemFilterBottomSheet.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.cyrillrx.rpg.core.presentation.component.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import com.cyrillrx.rpg.core.presentation.component.getColor
-import com.cyrillrx.rpg.core.presentation.component.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
-import com.cyrillrx.rpg.core.presentation.component.getColor
-import com.cyrillrx.rpg.core.presentation.component.getFormattedSchool
+import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
+import com.cyrillrx.rpg.core.presentation.component.dnd.getFormattedSchool
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
-import com.cyrillrx.rpg.core.presentation.component.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import com.cyrillrx.rpg.core.presentation.component.toFormattedLevel
-import com.cyrillrx.rpg.core.presentation.component.toFormattedString
-import com.cyrillrx.rpg.core.presentation.component.toIcon
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedLevel
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.dnd.toIcon
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
@@ -1,35 +1,137 @@
-package com.cyrillrx.rpg.creature.data;
+package com.cyrillrx.rpg.creature.data
 
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.BaseCreature
 import com.cyrillrx.rpg.creature.domain.Creature
 
 class SampleCreatureRepository {
-    fun getAll(): List<Creature> {
-        val item = get()
-        return listOf(item, item, item)
-    }
-
-    fun get(): Creature = Creature(
-        id = "1",
-        name = "Goblin",
-        description = "A small, black-hearted creature that lairs in despoiled dungeons and other dismal settings.",
-        type = Creature.Type.HUMANOID,
-        subtype = "goblinoid",
-        size = BaseCreature.Size.SMALL,
-        alignment = BaseCreature.Alignment.LAWFUL_EVIL,
-        challengeRating = 0.25f,
-        abilities = Abilities(
-            strValue = 8,
-            dexValue = 14,
-            conValue = 10,
-            intValue = 10,
-            wisValue = 8,
-            chaValue = 8,
+    fun getAll(): List<Creature> = listOf(
+        Creature(
+            id = "1",
+            name = "Goblin",
+            description = "A small, black-hearted creature that lairs in despoiled dungeons and other dismal settings.",
+            type = Creature.Type.HUMANOID,
+            subtype = "goblinoid",
+            size = BaseCreature.Size.SMALL,
+            alignment = BaseCreature.Alignment.NEUTRAL_EVIL,
+            challengeRating = 0.25f,
+            abilities = Abilities(
+                strValue = 8,
+                dexValue = 14,
+                conValue = 10,
+                intValue = 10,
+                wisValue = 8,
+                chaValue = 8,
+            ),
+            armorClass = 15,
+            maxHitPoints = 7,
+            speed = "30 ft.",
+            languages = listOf("Common", "Goblin"),
         ),
-        armorClass = 15,
-        maxHitPoints = 7,
-        speed = "",
-        languages = emptyList(),
+        Creature(
+            id = "2",
+            name = "Young Red Dragon",
+            description = "A fierce dragon that breathes fire and terrorizes the countryside.",
+            type = Creature.Type.DRAGON,
+            subtype = "",
+            size = BaseCreature.Size.LARGE,
+            alignment = BaseCreature.Alignment.CHAOTIC_EVIL,
+            challengeRating = 10f,
+            abilities = Abilities(
+                strValue = 23,
+                dexValue = 10,
+                conValue = 21,
+                intValue = 14,
+                wisValue = 11,
+                chaValue = 19,
+            ),
+            armorClass = 18,
+            maxHitPoints = 178,
+            speed = "40 ft., climb 40 ft., fly 80 ft.",
+            languages = listOf("Common", "Draconic"),
+        ),
+        Creature(
+            id = "3",
+            name = "Skeleton",
+            description = "An animated pile of bones held together by dark magic.",
+            type = Creature.Type.UNDEAD,
+            subtype = "",
+            size = BaseCreature.Size.MEDIUM,
+            alignment = BaseCreature.Alignment.LAWFUL_EVIL,
+            challengeRating = 0.25f,
+            abilities = Abilities(
+                strValue = 10,
+                dexValue = 14,
+                conValue = 15,
+                intValue = 6,
+                wisValue = 8,
+                chaValue = 5,
+            ),
+            armorClass = 13,
+            maxHitPoints = 13,
+            speed = "30 ft.",
+            languages = listOf("understands languages it knew in life"),
+        ),
+        Creature(
+            id = "4",
+            name = "Dire Wolf",
+            description = "A large and fearsome wolf that hunts in packs.",
+            type = Creature.Type.BEAST,
+            subtype = "",
+            size = BaseCreature.Size.LARGE,
+            alignment = BaseCreature.Alignment.NEUTRAL,
+            challengeRating = 1f,
+            abilities = Abilities(
+                strValue = 17,
+                dexValue = 15,
+                conValue = 15,
+                intValue = 3,
+                wisValue = 12,
+                chaValue = 7,
+            ),
+            armorClass = 14,
+            maxHitPoints = 37,
+            speed = "50 ft.",
+            languages = emptyList(),
+        ),
+        Creature(
+            id = "5",
+            name = "Balor",
+            description = "A towering fiend wreathed in flame, wielding a whip and longsword of fire.",
+            type = Creature.Type.FIEND,
+            subtype = "demon",
+            size = BaseCreature.Size.HUGE,
+            alignment = BaseCreature.Alignment.CHAOTIC_EVIL,
+            challengeRating = 19f,
+            abilities = Abilities(
+                strValue = 26,
+                dexValue = 15,
+                conValue = 22,
+                intValue = 20,
+                wisValue = 16,
+                chaValue = 22,
+            ),
+            armorClass = 19,
+            maxHitPoints = 262,
+            speed = "40 ft., fly 80 ft.",
+            languages = listOf("Abyssal", "telepathy 120 ft."),
+        ),
+        Creature(
+            id = "6",
+            name = "Gelatinous Cube",
+            description = "A nearly transparent ooze that fills dungeon corridors.",
+            type = Creature.Type.OOZE,
+            subtype = "",
+            size = BaseCreature.Size.LARGE,
+            alignment = BaseCreature.Alignment.NEUTRAL,
+            challengeRating = 2f,
+            abilities = Abilities(strValue = 14, dexValue = 3, conValue = 20, intValue = 1, wisValue = 6, chaValue = 1),
+            armorClass = 6,
+            maxHitPoints = 84,
+            speed = "15 ft.",
+            languages = emptyList(),
+        ),
     )
+
+    fun get(): Creature = getAll().first()
 }


### PR DESCRIPTION
## 📝 Description

Add a compact list view and detail screen for creatures, mirroring the spell and magical item patterns.

- Diversify `SampleCreatureRepository` with varied creature types and CRs
- Create `CreatureFormatExt.kt` in `core/presentation/dnd/` with `toFormattedString()`, `toIcon()`, `getColor()`, and `toFormattedCR()` extensions
- Move all `*FormatExt.kt` files from `core/presentation/component/` to `core/presentation/dnd/` package
- Create `CreatureCompactListItem` with colored type icon and CR badge
- Create `CreatureCompactListScreen` with vertical LazyColumn
- Add `CreatureRoute.CompactList` and `openCreatureCompactList()` to HomeRouter
- Rename `CreatureDetailListScreen` back to `CreatureListScreen` (`CreatureRoute.List`)
- Create `CreatureDetailScreen` with SimpleTopBar and scrollable CreatureItem
- Wire `CreatureRoute.Detail` composable in route handler

## 🖼️ Media

CreatureListScreen
<img width="1152" height="1220" alt="image" src="https://github.com/user-attachments/assets/273084a6-e8f3-419d-89bc-51b03aa9f09e" />

CompactList
<img width="1030" height="1098" alt="image" src="https://github.com/user-attachments/assets/5e87f8b4-0643-4b1f-8743-27b064319425" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed