### PR TITLE
docs(roadmap): add ROADMAP link to README and mark bestiary filters as complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A digital toolkit for tabletop role-playing game sessions. Designed for Game Mas
 | Document                                 | Description                                      |
 |------------------------------------------|--------------------------------------------------|
 | [`AGENTS.md`](AGENTS.md)                 | Central contributor guide — start here           |
+| [`docs/ROADMAP.md`](docs/ROADMAP.md)     | Planned phases and feature progress              |
 | [`docs/conventions/`](docs/conventions/) | Coding, Git, and technology-specific conventions |
 | [`docs/prd/`](docs/prd/)                 | Product Requirement Documents                    |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@ For detailed feature specifications, see the [PRDs](prd/).
 
 - [x] Complete Spellbook filters (school, class) - [PRD-001a](prd/PRD-001a-SPELLBOOK.md)
 - [x] Complete Inventory filters (type, rarity) - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
-- [ ] Complete Bestiary filters (type, CR) - [PRD-001c](prd/PRD-001c-BESTIARY.md)
+- [x] Complete Bestiary filters (type, CR) - [PRD-001c](prd/PRD-001c-BESTIARY.md)
 
 ## Phase 3 - Local Lists
 

--- a/docs/prd/PRD-001c-BESTIARY.md
+++ b/docs/prd/PRD-001c-BESTIARY.md
@@ -26,7 +26,7 @@ Refer to [PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md) for the shared 
 - [x] Display a scrollable list of all monsters from the local seed database.
 - [x] Full-text search on name and description.
 - [x] Filter by monster type and CR.
-- [ ] View monster detail: name, type, size, alignment, AC, HP, speed, ability scores, skills, senses, languages, CR, traits, actions, reactions, legendary actions.
+- [x] View monster detail: name, type, size, alignment, AC, HP, speed, ability scores, skills, senses, languages, CR, traits, actions, reactions, legendary actions.
 
 ### Phase 2 — Local Lists
 

--- a/docs/prd/PRD-001c-BESTIARY.md
+++ b/docs/prd/PRD-001c-BESTIARY.md
@@ -25,7 +25,7 @@ Refer to [PRD-001 — Reference Data](PRD-001-REFERENCE-DATA.md) for the shared 
 
 - [x] Display a scrollable list of all monsters from the local seed database.
 - [x] Full-text search on name and description.
-- [ ] Filter by monster type and CR.
+- [x] Filter by monster type and CR.
 - [ ] View monster detail: name, type, size, alignment, AC, HP, speed, ability scores, skills, senses, languages, CR, traits, actions, reactions, legendary actions.
 
 ### Phase 2 — Local Lists


### PR DESCRIPTION
## 📝 Description

- Added a `ROADMAP.md` row to the Documentation table in `README.md` so the roadmap is discoverable from the project root.
- Marked the Bestiary filters (type, CR) task as complete in `docs/ROADMAP.md`
- Updated `docs/prd/PRD-001c-BESTIARY.md` to mark filter by type/CR and monster detail view as complete, keeping the PRD in sync with the ROADMAP.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed