### PR TITLE
test(magicalitem): add magical item domain and ViewModel tests

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModelTest.kt
@@ -1,0 +1,75 @@
+package com.cyrillrx.rpg.magicalitem.presentation.viewmodel
+
+import com.cyrillrx.rpg.core.presentation.state.DetailState
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MagicalItemDetailViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = SampleMagicalItemRepository()
+    private val item = SampleMagicalItemRepository.getFirst()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `state is Loading initially`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemDetailViewModel(item.id, repository)
+
+        assertEquals(expected = DetailState.Loading, actual = viewModel.state.value)
+    }
+
+    @Test
+    fun `state is NotFound if item not found`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemDetailViewModel("no_match", repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertIs<DetailState.NotFound>(state)
+        assertEquals(expected = DetailState.NotFound("no_match"), actual = state)
+    }
+
+    @Test
+    fun `state emits Found for valid item id`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemDetailViewModel(item.id, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertIs<DetailState.Found<MagicalItem>>(state)
+        assertEquals(expected = item.id, actual = state.item.id)
+        assertEquals(expected = item.title, actual = state.item.title)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -1,0 +1,189 @@
+package com.cyrillrx.rpg.magicalitem.presentation.viewmodel
+
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
+import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MagicalItemListViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = SampleMagicalItemRepository()
+    private val item = SampleMagicalItemRepository.getFirst()
+    private val router = NoOpMagicalItemRouter()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state loads all items`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val body = assertIs<MagicalItemListState.Body.WithData>(state.body)
+        assertEquals(expected = 8, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `onTypeToggled filters items by type`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onTypeToggled(MagicalItem.Type.POTION)
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertTrue(state.filter.types.contains(MagicalItem.Type.POTION))
+        val body = assertIs<MagicalItemListState.Body.WithData>(state.body)
+        assertEquals(expected = 1, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `onRarityToggled filters items by rarity`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onRarityToggled(MagicalItem.Rarity.RARE)
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val body = assertIs<MagicalItemListState.Body.WithData>(state.body)
+        assertEquals(expected = 3, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `onSearchQueryChanged filters items by title`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged(item.title)
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val body = assertIs<MagicalItemListState.Body.WithData>(state.body)
+        assertEquals(expected = 1, actual = body.searchResults.size)
+        assertEquals(expected = item.title, actual = body.searchResults.first().title)
+    }
+
+    @Test
+    fun `onResetFilters clears active filters`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onTypeToggled(MagicalItem.Type.POTION)
+
+        advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.filter.hasActiveFilters)
+
+        viewModel.onResetFilters()
+
+        advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.filter.hasActiveFilters)
+        assertEquals(expected = MagicalItemFilter(), actual = viewModel.state.value.filter)
+        val body = assertIs<MagicalItemListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(expected = 8, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `state is Empty when no items match filter`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(router, repository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged("no_match")
+
+        advanceUntilIdle()
+
+        assertIs<MagicalItemListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `state is Error when repository throws`() = runTest(testDispatcher) {
+        val failingRepository = FailingMagicalItemRepository()
+        val viewModel = MagicalItemListViewModel(router, failingRepository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<MagicalItemListState.Body.Error>(viewModel.state.value.body)
+    }
+}
+
+private class NoOpMagicalItemRouter : MagicalItemRouter {
+    override fun navigateUp() = Unit
+    override fun openMagicalItemDetail(magicalItem: MagicalItem) = Unit
+}
+
+private class FailingMagicalItemRepository : MagicalItemRepository {
+    override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
+        throw RuntimeException("Simulated repository error")
+    }
+
+    override suspend fun getById(id: String): MagicalItem? {
+        throw RuntimeException("Simulated repository error")
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -91,6 +91,7 @@ class MagicalItemListViewModelTest {
         advanceUntilIdle()
 
         val state = viewModel.state.value
+        assertTrue(state.filter.rarities.contains(MagicalItem.Rarity.RARE))
         val body = assertIs<MagicalItemListState.Body.WithData>(state.body)
         assertEquals(expected = 3, actual = body.searchResults.size)
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
@@ -15,8 +15,8 @@ class SampleMagicalItemRepository : MagicalItemRepository {
     companion object {
         private val items: List<MagicalItem> = listOf(
             oathAxe(),
-            cloakOfProtection(),
             healingPotion(),
+            cloakOfProtection(),
             shieldPlus1(),
             wandOfFireballs(),
             ringOfProtection(),
@@ -28,7 +28,7 @@ class SampleMagicalItemRepository : MagicalItemRepository {
 
         fun getFirst(): MagicalItem = items.first()
 
-        private fun oathAxe() = MagicalItem(
+        fun oathAxe() = MagicalItem(
             id = "Oath Axe",
             title = "Oath Axe",
             subtitle = "Weapon (battleaxe), unique (requires attunement)",
@@ -36,6 +36,16 @@ class SampleMagicalItemRepository : MagicalItemRepository {
             type = MagicalItem.Type.WEAPON,
             rarity = MagicalItem.Rarity.RARE,
             attunement = true,
+        )
+
+        fun healingPotion() = MagicalItem(
+            id = "Healing Potion",
+            title = "Healing Potion",
+            subtitle = "Potion, common",
+            description = "You regain 2d4 + 2 hit points when you drink this potion.",
+            type = MagicalItem.Type.POTION,
+            rarity = MagicalItem.Rarity.COMMON,
+            attunement = false,
         )
 
         private fun cloakOfProtection() = MagicalItem(
@@ -46,16 +56,6 @@ class SampleMagicalItemRepository : MagicalItemRepository {
             type = MagicalItem.Type.WONDROUS_ITEM,
             rarity = MagicalItem.Rarity.UNCOMMON,
             attunement = true,
-        )
-
-        private fun healingPotion() = MagicalItem(
-            id = "Healing Potion",
-            title = "Healing Potion",
-            subtitle = "Potion, common",
-            description = "You regain 2d4 + 2 hit points when you drink this potion.",
-            type = MagicalItem.Type.POTION,
-            rarity = MagicalItem.Rarity.COMMON,
-            attunement = false,
         )
 
         private fun shieldPlus1() = MagicalItem(

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
@@ -76,4 +76,10 @@ class MagicalItemFilterTest {
         val raritiesFilter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.RARE))
         assertTrue(raritiesFilter.hasActiveFilters)
     }
+
+    @Test
+    fun `hasActiveFilters is false when only query is set`() {
+        val queryFilter = MagicalItemFilter(query = "oath")
+        assertFalse(queryFilter.hasActiveFilters)
+    }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
@@ -1,0 +1,79 @@
+package com.cyrillrx.rpg.magicalitem.domain
+
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MagicalItemFilterTest {
+
+    private val oathAxe = SampleMagicalItemRepository.oathAxe()
+    private val healingPotion = SampleMagicalItemRepository.healingPotion()
+
+    @Test
+    fun `default filter matches any item`() {
+        val filter = MagicalItemFilter()
+        assertTrue(filter.matches(oathAxe))
+        assertTrue(filter.matches(healingPotion))
+    }
+
+    @Test
+    fun `filter by matching type matches`() {
+        val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.WEAPON))
+        assertTrue(filter.matches(oathAxe))
+    }
+
+    @Test
+    fun `filter by non-matching type does not match`() {
+        val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.POTION))
+        assertFalse(filter.matches(oathAxe))
+    }
+
+    @Test
+    fun `filter by matching rarity matches`() {
+        val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.RARE))
+        assertTrue(filter.matches(oathAxe))
+    }
+
+    @Test
+    fun `filter by non-matching rarity does not match`() {
+        val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.COMMON))
+        assertFalse(filter.matches(oathAxe))
+    }
+
+    @Test
+    fun `filter by text query matches title`() {
+        val filter = MagicalItemFilter(query = "oath")
+        assertTrue(filter.matches(oathAxe))
+    }
+
+    @Test
+    fun `filter by text query matches title with different case`() {
+        val filter = MagicalItemFilter(query = "OATH")
+        assertTrue(filter.matches(oathAxe))
+    }
+
+    @Test
+    fun `filter by text query matches description`() {
+        val filter = MagicalItemFilter(query = "command word")
+        assertTrue(filter.matches(oathAxe))
+    }
+
+    @Test
+    fun `hasActiveFilters is false for default filter`() {
+        val defaultFilter = MagicalItemFilter()
+        assertFalse(defaultFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is true when types are set`() {
+        val typesFilter = MagicalItemFilter(types = setOf(MagicalItem.Type.WEAPON))
+        assertTrue(typesFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is true when rarities are set`() {
+        val raritiesFilter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.RARE))
+        assertTrue(raritiesFilter.hasActiveFilters)
+    }
+}


### PR DESCRIPTION
## 📝 Description

Add comprehensive test coverage for the MagicalItem domain, completing the test suite for all three domains (Creature, Spell, MagicalItem):

- **MagicalItemFilterTest** (11 tests) — matches by type, rarity, query (title/description), case-insensitive + hasActiveFilters
- **MagicalItemDetailViewModelTest** (3 tests) — Loading, NotFound, Found states
- **MagicalItemListViewModelTest** (7 tests) — initial load, type/rarity/query filters, reset, empty, error

Also exposes factory methods in `SampleMagicalItemRepository` for test reuse.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed