### PR TITLE
test(spell): add spell domain and ViewModel tests

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellBookViewModelTest.kt
@@ -1,0 +1,209 @@
+package com.cyrillrx.rpg.spell.presentation.viewmodel
+
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.spell.data.SampleSpellRepository
+import com.cyrillrx.rpg.spell.domain.Spell
+import com.cyrillrx.rpg.spell.domain.SpellFilter
+import com.cyrillrx.rpg.spell.domain.SpellRepository
+import com.cyrillrx.rpg.spell.presentation.SpellListState
+import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SpellBookViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = SampleSpellRepository()
+    private val spell = SampleSpellRepository.getFirst()
+    private val router = NoOpSpellRouter()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state loads all spells`() = runTest(testDispatcher) {
+        val viewModel = SpellBookViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val body = assertIs<SpellListState.Body.WithData>(state.body)
+        assertEquals(expected = 5, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `onSchoolToggled filters spells by school`() = runTest(testDispatcher) {
+        val viewModel = SpellBookViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onSchoolToggled(Spell.School.EVOCATION)
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertTrue(state.filter.schools.contains(Spell.School.EVOCATION))
+        val body = assertIs<SpellListState.Body.WithData>(state.body)
+        assertEquals(expected = 2, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `onLevelToggled filters spells by level`() = runTest(testDispatcher) {
+        val viewModel = SpellBookViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onLevelToggled(3)
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val body = assertIs<SpellListState.Body.WithData>(state.body)
+        assertEquals(expected = 2, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `onClassToggled filters spells by class`() = runTest(testDispatcher) {
+        val viewModel = SpellBookViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onClassToggled(PlayerCharacter.Class.BARD)
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val body = assertIs<SpellListState.Body.WithData>(state.body)
+        assertEquals(expected = 1, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `onSearchQueryChanged filters spells by title`() = runTest(testDispatcher) {
+        val viewModel = SpellBookViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged(spell.title)
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val body = assertIs<SpellListState.Body.WithData>(state.body)
+        assertEquals(expected = 1, actual = body.searchResults.size)
+        assertEquals(expected = spell.title, actual = body.searchResults.first().title)
+    }
+
+    @Test
+    fun `onResetFilters clears active filters`() = runTest(testDispatcher) {
+        val viewModel = SpellBookViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onSchoolToggled(Spell.School.EVOCATION)
+
+        advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.filter.hasActiveFilters)
+
+        viewModel.onResetFilters()
+
+        advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.filter.hasActiveFilters)
+        assertEquals(expected = SpellFilter(), actual = viewModel.state.value.filter)
+        val body = assertIs<SpellListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(expected = 5, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `state is Empty when no spells match filter`() = runTest(testDispatcher) {
+        val viewModel = SpellBookViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged("no_match")
+
+        advanceUntilIdle()
+
+        assertIs<SpellListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `state is Error when repository throws`() = runTest(testDispatcher) {
+        val failingRepository = FailingSpellRepository()
+        val viewModel = SpellBookViewModel(router, failingRepository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<SpellListState.Body.Error>(viewModel.state.value.body)
+    }
+}
+
+private class NoOpSpellRouter : SpellRouter {
+    override fun navigateUp() = Unit
+    override fun openSpellDetail(spell: Spell) = Unit
+}
+
+private class FailingSpellRepository : SpellRepository {
+    override suspend fun getAll(filter: SpellFilter?): List<Spell> {
+        throw RuntimeException("Simulated repository error")
+    }
+
+    override suspend fun getById(id: String): Spell? {
+        throw RuntimeException("Simulated repository error")
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellDetailViewModelTest.kt
@@ -1,0 +1,75 @@
+package com.cyrillrx.rpg.spell.presentation.viewmodel
+
+import com.cyrillrx.rpg.core.presentation.state.DetailState
+import com.cyrillrx.rpg.spell.data.SampleSpellRepository
+import com.cyrillrx.rpg.spell.domain.Spell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SpellDetailViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = SampleSpellRepository()
+    private val spell = SampleSpellRepository.getFirst()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `state is Loading initially`() = runTest(testDispatcher) {
+        val viewModel = SpellDetailViewModel(spell.id, repository)
+
+        assertEquals(expected = DetailState.Loading, actual = viewModel.state.value)
+    }
+
+    @Test
+    fun `state is NotFound if spell not found`() = runTest(testDispatcher) {
+        val viewModel = SpellDetailViewModel("no_match", repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertIs<DetailState.NotFound>(state)
+        assertEquals(expected = DetailState.NotFound("no_match"), actual = state)
+    }
+
+    @Test
+    fun `state emits Found for valid spell id`() = runTest(testDispatcher) {
+        val viewModel = SpellDetailViewModel(spell.id, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertIs<DetailState.Found<Spell>>(state)
+        assertEquals(expected = spell.id, actual = state.item.id)
+        assertEquals(expected = spell.title, actual = state.item.title)
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
@@ -26,7 +26,7 @@ class SampleSpellRepository : SpellRepository {
 
         fun getFirst(): Spell = spells.first()
 
-        private fun fireball() = Spell(
+        fun fireball() = Spell(
             id = "Fireball",
             title = "Fireball",
             description = "A bright streak flashes from your pointing finger to a point you choose within range and then blossoms with a low roar into an explosion of flame.",
@@ -42,7 +42,7 @@ class SampleSpellRepository : SpellRepository {
             ),
         )
 
-        private fun mageArmor() = Spell(
+        fun mageArmor() = Spell(
             id = "Mage Armor",
             title = "Mage Armor",
             description = "You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends.",

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
@@ -36,18 +36,32 @@ class CreatureFilterTest {
     }
 
     @Test
-    fun `filter by text query matches name`() {
+    fun `filter by text query matches title`() {
         val filter = CreatureFilter(query = "goblin")
         assertTrue(filter.matches(goblin))
     }
 
     @Test
+    fun `filter by text query matches title with different case`() {
+        val filter = CreatureFilter(query = "GOBLIN")
+        assertTrue(filter.matches(goblin))
+    }
+
+    @Test
     fun `hasActiveFilters is false for default filter`() {
-        assertFalse(CreatureFilter().hasActiveFilters)
+        val defaultCreatureFilter = CreatureFilter()
+        assertFalse(defaultCreatureFilter.hasActiveFilters)
     }
 
     @Test
     fun `hasActiveFilters is true when types are set`() {
-        assertTrue(CreatureFilter(types = setOf(Creature.Type.BEAST)).hasActiveFilters)
+        val beastFilter = CreatureFilter(types = setOf(Creature.Type.BEAST))
+        assertTrue(beastFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is true when challengeRatings are set`() {
+        val challengeRatingsFilter = CreatureFilter(challengeRatings = setOf(0.25f))
+        assertTrue(challengeRatingsFilter.hasActiveFilters)
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
@@ -36,6 +36,12 @@ class CreatureFilterTest {
     }
 
     @Test
+    fun `filter by non-matching challenge rating does not match`() {
+        val filter = CreatureFilter(challengeRatings = setOf(99f))
+        assertFalse(filter.matches(goblin))
+    }
+
+    @Test
     fun `filter by text query matches title`() {
         val filter = CreatureFilter(query = "goblin")
         assertTrue(filter.matches(goblin))
@@ -44,6 +50,12 @@ class CreatureFilterTest {
     @Test
     fun `filter by text query matches title with different case`() {
         val filter = CreatureFilter(query = "GOBLIN")
+        assertTrue(filter.matches(goblin))
+    }
+
+    @Test
+    fun `filter by text query matches description`() {
+        val filter = CreatureFilter(query = "black-hearted")
         assertTrue(filter.matches(goblin))
     }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
@@ -86,8 +86,8 @@ class SpellFilterTest {
 
     @Test
     fun `hasActiveFilters is true when levels are set`() {
-        val lvl1SpellFilter = SpellFilter(levels = setOf(3))
-        assertTrue(lvl1SpellFilter.hasActiveFilters)
+        val lvl3SpellFilter = SpellFilter(levels = setOf(3))
+        assertTrue(lvl3SpellFilter.hasActiveFilters)
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
@@ -1,0 +1,98 @@
+package com.cyrillrx.rpg.spell.domain
+
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.spell.data.SampleSpellRepository
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SpellFilterTest {
+
+    private val fireball = SampleSpellRepository.fireball()
+    private val mageArmor = SampleSpellRepository.mageArmor()
+
+    @Test
+    fun `default filter matches any spell`() {
+        val filter = SpellFilter()
+        assertTrue(filter.matches(fireball))
+        assertTrue(filter.matches(mageArmor))
+    }
+
+    @Test
+    fun `filter by matching school matches`() {
+        val filter = SpellFilter(schools = setOf(Spell.School.EVOCATION))
+        assertTrue(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by non-matching school does not match`() {
+        val filter = SpellFilter(schools = setOf(Spell.School.ABJURATION))
+        assertFalse(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by matching level matches`() {
+        val filter = SpellFilter(levels = setOf(3))
+        assertTrue(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by non-matching level does not match`() {
+        val filter = SpellFilter(levels = setOf(1))
+        assertFalse(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by matching class matches`() {
+        val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.SORCERER))
+        assertTrue(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by non-matching class does not match`() {
+        val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.PALADIN))
+        assertFalse(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by text query matches title`() {
+        val filter = SpellFilter(query = "fireball")
+        assertTrue(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by text query matches title with different case`() {
+        val filter = SpellFilter(query = "FIREBALL")
+        assertTrue(filter.matches(fireball))
+    }
+
+    @Test
+    fun `filter by text query matches description`() {
+        val filter = SpellFilter(query = "explosion of flame")
+        assertTrue(filter.matches(fireball))
+    }
+
+    @Test
+    fun `hasActiveFilters is false for default filter`() {
+        val defaultSpellFilter = SpellFilter()
+        assertFalse(defaultSpellFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is true when schools are set`() {
+        val evocationSchoolFilter = SpellFilter(schools = setOf(Spell.School.EVOCATION))
+        assertTrue(evocationSchoolFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is true when levels are set`() {
+        val lvl1SpellFilter = SpellFilter(levels = setOf(3))
+        assertTrue(lvl1SpellFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is true when classes are set`() {
+        val wizardSpellFilter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.WIZARD))
+        assertTrue(wizardSpellFilter.hasActiveFilters)
+    }
+}


### PR DESCRIPTION
## 📝 Description

Add comprehensive test coverage for the Spell domain, mirroring the patterns established for Creature in #37:

- **SpellFilterTest** (14 tests) — matches by school, level, class, query, description + hasActiveFilters
- **SpellDetailViewModelTest** (3 tests) — Loading, NotFound, Found states
- **SpellBookViewModelTest** (8 tests) — initial load, school/level/class/query filters, reset, empty, error

Also aligns `CreatureFilterTest` with `SpellFilterTest` coverage by adding:
- Non-matching CR filter test
- Description query test
- Case-insensitive query test

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed