### PR TITLE
refactor(compose-app): inject repositories into handle*Routes() functions in App.kt

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -6,6 +6,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.cyrillrx.rpg.campaign.navigation.handleCampaignRoutes
 import com.cyrillrx.rpg.character.presentation.navigation.handlePlayerCharacterRoutes
+import com.cyrillrx.rpg.campaign.data.SQLDelightCampaignRepository
+import com.cyrillrx.rpg.character.data.RamPlayerCharacterRepository
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
 import com.cyrillrx.rpg.core.presentation.theme.AppTheme
@@ -13,7 +15,9 @@ import com.cyrillrx.rpg.creature.data.JsonCreatureRepository
 import com.cyrillrx.rpg.creature.presentation.navigation.handleCreatureRoutes
 import com.cyrillrx.rpg.home.presentation.HomeScreen
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouterImpl
+import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.handleMagicalItemRoutes
+import com.cyrillrx.rpg.spell.data.JsonSpellRepository
 import com.cyrillrx.rpg.spell.presentation.navigation.handleSpellRoutes
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -32,11 +36,11 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
             val homeRouter = HomeRouterImpl(navController)
             composable<MainRoute.Home> { HomeScreen(homeRouter) }
 
-            handleCampaignRoutes(navController, dbDriverFactory)
-            handlePlayerCharacterRoutes(navController)
+            handleCampaignRoutes(navController, SQLDelightCampaignRepository(dbDriverFactory))
+            handlePlayerCharacterRoutes(navController, RamPlayerCharacterRepository())
 
-            handleSpellRoutes(navController, fileReader)
-            handleMagicalItemRoutes(navController, fileReader)
+            handleSpellRoutes(navController, JsonSpellRepository(fileReader))
+            handleMagicalItemRoutes(navController, JsonMagicalItemRepository(fileReader))
             handleCreatureRoutes(navController, JsonCreatureRepository(fileReader))
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
@@ -9,12 +9,11 @@ import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.campaign.create.CreateCampaignScreen
 import com.cyrillrx.rpg.campaign.create.viewmodel.CreateCampaignViewModel
 import com.cyrillrx.rpg.campaign.create.viewmodel.CreateCampaignViewModelFactory
-import com.cyrillrx.rpg.campaign.data.SQLDelightCampaignRepository
+import com.cyrillrx.rpg.campaign.domain.CampaignRepository
 import com.cyrillrx.rpg.campaign.detail.CampaignDetailScreen
 import com.cyrillrx.rpg.campaign.list.CampaignListScreen
 import com.cyrillrx.rpg.campaign.list.viewmodel.CampaignListViewModel
 import com.cyrillrx.rpg.campaign.list.viewmodel.CampaignListViewModelFactory
-import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
 import kotlinx.serialization.Serializable
 
 interface CampaignRoute {
@@ -28,9 +27,8 @@ interface CampaignRoute {
     data object Create
 }
 
-fun NavGraphBuilder.handleCampaignRoutes(navController: NavController, dbDriverFactory: DatabaseDriverFactory) {
+fun NavGraphBuilder.handleCampaignRoutes(navController: NavController, repository: CampaignRepository) {
     val router = CampaignRouterImpl(navController)
-    val repository = SQLDelightCampaignRepository(dbDriverFactory)
 
     composable<CampaignRoute.List> {
         val viewModelFactory = CampaignListViewModelFactory(router, repository)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.cyrillrx.core.data.deserialize
-import com.cyrillrx.rpg.character.data.RamPlayerCharacterRepository
+import com.cyrillrx.rpg.character.domain.PlayerCharacterRepository
 import com.cyrillrx.rpg.character.presentation.component.CreatePlayerCharacterScreen
 import com.cyrillrx.rpg.character.presentation.component.PlayerCharacterDetailScreen
 import com.cyrillrx.rpg.character.presentation.component.PlayerCharacterListScreen
@@ -25,10 +25,9 @@ interface PlayerCharacterRoute {
     data object Create
 }
 
-fun NavGraphBuilder.handlePlayerCharacterRoutes(navController: NavController) {
+fun NavGraphBuilder.handlePlayerCharacterRoutes(navController: NavController, repository: PlayerCharacterRepository) {
     composable<PlayerCharacterRoute.List> {
         val router = PlayerCharacterRouterImpl(navController)
-        val repository = RamPlayerCharacterRepository()
         val viewModelFactory = PlayerCharacterListViewModelFactory(router, repository)
         val viewModel = viewModel<PlayerCharacterListViewModel>(factory = viewModelFactory)
         PlayerCharacterListScreen(viewModel)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -5,8 +5,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.cyrillrx.rpg.core.data.ComposeFileReader
-import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardCarouselScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListScreen
@@ -27,10 +26,9 @@ interface MagicalItemRoute {
     data class Detail(val magicalItemId: String)
 }
 
-fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileReader: ComposeFileReader) {
+fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, repository: MagicalItemRepository) {
     composable<MagicalItemRoute.List> {
         val router = MagicalItemRouterImpl(navController)
-        val repository = JsonMagicalItemRepository(fileReader)
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
         MagicalItemListScreen(viewModel)
@@ -38,7 +36,6 @@ fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileRe
 
     composable<MagicalItemRoute.CardCarousel> {
         val router = MagicalItemRouterImpl(navController)
-        val repository = JsonMagicalItemRepository(fileReader)
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
         MagicalItemCardCarouselScreen(viewModel)
@@ -46,7 +43,6 @@ fun NavGraphBuilder.handleMagicalItemRoutes(navController: NavController, fileRe
 
     composable<MagicalItemRoute.Detail> { entry ->
         val id = entry.toRoute<MagicalItemRoute.Detail>().magicalItemId
-        val repository = JsonMagicalItemRepository(fileReader)
         val viewModel = viewModel<MagicalItemDetailViewModel>(
             factory = MagicalItemDetailViewModelFactory(id, repository),
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -7,8 +7,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.cyrillrx.rpg.core.data.ComposeFileReader
-import com.cyrillrx.rpg.spell.data.JsonSpellRepository
+import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardCarouselScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellListScreen
@@ -29,13 +28,12 @@ interface SpellRoute {
     data class Detail(val spellId: String)
 }
 
-fun NavGraphBuilder.handleSpellRoutes(navController: NavController, fileReader: ComposeFileReader) {
+fun NavGraphBuilder.handleSpellRoutes(navController: NavController, repository: SpellRepository) {
     composable<SpellRoute.List>(
         enterTransition = { slideInHorizontally { initialOffset -> initialOffset } },
         exitTransition = { slideOutHorizontally { initialOffset -> initialOffset } },
     ) {
         val router = SpellRouterImpl(navController)
-        val repository = JsonSpellRepository(fileReader)
         val viewModelFactory = SpellBookViewModelFactory(router, repository)
         val viewModel = viewModel<SpellBookViewModel>(factory = viewModelFactory)
         SpellListScreen(viewModel, router)
@@ -43,7 +41,6 @@ fun NavGraphBuilder.handleSpellRoutes(navController: NavController, fileReader: 
 
     composable<SpellRoute.CardCarousel> {
         val router = SpellRouterImpl(navController)
-        val repository = JsonSpellRepository(fileReader)
         val viewModelFactory = SpellBookViewModelFactory(router, repository)
         val viewModel = viewModel<SpellBookViewModel>(factory = viewModelFactory)
         SpellCardCarouselScreen(viewModel, router)
@@ -51,7 +48,6 @@ fun NavGraphBuilder.handleSpellRoutes(navController: NavController, fileReader: 
 
     composable<SpellRoute.Detail> { entry ->
         val id = entry.toRoute<SpellRoute.Detail>().spellId
-        val repository = JsonSpellRepository(fileReader)
         val viewModel = viewModel<SpellDetailViewModel>(
             factory = SpellDetailViewModelFactory(id, repository),
         )


### PR DESCRIPTION
## 📝 Description

Align all `handle*Routes` function signatures to receive a repository interface instead of creating it internally. Repositories are now instantiated in `App.kt` and injected, following the pattern already used by `handleCreatureRoutes`.

This decouples navigation from concrete repository implementations and makes the DI pattern consistent across all features.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed