### PR TITLE
feat(creature): add filter bottom sheet to creature screens

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_creature.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_creature.xml
@@ -44,6 +44,10 @@
     <string name="creature_alignment_chaotic_evil">Chaotique mauvais</string>
     <string name="creature_alignment_unknown">Alignement inconnu</string>
 
+    <!-- Creature filter -->
+    <string name="title_filter_creatures">Filtrer les créatures</string>
+    <string name="label_filter_cr">Indice de dangerosité</string>
+
     <!-- Creature ability -->
     <string name="ability_label_str">For</string>
     <string name="ability_label_dex">Dex</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
@@ -45,6 +45,10 @@
     <string name="creature_alignment_chaotic_evil">Chaotic evil</string>
     <string name="creature_alignment_unknown">Unknown alignment</string>
 
+    <!-- Creature filter -->
+    <string name="title_filter_creatures">Filter Creatures</string>
+    <string name="label_filter_cr">Challenge Rating</string>
+
     <!-- Creature ability -->
     <string name="ability_label_str">Str</string>
     <string name="ability_label_dex">Dex</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
@@ -142,14 +142,12 @@ fun Creature.getSubtitle(): String = stringResource(
     alignment.toFormattedString(),
 )
 
-fun Creature.toFormattedCR(): String {
-    val value = when (challengeRating) {
-        0f -> "0"
-        0.125f -> "1/8"
-        0.25f -> "1/4"
-        0.5f -> "1/2"
-        else -> if (challengeRating == challengeRating.toLong().toFloat()) challengeRating.toLong()
-            .toString() else challengeRating.toString()
-    }
-    return "CR $value"
+fun Creature.toFormattedCR(): String = "CR ${formatCRValue(challengeRating)}"
+
+fun formatCRValue(cr: Float): String = when (cr) {
+    0f -> "0"
+    0.125f -> "1/8"
+    0.25f -> "1/4"
+    0.5f -> "1/2"
+    else -> if (cr == cr.toLong().toFloat()) cr.toLong().toString() else cr.toString()
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -41,6 +44,9 @@ fun CreatureCompactListScreen(viewModel: CreatureListViewModel) {
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onCreatureClicked = viewModel::onCreatureClicked,
+        onTypeToggled = viewModel::onTypeToggled,
+        onChallengeRatingToggled = viewModel::onChallengeRatingToggled,
+        onResetFilters = viewModel::onResetFilters,
     )
 }
 
@@ -50,7 +56,12 @@ fun CreatureCompactListScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onCreatureClicked: (Creature) -> Unit,
+    onTypeToggled: (Creature.Type) -> Unit,
+    onChallengeRatingToggled: (Float) -> Unit,
+    onResetFilters: () -> Unit,
 ) {
+    var showFilterSheet by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             SearchBarWithBack(
@@ -58,6 +69,8 @@ fun CreatureCompactListScreen(
                 query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
+                onFilterClicked = { showFilterSheet = true },
+                hasActiveFilters = state.filter.hasActiveFilters,
             )
         },
     ) { paddingValues ->
@@ -74,6 +87,16 @@ fun CreatureCompactListScreen(
                 is CreatureListState.Body.WithData -> CreatureCompactList(body.searchResults, onCreatureClicked)
             }
         }
+    }
+
+    if (showFilterSheet) {
+        CreatureFilterBottomSheet(
+            filter = state.filter,
+            onTypeToggled = onTypeToggled,
+            onChallengeRatingToggled = onChallengeRatingToggled,
+            onResetFilters = onResetFilters,
+            onDismiss = { showFilterSheet = false },
+        )
     }
 }
 
@@ -111,7 +134,7 @@ private val stateWithSampleData = CreatureListState(
 @Composable
 private fun PreviewCreatureCompactListScreenLight() {
     AppThemePreview(darkTheme = false) {
-        CreatureCompactListScreen(stateWithSampleData, {}, {}, {})
+        CreatureCompactListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -119,6 +142,6 @@ private fun PreviewCreatureCompactListScreenLight() {
 @Composable
 private fun PreviewCreatureCompactListScreenDark() {
     AppThemePreview(darkTheme = true) {
-        CreatureCompactListScreen(stateWithSampleData, {}, {}, {})
+        CreatureCompactListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureFilterBottomSheet.kt
@@ -1,0 +1,139 @@
+package com.cyrillrx.rpg.creature.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.dnd.formatCRValue
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.CreatureFilter
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_reset_all
+import rpg_companion.composeapp.generated.resources.label_filter_cr
+import rpg_companion.composeapp.generated.resources.label_filter_type
+import rpg_companion.composeapp.generated.resources.title_filter_creatures
+
+private val commonCRs = listOf(
+    0f, 0.125f, 0.25f, 0.5f,
+    1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f,
+    11f, 12f, 13f, 14f, 15f, 16f, 17f,
+    20f, 21f, 24f, 30f,
+)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun CreatureFilterBottomSheet(
+    filter: CreatureFilter,
+    onTypeToggled: (Creature.Type) -> Unit,
+    onChallengeRatingToggled: (Float) -> Unit,
+    onResetFilters: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacingCommon)
+                .padding(bottom = spacingLarge),
+            verticalArrangement = Arrangement.spacedBy(spacingCommon),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(Res.string.title_filter_creatures),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                TextButton(onClick = onResetFilters) {
+                    Text(text = stringResource(Res.string.btn_reset_all))
+                }
+            }
+
+            // Type
+            Text(
+                text = stringResource(Res.string.label_filter_type),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                Creature.Type.entries.forEach { type ->
+                    FilterChip(
+                        selected = type in filter.types,
+                        onClick = { onTypeToggled(type) },
+                        label = { Text(text = type.toFormattedString()) },
+                    )
+                }
+            }
+
+            // Challenge Rating
+            Text(
+                text = stringResource(Res.string.label_filter_cr),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                commonCRs.forEach { cr ->
+                    val crLabel = formatCRValue(cr)
+                    FilterChip(
+                        selected = cr in filter.challengeRatings,
+                        onClick = { onChallengeRatingToggled(cr) },
+                        label = { Text(text = crLabel) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureFilterBottomSheetLight() {
+    val sampleFilter = CreatureFilter(
+        types = setOf(Creature.Type.DRAGON),
+        challengeRatings = setOf(10f),
+    )
+    AppThemePreview(darkTheme = false) {
+        CreatureFilterBottomSheet(sampleFilter, {}, {}, {}, {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureFilterBottomSheetDark() {
+    val sampleFilter = CreatureFilter(
+        types = setOf(Creature.Type.DRAGON),
+        challengeRatings = setOf(10f),
+    )
+    AppThemePreview(darkTheme = true) {
+        CreatureFilterBottomSheet(sampleFilter, {}, {}, {}, {})
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureFilterBottomSheet.kt
@@ -114,13 +114,14 @@ fun CreatureFilterBottomSheet(
     }
 }
 
+private val sampleFilter = CreatureFilter(
+    types = setOf(Creature.Type.DRAGON),
+    challengeRatings = setOf(10f),
+)
+
 @Preview
 @Composable
 private fun PreviewCreatureFilterBottomSheetLight() {
-    val sampleFilter = CreatureFilter(
-        types = setOf(Creature.Type.DRAGON),
-        challengeRatings = setOf(10f),
-    )
     AppThemePreview(darkTheme = false) {
         CreatureFilterBottomSheet(sampleFilter, {}, {}, {}, {})
     }
@@ -129,10 +130,6 @@ private fun PreviewCreatureFilterBottomSheetLight() {
 @Preview
 @Composable
 private fun PreviewCreatureFilterBottomSheetDark() {
-    val sampleFilter = CreatureFilter(
-        types = setOf(Creature.Type.DRAGON),
-        challengeRatings = setOf(10f),
-    )
     AppThemePreview(darkTheme = true) {
         CreatureFilterBottomSheet(sampleFilter, {}, {}, {}, {})
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.EmptySearch
@@ -34,16 +37,24 @@ fun CreatureListScreen(viewModel: CreatureListViewModel) {
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onCreatureClicked = viewModel::onCreatureClicked,
+        onTypeToggled = viewModel::onTypeToggled,
+        onChallengeRatingToggled = viewModel::onChallengeRatingToggled,
+        onResetFilters = viewModel::onResetFilters,
     )
 }
 
 @Composable
 fun CreatureListScreen(
     state: CreatureListState,
+    onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onCreatureClicked: (Creature) -> Unit,
-    onNavigateUpClicked: () -> Unit,
+    onTypeToggled: (Creature.Type) -> Unit,
+    onChallengeRatingToggled: (Float) -> Unit,
+    onResetFilters: () -> Unit,
 ) {
+    var showFilterSheet by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             SearchBarWithBack(
@@ -51,6 +62,8 @@ fun CreatureListScreen(
                 query = state.filter.query,
                 onQueryChanged = onSearchQueryChanged,
                 onNavigateUpClicked = onNavigateUpClicked,
+                onFilterClicked = { showFilterSheet = true },
+                hasActiveFilters = state.filter.hasActiveFilters,
             )
         },
     ) { paddingValues ->
@@ -62,6 +75,16 @@ fun CreatureListScreen(
                 is CreatureListState.Body.WithData -> CreatureList(body.searchResults, onCreatureClicked)
             }
         }
+    }
+
+    if (showFilterSheet) {
+        CreatureFilterBottomSheet(
+            filter = state.filter,
+            onTypeToggled = onTypeToggled,
+            onChallengeRatingToggled = onChallengeRatingToggled,
+            onResetFilters = onResetFilters,
+            onDismiss = { showFilterSheet = false },
+        )
     }
 }
 
@@ -89,7 +112,7 @@ private val stateWithSampleData = CreatureListState(
 @Composable
 private fun PreviewCreatureListScreenLight() {
     AppThemePreview(darkTheme = false) {
-        CreatureListScreen(stateWithSampleData, {}, {}, {})
+        CreatureListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -97,6 +120,6 @@ private fun PreviewCreatureListScreenLight() {
 @Composable
 private fun PreviewCreatureListScreenDark() {
     AppThemePreview(darkTheme = true) {
-        CreatureListScreen(stateWithSampleData, {}, {}, {})
+        CreatureListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
     }
 }


### PR DESCRIPTION
## 📝 Description

Add a filter bottom sheet to both creature screens (compact list and full list), allowing users to filter by type and challenge rating.

- Add localized string resources for filter labels (en + fr) in `strings_creature.xml`
- Create `CreatureFilterBottomSheet` with type and CR filter chip sections
- Extract `formatCRValue()` helper for CR chip labels
- Wire filter button and bottom sheet into `CreatureCompactListScreen` and `CreatureListScreen`

## 🖼️ Media

New filter button
<img width="1016" height="132" alt="image" src="https://github.com/user-attachments/assets/0c622d70-5cd4-4d94-a621-05e37699fc2d" />

New filter screen
<img width="1026" height="1100" alt="image" src="https://github.com/user-attachments/assets/1d141c24-2a58-4fb7-aa7a-52f36739b7f8" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed