### PR TITLE
refactor(presentation): navigate by ID instead of serialized object

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="no_result_found">No results found.</string>
     <string name="no_result_found_for_query">No results found for '%1$s'.</string>
 
-    <string name="error_creature_not_found">Creature not found.</string>
-    <string name="error_spell_not_found">Spell not found.</string>
-    <string name="error_magical_item_not_found">Magical item not found.</string>
+    <string name="error_creature_not_found">Creature not found: %1$s</string>
+    <string name="error_spell_not_found">Spell not found: %1$s</string>
+    <string name="error_magical_item_not_found">Magical item not found: %1$s</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -41,4 +41,8 @@
 
     <string name="no_result_found">No results found.</string>
     <string name="no_result_found_for_query">No results found for '%1$s'.</string>
+
+    <string name="error_creature_not_found">Creature not found.</string>
+    <string name="error_spell_not_found">Spell not found.</string>
+    <string name="error_magical_item_not_found">Magical item not found.</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/state/DetailState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/state/DetailState.kt
@@ -3,5 +3,5 @@ package com.cyrillrx.rpg.core.presentation.state
 sealed interface DetailState<out T> {
     data object Loading : DetailState<Nothing>
     data class Found<T>(val item: T) : DetailState<T>
-    data object NotFound : DetailState<Nothing>
+    data class NotFound(val id: String) : DetailState<Nothing>
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/state/DetailState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/state/DetailState.kt
@@ -1,0 +1,7 @@
+package com.cyrillrx.rpg.core.presentation.state
+
+sealed interface DetailState<out T> {
+    data object Loading : DetailState<Nothing>
+    data class Found<T>(val item: T) : DetailState<T>
+    data object NotFound : DetailState<Nothing>
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/state/DetailState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/state/DetailState.kt
@@ -4,4 +4,8 @@ sealed interface DetailState<out T> {
     data object Loading : DetailState<Nothing>
     data class Found<T>(val item: T) : DetailState<T>
     data class NotFound(val id: String) : DetailState<Nothing>
+
+    companion object {
+        fun <T> of(id: String, item: T?): DetailState<T> = if (item == null) NotFound(id) else Found(item)
+    }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
@@ -17,6 +17,7 @@ import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_creature_not_found
 
@@ -28,7 +29,7 @@ fun CreatureDetailScreen(
     val state by viewModel.state.collectAsState()
     when (val s = state) {
         DetailState.Loading -> Loader()
-        DetailState.NotFound -> ErrorLayout(Res.string.error_creature_not_found)
+        is DetailState.NotFound -> ErrorLayout(stringResource(Res.string.error_creature_not_found, s.id))
         is DetailState.Found -> CreatureDetailScreen(s.item, onNavigateUpClicked)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
@@ -5,12 +5,33 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.error_creature_not_found
+
+@Composable
+fun CreatureDetailScreen(
+    viewModel: CreatureDetailViewModel,
+    onNavigateUpClicked: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+    when (val s = state) {
+        DetailState.Loading -> Loader()
+        DetailState.NotFound -> ErrorLayout(Res.string.error_creature_not_found)
+        is DetailState.Found -> CreatureDetailScreen(s.item, onNavigateUpClicked)
+    }
+}
 
 @Composable
 fun CreatureDetailScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -1,15 +1,18 @@
 package com.cyrillrx.rpg.creature.presentation.navigation
 
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureListScreen
+import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModel
+import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModelFactory
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModelFactory
 import kotlinx.serialization.Serializable
@@ -22,7 +25,7 @@ interface CreatureRoute {
     data object List
 
     @Serializable
-    data class Detail(val serializedCreature: String)
+    data class Detail(val creatureId: String)
 }
 
 fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repository: CreatureRepository) {
@@ -41,10 +44,13 @@ fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repositor
     }
 
     composable<CreatureRoute.Detail> { entry ->
-        val args = entry.toRoute<CreatureRoute.Detail>()
-        CreatureDetailScreen(
-            creature = args.serializedCreature.deserialize(),
-            onNavigateUpClicked = { navController.navigateUp() },
+        val id = entry.toRoute<CreatureRoute.Detail>().creatureId
+        val viewModel = viewModel<CreatureDetailViewModel>(
+            factory = CreatureDetailViewModelFactory(id, repository),
         )
+        val creature by viewModel.item.collectAsState()
+        creature?.let {
+            CreatureDetailScreen(it, onNavigateUpClicked = { navController.navigateUp() })
+        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -1,7 +1,5 @@
 package com.cyrillrx.rpg.creature.presentation.navigation
 
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -48,9 +46,6 @@ fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repositor
         val viewModel = viewModel<CreatureDetailViewModel>(
             factory = CreatureDetailViewModelFactory(id, repository),
         )
-        val creature by viewModel.item.collectAsState()
-        creature?.let {
-            CreatureDetailScreen(it, onNavigateUpClicked = { navController.navigateUp() })
-        }
+        CreatureDetailScreen(viewModel, onNavigateUpClicked = { navController.navigateUp() })
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -1,7 +1,6 @@
 package com.cyrillrx.rpg.creature.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.creature.domain.Creature
 
 interface CreatureRouter {
@@ -15,6 +14,6 @@ class CreatureRouterImpl(private val navController: NavController) : CreatureRou
     }
 
     override fun openCreatureDetail(creature: Creature) {
-        navController.navigate(CreatureRoute.Detail(creature.serialize()))
+        navController.navigate(CreatureRoute.Detail(creature.id))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,8 +17,11 @@ class CreatureDetailViewModel(
     creatureId: String,
     repository: CreatureRepository,
 ) : ViewModel() {
-    val item: StateFlow<Creature?> = flow { emit(repository.getById(creatureId)) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+    val state: StateFlow<DetailState<Creature>> = flow {
+        val item = repository.getById(creatureId)
+        val state = if (item == null) DetailState.NotFound else DetailState.Found(item)
+        emit(state)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }
 
 class CreatureDetailViewModelFactory(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
@@ -19,7 +19,7 @@ class CreatureDetailViewModel(
 ) : ViewModel() {
     val state: StateFlow<DetailState<Creature>> = flow {
         val item = repository.getById(creatureId)
-        val state = if (item == null) DetailState.NotFound else DetailState.Found(item)
+        val state = if (item == null) DetailState.NotFound(creatureId) else DetailState.Found(item)
         emit(state)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
@@ -19,8 +19,7 @@ class CreatureDetailViewModel(
 ) : ViewModel() {
     val state: StateFlow<DetailState<Creature>> = flow {
         val item = repository.getById(creatureId)
-        val state = if (item == null) DetailState.NotFound(creatureId) else DetailState.Found(item)
-        emit(state)
+        emit(DetailState.of(creatureId, item))
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
@@ -1,0 +1,31 @@
+package com.cyrillrx.rpg.creature.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlin.reflect.KClass
+
+class CreatureDetailViewModel(
+    creatureId: String,
+    repository: CreatureRepository,
+) : ViewModel() {
+    val item: StateFlow<Creature?> = flow { emit(repository.getById(creatureId)) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+}
+
+class CreatureDetailViewModelFactory(
+    private val creatureId: String,
+    private val repository: CreatureRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+        @Suppress("UNCHECKED_CAST")
+        return CreatureDetailViewModel(creatureId, repository) as T
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureDetailViewModel.kt
@@ -20,7 +20,7 @@ class CreatureDetailViewModel(
     val state: StateFlow<DetailState<Creature>> = flow {
         val item = repository.getById(creatureId)
         emit(DetailState.of(creatureId, item))
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000), DetailState.Loading)
 }
 
 class CreatureDetailViewModelFactory(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -42,8 +42,7 @@ class CreatureListViewModel(
     }
 
     fun onCreatureClicked(creature: Creature) {
-        // TODO : open detail
-        // router.openCreatureDetail(creature)
+        router.openCreatureDetail(creature)
     }
 
     fun onTypeToggled(type: Creature.Type) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -83,6 +83,6 @@ fun MagicalItemCard(
 @Preview
 @Composable
 private fun PreviewMagicalItemCard() {
-    val item = SampleMagicalItemsRepository().get()
+    val item = SampleMagicalItemRepository().get()
     MagicalItemCard(item)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
@@ -22,7 +22,7 @@ import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
-import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
@@ -116,7 +116,7 @@ private fun MagicalItemCardCarousel(
 }
 
 private val stateWithSampleData = MagicalItemListState(
-    body = MagicalItemListState.Body.WithData(SampleMagicalItemsRepository().getAll()),
+    body = MagicalItemListState.Body.WithData(SampleMagicalItemRepository().getAll()),
 )
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -27,6 +27,6 @@ fun MagicalItemCardScreen(
 @Preview
 @Composable
 fun PreviewMagicalItemCardScreen() {
-    val magicalItem = SampleMagicalItemsRepository().get()
+    val magicalItem = SampleMagicalItemRepository().get()
     MagicalItemCardScreen(magicalItem, {})
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardScreen.kt
@@ -4,10 +4,31 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.error_magical_item_not_found
+
+@Composable
+fun MagicalItemCardScreen(
+    viewModel: MagicalItemDetailViewModel,
+    onNavigateUpClicked: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+    when (val s = state) {
+        DetailState.Loading -> Loader()
+        DetailState.NotFound -> ErrorLayout(Res.string.error_magical_item_not_found)
+        is DetailState.Found -> MagicalItemCardScreen(s.item, onNavigateUpClicked)
+    }
+}
 
 @Composable
 fun MagicalItemCardScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardScreen.kt
@@ -14,6 +14,7 @@ import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_magical_item_not_found
 
@@ -25,7 +26,7 @@ fun MagicalItemCardScreen(
     val state by viewModel.state.collectAsState()
     when (val s = state) {
         DetailState.Loading -> Loader()
-        DetailState.NotFound -> ErrorLayout(Res.string.error_magical_item_not_found)
+        is DetailState.NotFound -> ErrorLayout(stringResource(Res.string.error_magical_item_not_found, s.id))
         is DetailState.Found -> MagicalItemCardScreen(s.item, onNavigateUpClicked)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
@@ -24,7 +24,7 @@ import com.cyrillrx.rpg.core.presentation.theme.borderWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
-import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -81,7 +81,7 @@ fun MagicalItemListItem(
 @Composable
 private fun PreviewMagicalItemListItemLight() {
     AppThemePreview(darkTheme = false) {
-        MagicalItemListItem(magicalItem = SampleMagicalItemsRepository().get(), onClick = {})
+        MagicalItemListItem(magicalItem = SampleMagicalItemRepository().get(), onClick = {})
     }
 }
 
@@ -89,6 +89,6 @@ private fun PreviewMagicalItemListItemLight() {
 @Composable
 private fun PreviewMagicalItemListItemDark() {
     AppThemePreview(darkTheme = true) {
-        MagicalItemListItem(magicalItem = SampleMagicalItemsRepository().get(), onClick = {})
+        MagicalItemListItem(magicalItem = SampleMagicalItemRepository().get(), onClick = {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -26,7 +26,7 @@ import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
-import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemsRepository
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
@@ -127,7 +127,7 @@ private fun MagicalItemList(
 }
 
 private val stateWithSampleData = MagicalItemListState(
-    body = MagicalItemListState.Body.WithData(SampleMagicalItemsRepository().getAll()),
+    body = MagicalItemListState.Body.WithData(SampleMagicalItemRepository().getAll()),
 )
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -1,7 +1,5 @@
 package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -52,9 +50,6 @@ fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileRe
         val viewModel = viewModel<MagicalItemDetailViewModel>(
             factory = MagicalItemDetailViewModelFactory(id, repository),
         )
-        val magicalItem by viewModel.item.collectAsState()
-        magicalItem?.let {
-            MagicalItemCardScreen(it, onNavigateUpClicked = { navController.navigateUp() })
-        }
+        MagicalItemCardScreen(viewModel, onNavigateUpClicked = { navController.navigateUp() })
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -1,16 +1,19 @@
 package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardCarouselScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListScreen
+import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModel
+import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModelFactory
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModelFactory
 import kotlinx.serialization.Serializable
@@ -23,7 +26,7 @@ interface MagicalItemRoute {
     data object CardCarousel
 
     @Serializable
-    data class Detail(val serializedItem: String)
+    data class Detail(val magicalItemId: String)
 }
 
 fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileReader: ComposeFileReader) {
@@ -44,10 +47,14 @@ fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileRe
     }
 
     composable<MagicalItemRoute.Detail> { entry ->
-        val args = entry.toRoute<MagicalItemRoute.Detail>()
-        MagicalItemCardScreen(
-            magicalItem = args.serializedItem.deserialize(),
-            onNavigateUpClicked = { navController.navigateUp() },
+        val id = entry.toRoute<MagicalItemRoute.Detail>().magicalItemId
+        val repository = JsonMagicalItemRepository(fileReader)
+        val viewModel = viewModel<MagicalItemDetailViewModel>(
+            factory = MagicalItemDetailViewModelFactory(id, repository),
         )
+        val magicalItem by viewModel.item.collectAsState()
+        magicalItem?.let {
+            MagicalItemCardScreen(it, onNavigateUpClicked = { navController.navigateUp() })
+        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
@@ -1,7 +1,6 @@
 package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 
 interface MagicalItemRouter {
@@ -15,6 +14,6 @@ class MagicalItemRouterImpl(private val navController: NavController) : MagicalI
     }
 
     override fun openMagicalItemDetail(magicalItem: MagicalItem) {
-        navController.navigate(MagicalItemRoute.Detail(magicalItem.serialize()))
+        navController.navigate(MagicalItemRoute.Detail(magicalItem.id))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,8 +17,11 @@ class MagicalItemDetailViewModel(
     magicalItemId: String,
     repository: MagicalItemRepository,
 ) : ViewModel() {
-    val item: StateFlow<MagicalItem?> = flow { emit(repository.getById(magicalItemId)) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+    val state: StateFlow<DetailState<MagicalItem>> = flow {
+        val item = repository.getById(magicalItemId)
+        val state = if (item == null) DetailState.NotFound else DetailState.Found(item)
+        emit(state)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }
 
 class MagicalItemDetailViewModelFactory(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
@@ -1,0 +1,31 @@
+package com.cyrillrx.rpg.magicalitem.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlin.reflect.KClass
+
+class MagicalItemDetailViewModel(
+    magicalItemId: String,
+    repository: MagicalItemRepository,
+) : ViewModel() {
+    val item: StateFlow<MagicalItem?> = flow { emit(repository.getById(magicalItemId)) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+}
+
+class MagicalItemDetailViewModelFactory(
+    private val magicalItemId: String,
+    private val repository: MagicalItemRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+        @Suppress("UNCHECKED_CAST")
+        return MagicalItemDetailViewModel(magicalItemId, repository) as T
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
@@ -19,8 +19,7 @@ class MagicalItemDetailViewModel(
 ) : ViewModel() {
     val state: StateFlow<DetailState<MagicalItem>> = flow {
         val item = repository.getById(magicalItemId)
-        val state = if (item == null) DetailState.NotFound(magicalItemId) else DetailState.Found(item)
-        emit(state)
+        emit(DetailState.of(magicalItemId, item))
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
@@ -19,7 +19,7 @@ class MagicalItemDetailViewModel(
 ) : ViewModel() {
     val state: StateFlow<DetailState<MagicalItem>> = flow {
         val item = repository.getById(magicalItemId)
-        val state = if (item == null) DetailState.NotFound else DetailState.Found(item)
+        val state = if (item == null) DetailState.NotFound(magicalItemId) else DetailState.Found(item)
         emit(state)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModel.kt
@@ -20,7 +20,7 @@ class MagicalItemDetailViewModel(
     val state: StateFlow<DetailState<MagicalItem>> = flow {
         val item = repository.getById(magicalItemId)
         emit(DetailState.of(magicalItemId, item))
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000), DetailState.Loading)
 }
 
 class MagicalItemDetailViewModelFactory(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
@@ -14,6 +14,7 @@ import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_spell_not_found
 
@@ -25,7 +26,7 @@ fun SpellCardScreen(
     val state by viewModel.state.collectAsState()
     when (val s = state) {
         DetailState.Loading -> Loader()
-        DetailState.NotFound -> ErrorLayout(Res.string.error_spell_not_found)
+        is DetailState.NotFound -> ErrorLayout(stringResource(Res.string.error_spell_not_found, s.id))
         is DetailState.Found -> SpellCardScreen(s.item, onNavigateUpClicked)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
@@ -4,10 +4,31 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.domain.Spell
+import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.error_spell_not_found
+
+@Composable
+fun SpellCardScreen(
+    viewModel: SpellDetailViewModel,
+    onNavigateUpClicked: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+    when (val s = state) {
+        DetailState.Loading -> Loader()
+        DetailState.NotFound -> ErrorLayout(Res.string.error_spell_not_found)
+        is DetailState.Found -> SpellCardScreen(s.item, onNavigateUpClicked)
+    }
+}
 
 @Composable
 fun SpellCardScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -2,8 +2,6 @@ package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -57,9 +55,6 @@ fun NavGraphBuilder.handleSpellRoutes(navController: NavController, fileReader: 
         val viewModel = viewModel<SpellDetailViewModel>(
             factory = SpellDetailViewModelFactory(id, repository),
         )
-        val spell by viewModel.item.collectAsState()
-        spell?.let {
-            SpellCardScreen(it, onNavigateUpClicked = { navController.navigateUp() })
-        }
+        SpellCardScreen(viewModel, onNavigateUpClicked = { navController.navigateUp() })
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -2,12 +2,13 @@ package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.spell.data.JsonSpellRepository
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardCarouselScreen
@@ -15,6 +16,8 @@ import com.cyrillrx.rpg.spell.presentation.component.SpellCardScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellListScreen
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellBookViewModel
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellBookViewModelFactory
+import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
+import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModelFactory
 import kotlinx.serialization.Serializable
 
 interface SpellRoute {
@@ -25,7 +28,7 @@ interface SpellRoute {
     data object CardCarousel
 
     @Serializable
-    data class Detail(val serializedSpell: String)
+    data class Detail(val spellId: String)
 }
 
 fun NavGraphBuilder.handleSpellRoutes(navController: NavController, fileReader: ComposeFileReader) {
@@ -49,10 +52,14 @@ fun NavGraphBuilder.handleSpellRoutes(navController: NavController, fileReader: 
     }
 
     composable<SpellRoute.Detail> { entry ->
-        val args = entry.toRoute<SpellRoute.Detail>()
-        SpellCardScreen(
-            spell = args.serializedSpell.deserialize(),
-            onNavigateUpClicked = { navController.navigateUp() },
+        val id = entry.toRoute<SpellRoute.Detail>().spellId
+        val repository = JsonSpellRepository(fileReader)
+        val viewModel = viewModel<SpellDetailViewModel>(
+            factory = SpellDetailViewModelFactory(id, repository),
         )
+        val spell by viewModel.item.collectAsState()
+        spell?.let {
+            SpellCardScreen(it, onNavigateUpClicked = { navController.navigateUp() })
+        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
@@ -1,7 +1,6 @@
 package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.spell.domain.Spell
 
 interface SpellRouter {
@@ -15,6 +14,6 @@ class SpellRouterImpl(private val navController: NavController) : SpellRouter {
     }
 
     override fun openSpellDetail(spell: Spell) {
-        navController.navigate(SpellRoute.Detail(spell.serialize()))
+        navController.navigate(SpellRoute.Detail(spell.id))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
@@ -19,8 +19,7 @@ class SpellDetailViewModel(
 ) : ViewModel() {
     val state: StateFlow<DetailState<Spell>> = flow {
         val item = repository.getById(spellId)
-        val state = if (item == null) DetailState.NotFound(spellId) else DetailState.Found(item)
-        emit(state)
+        emit(DetailState.of(spellId, item))
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
@@ -1,0 +1,31 @@
+package com.cyrillrx.rpg.spell.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.spell.domain.Spell
+import com.cyrillrx.rpg.spell.domain.SpellRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlin.reflect.KClass
+
+class SpellDetailViewModel(
+    spellId: String,
+    repository: SpellRepository,
+) : ViewModel() {
+    val item: StateFlow<Spell?> = flow { emit(repository.getById(spellId)) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+}
+
+class SpellDetailViewModelFactory(
+    private val spellId: String,
+    private val repository: SpellRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+        @Suppress("UNCHECKED_CAST")
+        return SpellDetailViewModel(spellId, repository) as T
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
@@ -19,7 +19,7 @@ class SpellDetailViewModel(
 ) : ViewModel() {
     val state: StateFlow<DetailState<Spell>> = flow {
         val item = repository.getById(spellId)
-        val state = if (item == null) DetailState.NotFound else DetailState.Found(item)
+        val state = if (item == null) DetailState.NotFound(spellId) else DetailState.Found(item)
         emit(state)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
@@ -20,7 +20,7 @@ class SpellDetailViewModel(
     val state: StateFlow<DetailState<Spell>> = flow {
         val item = repository.getById(spellId)
         emit(DetailState.of(spellId, item))
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000), DetailState.Loading)
 }
 
 class SpellDetailViewModelFactory(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellRepository
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,8 +17,11 @@ class SpellDetailViewModel(
     spellId: String,
     repository: SpellRepository,
 ) : ViewModel() {
-    val item: StateFlow<Spell?> = flow { emit(repository.getById(spellId)) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+    val state: StateFlow<DetailState<Spell>> = flow {
+        val item = repository.getById(spellId)
+        val state = if (item == null) DetailState.NotFound else DetailState.Found(item)
+        emit(state)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DetailState.Loading)
 }
 
 class SpellDetailViewModelFactory(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
@@ -23,6 +23,9 @@ class JsonCreatureRepository(private val fileReader: FileReader) : CreatureRepos
         return allCreatures.filter(filter::matches)
     }
 
+    override suspend fun getById(id: String): Creature? =
+        getAll(null).firstOrNull { it.id == id }
+
     private suspend fun loadFromFile(): List<ApiBestiaryItem> {
         val result = fileReader.readFile("files/bestiaire.json")
         if (result is Result.Success) {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
@@ -134,4 +134,6 @@ class SampleCreatureRepository {
     )
 
     fun get(): Creature = getAll().first()
+
+    fun getById(id: String): Creature? = getAll().firstOrNull { it.id == id }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureRepository.kt
@@ -2,4 +2,5 @@ package com.cyrillrx.rpg.creature.domain
 
 interface CreatureRepository {
     suspend fun getAll(filter: CreatureFilter?): List<Creature>
+    suspend fun getById(id: String): Creature?
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -19,6 +19,9 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
         return allItems.filter(filter::matches)
     }
 
+    override suspend fun getById(id: String): MagicalItem? =
+        getAll(null).firstOrNull { it.id == id }
+
     private suspend fun loadFromFile(): List<ApiInventoryItem> {
         val result = fileReader.readFile("files/objets-magiques.json")
         if (result is Result.Success) {
@@ -30,6 +33,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     companion object {
         private fun ApiInventoryItem.toMagicalItem(): MagicalItem {
             return MagicalItem(
+                id = title,
                 title = title,
                 subtitle = getSubtitle(),
                 description = content,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
@@ -2,7 +2,7 @@ package com.cyrillrx.rpg.magicalitem.data
 
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 
-class SampleMagicalItemsRepository {
+class SampleMagicalItemRepository {
     fun getAll(): List<MagicalItem> = listOf(
         MagicalItem(
             id = "Hache du serment",

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemsRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemsRepository.kt
@@ -5,6 +5,7 @@ import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 class SampleMagicalItemsRepository {
     fun getAll(): List<MagicalItem> = listOf(
         MagicalItem(
+            id = "Hache du serment",
             title = "Hache du serment",
             subtitle = "Arme (hache d'arme), unique (harmonisation exigée)",
             description = "Lorsque vous faites une attaque au corps à corps avec cette arme, vous pouvez prononcer son mot de commande. La cible de votre attaque devient votre ennemi juré.",
@@ -13,6 +14,7 @@ class SampleMagicalItemsRepository {
             attunement = true,
         ),
         MagicalItem(
+            id = "Cape de protection",
             title = "Cape de protection",
             subtitle = "Objet merveilleux, peu commun (harmonisation exigée)",
             description = "Vous obtenez un bonus de +1 à la CA et aux jets de sauvegarde tant que vous portez cette cape.",
@@ -21,6 +23,7 @@ class SampleMagicalItemsRepository {
             attunement = true,
         ),
         MagicalItem(
+            id = "Potion de soins",
             title = "Potion de soins",
             subtitle = "Potion, commune",
             description = "Vous regagnez 2d4 + 2 points de vie lorsque vous buvez cette potion.",
@@ -29,6 +32,7 @@ class SampleMagicalItemsRepository {
             attunement = false,
         ),
         MagicalItem(
+            id = "Bouclier +1",
             title = "Bouclier +1",
             subtitle = "Armure (bouclier), peu commun",
             description = "Lorsque vous tenez ce bouclier, vous obtenez un bonus de +1 à la CA en plus du bonus normal du bouclier.",
@@ -37,6 +41,7 @@ class SampleMagicalItemsRepository {
             attunement = false,
         ),
         MagicalItem(
+            id = "Baguette de boules de feu",
             title = "Baguette de boules de feu",
             subtitle = "Baguette, rare (harmonisation exigée par un lanceur de sorts)",
             description = "Cette baguette a 7 charges. En tenant la baguette, vous pouvez utiliser une action pour dépenser 1 ou plusieurs charges et lancer le sort boule de feu.",
@@ -45,6 +50,7 @@ class SampleMagicalItemsRepository {
             attunement = true,
         ),
         MagicalItem(
+            id = "Anneau de protection",
             title = "Anneau de protection",
             subtitle = "Anneau, rare (harmonisation exigée)",
             description = "Vous obtenez un bonus de +1 à la CA et aux jets de sauvegarde tant que vous portez cet anneau.",
@@ -53,6 +59,7 @@ class SampleMagicalItemsRepository {
             attunement = true,
         ),
         MagicalItem(
+            id = "Parchemin de boule de feu",
             title = "Parchemin de boule de feu",
             subtitle = "Parchemin, peu commun",
             description = "Un sort de boule de feu est inscrit sur ce parchemin. Si le sort figure dans votre liste de sorts, vous pouvez le lancer.",
@@ -61,6 +68,7 @@ class SampleMagicalItemsRepository {
             attunement = false,
         ),
         MagicalItem(
+            id = "Bâton de pouvoir",
             title = "Bâton de pouvoir",
             subtitle = "Bâton, très rare (harmonisation exigée par un lanceur de sorts)",
             description = "Ce bâton confère un bonus de +2 aux jets d'attaque et de dégâts des attaques au corps à corps effectuées avec lui.",
@@ -71,4 +79,6 @@ class SampleMagicalItemsRepository {
     )
 
     fun get(): MagicalItem = getAll().first()
+
+    fun getById(id: String): MagicalItem? = getAll().firstOrNull { it.id == id }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 class MagicalItem(
+    val id: String,
     val title: String,
     val subtitle: String,
     val description: String,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemRepository.kt
@@ -2,4 +2,5 @@ package com.cyrillrx.rpg.magicalitem.domain
 
 interface MagicalItemRepository {
     suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem>
+    suspend fun getById(id: String): MagicalItem?
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -21,6 +21,9 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
         return allSpells.filter(filter::matches)
     }
 
+    override suspend fun getById(id: String): Spell? =
+        getAll(null).firstOrNull { it.id == id }
+
     private suspend fun loadFromFile(): List<ApiSpell> {
         val result = fileReader.readFile("files/grimoire.json")
         if (result is Result.Success) {
@@ -32,6 +35,7 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
     companion object {
         private fun ApiSpell.toSpell(): Spell {
             return Spell(
+                id = title.orEmpty(),
                 title = title.orEmpty(),
                 description = content.orEmpty(),
                 level = level ?: 0,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
@@ -14,8 +14,11 @@ class SampleSpellRepository {
 
     fun get(): Spell = fireball()
 
+    fun getById(id: String): Spell? = getAll().firstOrNull { it.id == id }
+
     companion object {
         private fun fireball() = Spell(
+            id = "Fireball",
             title = "Fireball",
             description = "A bright streak flashes from your pointing finger to a point you choose within range and then blossoms with a low roar into an explosion of flame.",
             level = 3,
@@ -31,6 +34,7 @@ class SampleSpellRepository {
         )
 
         private fun mageArmor() = Spell(
+            id = "Mage Armor",
             title = "Mage Armor",
             description = "You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends.",
             level = 1,
@@ -43,6 +47,7 @@ class SampleSpellRepository {
         )
 
         private fun detectThoughts() = Spell(
+            id = "Detect Thoughts",
             title = "Detect Thoughts",
             description = "For the duration, you can read the thoughts of certain creatures.",
             level = 2,
@@ -58,6 +63,7 @@ class SampleSpellRepository {
         )
 
         private fun thunderwave() = Spell(
+            id = "Thunderwave",
             title = "Thunderwave",
             description = "A wave of thunderous force sweeps out from you.",
             level = 1,
@@ -74,6 +80,7 @@ class SampleSpellRepository {
         )
 
         private fun counterspell() = Spell(
+            id = "Counterspell",
             title = "Counterspell",
             description = "You attempt to interrupt a creature in the process of casting a spell.",
             level = 3,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 class Spell(
+    val id: String,
     val title: String,
     val description: String,
     val level: Int,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellRepository.kt
@@ -2,4 +2,5 @@ package com.cyrillrx.rpg.spell.domain
 
 interface SpellRepository {
     suspend fun getAll(filter: SpellFilter?): List<Spell>
+    suspend fun getById(id: String): Spell?
 }


### PR DESCRIPTION
## 📝 Description

Refactor navigation for spell, creature, and magical item detail screens to pass IDs instead of serialized objects. Also improves the `NotFound` error state to include the searched ID for better debuggability.

- Navigate by ID in `SpellRoute`, `CreatureRoute`, `MagicalItemRoute` (replace serialized object with plain string ID)
- Add `getById` to `SpellRepository`, `CreatureRepository`, `MagicalItemRepository` and their implementations
- Add `SpellDetailViewModel`, `CreatureDetailViewModel`, `MagicalItemDetailViewModel` to handle async lookup by ID
- Encapsulate `DetailState` handling in detail screens via `when` on `DetailState.Loading / NotFound / Found`

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed