### PR TITLE
refactor(filter): split filter test files by concern and invert matches API

### DIFF
--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/domain/CampaignFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/domain/CampaignFilter.kt
@@ -1,0 +1,6 @@
+package com.cyrillrx.rpg.campaign.domain
+
+class CampaignFilter(
+    val query: String = "",
+    val ruleSets: Set<RuleSet> = emptySet(),
+)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/domain/CampaignRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/domain/CampaignRepository.kt
@@ -6,8 +6,3 @@ interface CampaignRepository {
     suspend fun save(campaign: Campaign)
     suspend fun delete(id: String)
 }
-
-class CampaignFilter(
-    val query: String = "",
-    val ruleSets: Set<RuleSet> = emptySet(),
-)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/RamPlayerCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/RamPlayerCharacterRepository.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.character.data
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.character.domain.PlayerCharacterFilter
 import com.cyrillrx.rpg.character.domain.PlayerCharacterRepository
-import com.cyrillrx.rpg.character.domain.matches
+import com.cyrillrx.rpg.character.domain.applyFilter
 
 class RamPlayerCharacterRepository : PlayerCharacterRepository {
 
@@ -11,10 +11,7 @@ class RamPlayerCharacterRepository : PlayerCharacterRepository {
 
     override suspend fun getAll(filter: PlayerCharacterFilter?): List<PlayerCharacter> {
         val allPlayerCharacters = playerCharacters.values.toList()
-
-        filter ?: return allPlayerCharacters
-
-        return allPlayerCharacters.filter { it.matches(filter) }
+        return allPlayerCharacters.applyFilter(filter)
     }
 
     override suspend fun get(id: String): PlayerCharacter? = playerCharacters[id]

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/RamPlayerCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/RamPlayerCharacterRepository.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.character.data
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.character.domain.PlayerCharacterFilter
 import com.cyrillrx.rpg.character.domain.PlayerCharacterRepository
+import com.cyrillrx.rpg.character.domain.matches
 
 class RamPlayerCharacterRepository : PlayerCharacterRepository {
 
@@ -13,7 +14,7 @@ class RamPlayerCharacterRepository : PlayerCharacterRepository {
 
         filter ?: return allPlayerCharacters
 
-        return allPlayerCharacters.filter(filter::matches)
+        return allPlayerCharacters.filter { it.matches(filter) }
     }
 
     override suspend fun get(id: String): PlayerCharacter? = playerCharacters[id]

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/PlayerCharacterFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/PlayerCharacterFilter.kt
@@ -9,7 +9,7 @@ fun List<PlayerCharacter>.applyFilter(filter: PlayerCharacterFilter?): List<Play
     return filter { it.matches(filter) }
 }
 
-fun PlayerCharacter.matches(filter: PlayerCharacterFilter): Boolean {
+internal fun PlayerCharacter.matches(filter: PlayerCharacterFilter): Boolean {
     val trimmedQuery = filter.query.trim()
 
     return name.contains(trimmedQuery, ignoreCase = true)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/PlayerCharacterFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/PlayerCharacterFilter.kt
@@ -4,6 +4,11 @@ class PlayerCharacterFilter(
     val query: String = "",
 )
 
+fun List<PlayerCharacter>.applyFilter(filter: PlayerCharacterFilter?): List<PlayerCharacter> {
+    if (filter == null) return this
+    return filter { it.matches(filter) }
+}
+
 fun PlayerCharacter.matches(filter: PlayerCharacterFilter): Boolean {
     val trimmedQuery = filter.query.trim()
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/PlayerCharacterFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/PlayerCharacterFilter.kt
@@ -1,11 +1,11 @@
 package com.cyrillrx.rpg.character.domain
 
 class PlayerCharacterFilter(
-    private val query: String = "",
-) {
-    fun matches(playerCharacter: PlayerCharacter): Boolean {
-        val trimmedQuery = query.trim()
+    val query: String = "",
+)
 
-        return playerCharacter.name.contains(trimmedQuery, ignoreCase = true)
-    }
+fun PlayerCharacter.matches(filter: PlayerCharacterFilter): Boolean {
+    val trimmedQuery = filter.query.trim()
+
+    return name.contains(trimmedQuery, ignoreCase = true)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
@@ -11,6 +11,7 @@ import com.cyrillrx.rpg.creature.domain.BaseCreature
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureFilter
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import com.cyrillrx.rpg.creature.domain.matches
 
 class JsonCreatureRepository(private val fileReader: FileReader) : CreatureRepository {
 
@@ -20,7 +21,7 @@ class JsonCreatureRepository(private val fileReader: FileReader) : CreatureRepos
 
         filter ?: return allCreatures
 
-        return allCreatures.filter(filter::matches)
+        return allCreatures.filter { it.matches(filter) }
     }
 
     override suspend fun getById(id: String): Creature? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
@@ -11,17 +11,14 @@ import com.cyrillrx.rpg.creature.domain.BaseCreature
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureFilter
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
-import com.cyrillrx.rpg.creature.domain.matches
+import com.cyrillrx.rpg.creature.domain.applyFilter
 
 class JsonCreatureRepository(private val fileReader: FileReader) : CreatureRepository {
 
     override suspend fun getAll(filter: CreatureFilter?): List<Creature> {
         val items = loadFromFile()
         val allCreatures = items.map { it.toCreature() }
-
-        filter ?: return allCreatures
-
-        return allCreatures.filter { it.matches(filter) }
+        return allCreatures.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Creature? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
@@ -5,12 +5,11 @@ import com.cyrillrx.rpg.creature.domain.BaseCreature
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureFilter
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
-import com.cyrillrx.rpg.creature.domain.matches
+import com.cyrillrx.rpg.creature.domain.applyFilter
 
 class SampleCreatureRepository : CreatureRepository {
     override suspend fun getAll(filter: CreatureFilter?): List<Creature> {
-        filter ?: return creatures
-        return creatures.filter { it.matches(filter) }
+        return creatures.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Creature? = creatures.firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleCreatureRepository.kt
@@ -5,11 +5,12 @@ import com.cyrillrx.rpg.creature.domain.BaseCreature
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureFilter
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import com.cyrillrx.rpg.creature.domain.matches
 
 class SampleCreatureRepository : CreatureRepository {
     override suspend fun getAll(filter: CreatureFilter?): List<Creature> {
         filter ?: return creatures
-        return creatures.filter(filter::matches)
+        return creatures.filter { it.matches(filter) }
     }
 
     override suspend fun getById(id: String): Creature? = creatures.firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
@@ -8,6 +8,11 @@ data class CreatureFilter(
     val hasActiveFilters: Boolean = types.isNotEmpty() || challengeRatings.isNotEmpty()
 }
 
+fun List<Creature>.applyFilter(filter: CreatureFilter?): List<Creature> {
+    if (filter == null) return this
+    return filter { it.matches(filter) }
+}
+
 fun Creature.matches(filter: CreatureFilter): Boolean {
     return (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.challengeRatings.isEmpty() || filter.challengeRatings.contains(challengeRating)) &&

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
@@ -13,7 +13,7 @@ fun List<Creature>.applyFilter(filter: CreatureFilter?): List<Creature> {
     return filter { it.matches(filter) }
 }
 
-fun Creature.matches(filter: CreatureFilter): Boolean {
+internal fun Creature.matches(filter: CreatureFilter): Boolean {
     return (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.challengeRatings.isEmpty() || filter.challengeRatings.contains(challengeRating)) &&
         (filter.query.isBlank() || matches(filter.query))

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilter.kt
@@ -6,17 +6,17 @@ data class CreatureFilter(
     val challengeRatings: Set<Float> = emptySet(),
 ) {
     val hasActiveFilters: Boolean = types.isNotEmpty() || challengeRatings.isNotEmpty()
+}
 
-    fun matches(creature: Creature): Boolean {
-        return (types.isEmpty() || types.contains(creature.type)) &&
-            (challengeRatings.isEmpty() || challengeRatings.contains(creature.challengeRating)) &&
-            (query.isBlank() || creature.matches(query))
-    }
+fun Creature.matches(filter: CreatureFilter): Boolean {
+    return (filter.types.isEmpty() || filter.types.contains(type)) &&
+        (filter.challengeRatings.isEmpty() || filter.challengeRatings.contains(challengeRating)) &&
+        (filter.query.isBlank() || matches(filter.query))
+}
 
-    private fun BaseCreature.matches(query: String): Boolean {
-        val trimmedQuery = query.trim()
+private fun BaseCreature.matches(query: String): Boolean {
+    val trimmedQuery = query.trim()
 
-        return name.contains(trimmedQuery, ignoreCase = true) ||
-            description.contains(trimmedQuery, ignoreCase = true)
-    }
+    return name.contains(trimmedQuery, ignoreCase = true) ||
+        description.contains(trimmedQuery, ignoreCase = true)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -7,17 +7,14 @@ import com.cyrillrx.rpg.magicalitem.data.api.ApiInventoryItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
-import com.cyrillrx.rpg.magicalitem.domain.matches
+import com.cyrillrx.rpg.magicalitem.domain.applyFilter
 
 class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalItemRepository {
 
     override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
         val inventoryItems = loadFromFile()
         val allItems = inventoryItems.map { it.toMagicalItem() }
-
-        filter ?: return allItems
-
-        return allItems.filter { it.matches(filter) }
+        return allItems.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): MagicalItem? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -7,6 +7,7 @@ import com.cyrillrx.rpg.magicalitem.data.api.ApiInventoryItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.domain.matches
 
 class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalItemRepository {
 
@@ -16,7 +17,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
 
         filter ?: return allItems
 
-        return allItems.filter(filter::matches)
+        return allItems.filter { it.matches(filter) }
     }
 
     override suspend fun getById(id: String): MagicalItem? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
@@ -3,11 +3,12 @@ package com.cyrillrx.rpg.magicalitem.data
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.domain.matches
 
 class SampleMagicalItemRepository : MagicalItemRepository {
     override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
         filter ?: return items
-        return items.filter(filter::matches)
+        return items.filter { it.matches(filter) }
     }
 
     override suspend fun getById(id: String): MagicalItem? = items.firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
@@ -3,12 +3,11 @@ package com.cyrillrx.rpg.magicalitem.data
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
-import com.cyrillrx.rpg.magicalitem.domain.matches
+import com.cyrillrx.rpg.magicalitem.domain.applyFilter
 
 class SampleMagicalItemRepository : MagicalItemRepository {
     override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
-        filter ?: return items
-        return items.filter { it.matches(filter) }
+        return items.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): MagicalItem? = items.firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -8,6 +8,11 @@ data class MagicalItemFilter(
     val hasActiveFilters: Boolean = types.isNotEmpty() || rarities.isNotEmpty()
 }
 
+fun List<MagicalItem>.applyFilter(filter: MagicalItemFilter?): List<MagicalItem> {
+    if (filter == null) return this
+    return filter { it.matches(filter) }
+}
+
 fun MagicalItem.matches(filter: MagicalItemFilter): Boolean {
     return (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.rarities.isEmpty() || filter.rarities.contains(rarity)) &&

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -13,7 +13,7 @@ fun List<MagicalItem>.applyFilter(filter: MagicalItemFilter?): List<MagicalItem>
     return filter { it.matches(filter) }
 }
 
-fun MagicalItem.matches(filter: MagicalItemFilter): Boolean {
+internal fun MagicalItem.matches(filter: MagicalItemFilter): Boolean {
     return (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.rarities.isEmpty() || filter.rarities.contains(rarity)) &&
         (filter.query.isBlank() || matches(filter.query))

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -6,18 +6,18 @@ data class MagicalItemFilter(
     val rarities: Set<MagicalItem.Rarity> = emptySet(),
 ) {
     val hasActiveFilters: Boolean = types.isNotEmpty() || rarities.isNotEmpty()
+}
 
-    fun matches(item: MagicalItem): Boolean {
-        return (types.isEmpty() || types.contains(item.type)) &&
-            (rarities.isEmpty() || rarities.contains(item.rarity)) &&
-            (query.isBlank() || item.matches(query))
-    }
+fun MagicalItem.matches(filter: MagicalItemFilter): Boolean {
+    return (filter.types.isEmpty() || filter.types.contains(type)) &&
+        (filter.rarities.isEmpty() || filter.rarities.contains(rarity)) &&
+        (filter.query.isBlank() || matches(filter.query))
+}
 
-    private fun MagicalItem.matches(query: String): Boolean {
-        val trimmedQuery = query.trim()
+private fun MagicalItem.matches(query: String): Boolean {
+    val trimmedQuery = query.trim()
 
-        return title.contains(trimmedQuery, ignoreCase = true) ||
-            subtitle.contains(trimmedQuery, ignoreCase = true) ||
-            description.contains(trimmedQuery, ignoreCase = true)
-    }
+    return title.contains(trimmedQuery, ignoreCase = true) ||
+        subtitle.contains(trimmedQuery, ignoreCase = true) ||
+        description.contains(trimmedQuery, ignoreCase = true)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -9,6 +9,7 @@ import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.Spell.School
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
+import com.cyrillrx.rpg.spell.domain.matches
 
 class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository {
 
@@ -18,7 +19,7 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
 
         filter ?: return allSpells
 
-        return allSpells.filter(filter::matches)
+        return allSpells.filter { it.matches(filter) }
     }
 
     override suspend fun getById(id: String): Spell? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -9,17 +9,14 @@ import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.Spell.School
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
-import com.cyrillrx.rpg.spell.domain.matches
+import com.cyrillrx.rpg.spell.domain.applyFilter
 
 class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository {
 
     override suspend fun getAll(filter: SpellFilter?): List<Spell> {
         val item = loadFromFile()
         val allSpells = item.map { it.toSpell() }
-
-        filter ?: return allSpells
-
-        return allSpells.filter { it.matches(filter) }
+        return allSpells.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Spell? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
@@ -4,11 +4,12 @@ import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
+import com.cyrillrx.rpg.spell.domain.matches
 
 class SampleSpellRepository : SpellRepository {
     override suspend fun getAll(filter: SpellFilter?): List<Spell> {
         filter ?: return spells
-        return spells.filter(filter::matches)
+        return spells.filter { it.matches(filter) }
     }
 
     override suspend fun getById(id: String): Spell? = spells.firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
@@ -4,12 +4,11 @@ import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
-import com.cyrillrx.rpg.spell.domain.matches
+import com.cyrillrx.rpg.spell.domain.applyFilter
 
 class SampleSpellRepository : SpellRepository {
     override suspend fun getAll(filter: SpellFilter?): List<Spell> {
-        filter ?: return spells
-        return spells.filter { it.matches(filter) }
+        return spells.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Spell? = spells.firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -9,18 +9,18 @@ data class SpellFilter(
     val levels: Set<Int> = emptySet(),
 ) {
     val hasActiveFilters: Boolean = schools.isNotEmpty() || playerClasses.isNotEmpty() || levels.isNotEmpty()
+}
 
-    fun matches(spell: Spell): Boolean {
-        return (schools.isEmpty() || spell.schools.any { schools.contains(it) }) &&
-            (playerClasses.isEmpty() || spell.availableClasses.any { playerClasses.contains(it) }) &&
-            (levels.isEmpty() || levels.contains(spell.level)) &&
-            (query.isBlank() || spell.matches(query))
-    }
+fun Spell.matches(filter: SpellFilter): Boolean {
+    return (filter.schools.isEmpty() || schools.any { filter.schools.contains(it) }) &&
+        (filter.playerClasses.isEmpty() || availableClasses.any { filter.playerClasses.contains(it) }) &&
+        (filter.levels.isEmpty() || filter.levels.contains(level)) &&
+        (filter.query.isBlank() || matches(filter.query))
+}
 
-    private fun Spell.matches(query: String): Boolean {
-        val trimmedQuery = query.trim()
+private fun Spell.matches(query: String): Boolean {
+    val trimmedQuery = query.trim()
 
-        return title.contains(trimmedQuery, ignoreCase = true) ||
-            description.contains(trimmedQuery, ignoreCase = true)
-    }
+    return title.contains(trimmedQuery, ignoreCase = true) ||
+        description.contains(trimmedQuery, ignoreCase = true)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -11,6 +11,11 @@ data class SpellFilter(
     val hasActiveFilters: Boolean = schools.isNotEmpty() || playerClasses.isNotEmpty() || levels.isNotEmpty()
 }
 
+fun List<Spell>.applyFilter(filter: SpellFilter?): List<Spell> {
+    if (filter == null) return this
+    return filter { it.matches(filter) }
+}
+
 fun Spell.matches(filter: SpellFilter): Boolean {
     return (filter.schools.isEmpty() || schools.any { filter.schools.contains(it) }) &&
         (filter.playerClasses.isEmpty() || availableClasses.any { filter.playerClasses.contains(it) }) &&

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -16,7 +16,7 @@ fun List<Spell>.applyFilter(filter: SpellFilter?): List<Spell> {
     return filter { it.matches(filter) }
 }
 
-fun Spell.matches(filter: SpellFilter): Boolean {
+internal fun Spell.matches(filter: SpellFilter): Boolean {
     return (filter.schools.isEmpty() || schools.any { filter.schools.contains(it) }) &&
         (filter.playerClasses.isEmpty() || availableClasses.any { filter.playerClasses.contains(it) }) &&
         (filter.levels.isEmpty() || filter.levels.contains(level)) &&

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureApplyFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureApplyFilterTest.kt
@@ -1,0 +1,50 @@
+package com.cyrillrx.rpg.creature.domain
+
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CreatureApplyFilterTest {
+
+    private val allCreatures = SampleCreatureRepository.getAll()
+
+    @Test
+    fun `null filter returns the full list`() {
+        val result = allCreatures.applyFilter(null)
+        assertEquals(allCreatures, result)
+    }
+
+    @Test
+    fun `default filter returns all creatures`() {
+        val result = allCreatures.applyFilter(CreatureFilter())
+        assertEquals(allCreatures.size, result.size)
+    }
+
+    @Test
+    fun `filter by type keeps only matching creatures`() {
+        val result = allCreatures.applyFilter(CreatureFilter(types = setOf(Creature.Type.HUMANOID)))
+        assertTrue(result.all { it.type == Creature.Type.HUMANOID })
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `filter by challenge rating keeps only matching creatures`() {
+        val result = allCreatures.applyFilter(CreatureFilter(challengeRatings = setOf(0.25f)))
+        assertTrue(result.all { it.challengeRating == 0.25f })
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `filter by query keeps only matching creatures`() {
+        val result = allCreatures.applyFilter(CreatureFilter(query = "goblin"))
+        assertEquals(1, result.size)
+        assertEquals("Goblin", result.first().name)
+    }
+
+    @Test
+    fun `filter with no match returns empty list`() {
+        val result = allCreatures.applyFilter(CreatureFilter(challengeRatings = setOf(99f)))
+        assertTrue(result.isEmpty())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
@@ -13,50 +13,50 @@ class CreatureFilterTest {
     @Test
     fun `default filter matches any creature`() {
         val filter = CreatureFilter()
-        assertTrue(filter.matches(goblin))
-        assertTrue(filter.matches(dragon))
+        assertTrue(goblin.matches(filter))
+        assertTrue(dragon.matches(filter))
     }
 
     @Test
     fun `filter by matching type matches`() {
         val filter = CreatureFilter(types = setOf(Creature.Type.HUMANOID))
-        assertTrue(filter.matches(goblin))
+        assertTrue(goblin.matches(filter))
     }
 
     @Test
     fun `filter by non-matching type does not match`() {
         val filter = CreatureFilter(types = setOf(Creature.Type.DRAGON))
-        assertFalse(filter.matches(goblin))
+        assertFalse(goblin.matches(filter))
     }
 
     @Test
     fun `filter by matching challenge rating matches`() {
         val filter = CreatureFilter(challengeRatings = setOf(0.25f))
-        assertTrue(filter.matches(goblin))
+        assertTrue(goblin.matches(filter))
     }
 
     @Test
     fun `filter by non-matching challenge rating does not match`() {
         val filter = CreatureFilter(challengeRatings = setOf(99f))
-        assertFalse(filter.matches(goblin))
+        assertFalse(goblin.matches(filter))
     }
 
     @Test
     fun `filter by text query matches title`() {
         val filter = CreatureFilter(query = "goblin")
-        assertTrue(filter.matches(goblin))
+        assertTrue(goblin.matches(filter))
     }
 
     @Test
     fun `filter by text query matches title with different case`() {
         val filter = CreatureFilter(query = "GOBLIN")
-        assertTrue(filter.matches(goblin))
+        assertTrue(goblin.matches(filter))
     }
 
     @Test
     fun `filter by text query matches description`() {
         val filter = CreatureFilter(query = "black-hearted")
-        assertTrue(filter.matches(goblin))
+        assertTrue(goblin.matches(filter))
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
@@ -1,63 +1,10 @@
 package com.cyrillrx.rpg.creature.domain
 
-import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CreatureFilterTest {
-
-    private val goblin = SampleCreatureRepository.goblin()
-    private val dragon = SampleCreatureRepository.youngRedDragon()
-
-    @Test
-    fun `default filter matches any creature`() {
-        val filter = CreatureFilter()
-        assertTrue(goblin.matches(filter))
-        assertTrue(dragon.matches(filter))
-    }
-
-    @Test
-    fun `filter by matching type matches`() {
-        val filter = CreatureFilter(types = setOf(Creature.Type.HUMANOID))
-        assertTrue(goblin.matches(filter))
-    }
-
-    @Test
-    fun `filter by non-matching type does not match`() {
-        val filter = CreatureFilter(types = setOf(Creature.Type.DRAGON))
-        assertFalse(goblin.matches(filter))
-    }
-
-    @Test
-    fun `filter by matching challenge rating matches`() {
-        val filter = CreatureFilter(challengeRatings = setOf(0.25f))
-        assertTrue(goblin.matches(filter))
-    }
-
-    @Test
-    fun `filter by non-matching challenge rating does not match`() {
-        val filter = CreatureFilter(challengeRatings = setOf(99f))
-        assertFalse(goblin.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches title`() {
-        val filter = CreatureFilter(query = "goblin")
-        assertTrue(goblin.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches title with different case`() {
-        val filter = CreatureFilter(query = "GOBLIN")
-        assertTrue(goblin.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches description`() {
-        val filter = CreatureFilter(query = "black-hearted")
-        assertTrue(goblin.matches(filter))
-    }
 
     @Test
     fun `hasActiveFilters is false for default filter`() {

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureFilterTest.kt
@@ -8,19 +8,25 @@ class CreatureFilterTest {
 
     @Test
     fun `hasActiveFilters is false for default filter`() {
-        val defaultCreatureFilter = CreatureFilter()
-        assertFalse(defaultCreatureFilter.hasActiveFilters)
+        val defaultFilter = CreatureFilter()
+        assertFalse(defaultFilter.hasActiveFilters)
     }
 
     @Test
     fun `hasActiveFilters is true when types are set`() {
-        val beastFilter = CreatureFilter(types = setOf(Creature.Type.BEAST))
-        assertTrue(beastFilter.hasActiveFilters)
+        val typesFilter = CreatureFilter(types = setOf(Creature.Type.BEAST))
+        assertTrue(typesFilter.hasActiveFilters)
     }
 
     @Test
     fun `hasActiveFilters is true when challengeRatings are set`() {
         val challengeRatingsFilter = CreatureFilter(challengeRatings = setOf(0.25f))
         assertTrue(challengeRatingsFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is false when only query is set`() {
+        val queryFilter = CreatureFilter(query = "goblin")
+        assertFalse(queryFilter.hasActiveFilters)
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/CreatureMatchesFilterTest.kt
@@ -1,0 +1,61 @@
+package com.cyrillrx.rpg.creature.domain
+
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CreatureMatchesFilterTest {
+
+    private val goblin = SampleCreatureRepository.goblin()
+    private val dragon = SampleCreatureRepository.youngRedDragon()
+
+    @Test
+    fun `default filter matches any creature`() {
+        val filter = CreatureFilter()
+        assertTrue(goblin.matches(filter))
+        assertTrue(dragon.matches(filter))
+    }
+
+    @Test
+    fun `filter by matching type matches`() {
+        val filter = CreatureFilter(types = setOf(Creature.Type.HUMANOID))
+        assertTrue(goblin.matches(filter))
+    }
+
+    @Test
+    fun `filter by non-matching type does not match`() {
+        val filter = CreatureFilter(types = setOf(Creature.Type.DRAGON))
+        assertFalse(goblin.matches(filter))
+    }
+
+    @Test
+    fun `filter by matching challenge rating matches`() {
+        val filter = CreatureFilter(challengeRatings = setOf(0.25f))
+        assertTrue(goblin.matches(filter))
+    }
+
+    @Test
+    fun `filter by non-matching challenge rating does not match`() {
+        val filter = CreatureFilter(challengeRatings = setOf(99f))
+        assertFalse(goblin.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches title`() {
+        val filter = CreatureFilter(query = "goblin")
+        assertTrue(goblin.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches title with different case`() {
+        val filter = CreatureFilter(query = "GOBLIN")
+        assertTrue(goblin.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches description`() {
+        val filter = CreatureFilter(query = "black-hearted")
+        assertTrue(goblin.matches(filter))
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemApplyFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemApplyFilterTest.kt
@@ -1,0 +1,49 @@
+package com.cyrillrx.rpg.magicalitem.domain
+
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MagicalItemApplyFilterTest {
+
+    private val allItems = SampleMagicalItemRepository.getAll()
+
+    @Test
+    fun `null filter returns the full list`() {
+        val result = allItems.applyFilter(null)
+        assertEquals(allItems, result)
+    }
+
+    @Test
+    fun `default filter returns all items`() {
+        val result = allItems.applyFilter(MagicalItemFilter())
+        assertEquals(allItems.size, result.size)
+    }
+
+    @Test
+    fun `filter by type keeps only matching items`() {
+        val result = allItems.applyFilter(MagicalItemFilter(types = setOf(MagicalItem.Type.WEAPON)))
+        assertTrue(result.all { it.type == MagicalItem.Type.WEAPON })
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `filter by rarity keeps only matching items`() {
+        val result = allItems.applyFilter(MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.RARE)))
+        assertTrue(result.all { it.rarity == MagicalItem.Rarity.RARE })
+        assertEquals(3, result.size)
+    }
+
+    @Test
+    fun `filter by query keeps only matching items`() {
+        val result = allItems.applyFilter(MagicalItemFilter(query = "fireball"))
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `filter with no match returns empty list`() {
+        val result = allItems.applyFilter(MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.LEGENDARY)))
+        assertTrue(result.isEmpty())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
@@ -13,50 +13,50 @@ class MagicalItemFilterTest {
     @Test
     fun `default filter matches any item`() {
         val filter = MagicalItemFilter()
-        assertTrue(filter.matches(oathAxe))
-        assertTrue(filter.matches(healingPotion))
+        assertTrue(oathAxe.matches(filter))
+        assertTrue(healingPotion.matches(filter))
     }
 
     @Test
     fun `filter by matching type matches`() {
         val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.WEAPON))
-        assertTrue(filter.matches(oathAxe))
+        assertTrue(oathAxe.matches(filter))
     }
 
     @Test
     fun `filter by non-matching type does not match`() {
         val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.POTION))
-        assertFalse(filter.matches(oathAxe))
+        assertFalse(oathAxe.matches(filter))
     }
 
     @Test
     fun `filter by matching rarity matches`() {
         val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.RARE))
-        assertTrue(filter.matches(oathAxe))
+        assertTrue(oathAxe.matches(filter))
     }
 
     @Test
     fun `filter by non-matching rarity does not match`() {
         val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.COMMON))
-        assertFalse(filter.matches(oathAxe))
+        assertFalse(oathAxe.matches(filter))
     }
 
     @Test
     fun `filter by text query matches title`() {
         val filter = MagicalItemFilter(query = "oath")
-        assertTrue(filter.matches(oathAxe))
+        assertTrue(oathAxe.matches(filter))
     }
 
     @Test
     fun `filter by text query matches title with different case`() {
         val filter = MagicalItemFilter(query = "OATH")
-        assertTrue(filter.matches(oathAxe))
+        assertTrue(oathAxe.matches(filter))
     }
 
     @Test
     fun `filter by text query matches description`() {
         val filter = MagicalItemFilter(query = "command word")
-        assertTrue(filter.matches(oathAxe))
+        assertTrue(oathAxe.matches(filter))
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilterTest.kt
@@ -1,63 +1,10 @@
 package com.cyrillrx.rpg.magicalitem.domain
 
-import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MagicalItemFilterTest {
-
-    private val oathAxe = SampleMagicalItemRepository.oathAxe()
-    private val healingPotion = SampleMagicalItemRepository.healingPotion()
-
-    @Test
-    fun `default filter matches any item`() {
-        val filter = MagicalItemFilter()
-        assertTrue(oathAxe.matches(filter))
-        assertTrue(healingPotion.matches(filter))
-    }
-
-    @Test
-    fun `filter by matching type matches`() {
-        val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.WEAPON))
-        assertTrue(oathAxe.matches(filter))
-    }
-
-    @Test
-    fun `filter by non-matching type does not match`() {
-        val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.POTION))
-        assertFalse(oathAxe.matches(filter))
-    }
-
-    @Test
-    fun `filter by matching rarity matches`() {
-        val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.RARE))
-        assertTrue(oathAxe.matches(filter))
-    }
-
-    @Test
-    fun `filter by non-matching rarity does not match`() {
-        val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.COMMON))
-        assertFalse(oathAxe.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches title`() {
-        val filter = MagicalItemFilter(query = "oath")
-        assertTrue(oathAxe.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches title with different case`() {
-        val filter = MagicalItemFilter(query = "OATH")
-        assertTrue(oathAxe.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches description`() {
-        val filter = MagicalItemFilter(query = "command word")
-        assertTrue(oathAxe.matches(filter))
-    }
 
     @Test
     fun `hasActiveFilters is false for default filter`() {

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemMatchesFilterTest.kt
@@ -54,6 +54,12 @@ class MagicalItemMatchesFilterTest {
     }
 
     @Test
+    fun `filter by text query matches subtitle`() {
+        val filter = MagicalItemFilter(query = "axe")
+        assertTrue(oathAxe.matches(filter))
+    }
+
+    @Test
     fun `filter by text query matches description`() {
         val filter = MagicalItemFilter(query = "command word")
         assertTrue(oathAxe.matches(filter))

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemMatchesFilterTest.kt
@@ -1,0 +1,61 @@
+package com.cyrillrx.rpg.magicalitem.domain
+
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MagicalItemMatchesFilterTest {
+
+    private val oathAxe = SampleMagicalItemRepository.oathAxe()
+    private val healingPotion = SampleMagicalItemRepository.healingPotion()
+
+    @Test
+    fun `default filter matches any item`() {
+        val filter = MagicalItemFilter()
+        assertTrue(oathAxe.matches(filter))
+        assertTrue(healingPotion.matches(filter))
+    }
+
+    @Test
+    fun `filter by matching type matches`() {
+        val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.WEAPON))
+        assertTrue(oathAxe.matches(filter))
+    }
+
+    @Test
+    fun `filter by non-matching type does not match`() {
+        val filter = MagicalItemFilter(types = setOf(MagicalItem.Type.POTION))
+        assertFalse(oathAxe.matches(filter))
+    }
+
+    @Test
+    fun `filter by matching rarity matches`() {
+        val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.RARE))
+        assertTrue(oathAxe.matches(filter))
+    }
+
+    @Test
+    fun `filter by non-matching rarity does not match`() {
+        val filter = MagicalItemFilter(rarities = setOf(MagicalItem.Rarity.COMMON))
+        assertFalse(oathAxe.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches title`() {
+        val filter = MagicalItemFilter(query = "oath")
+        assertTrue(oathAxe.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches title with different case`() {
+        val filter = MagicalItemFilter(query = "OATH")
+        assertTrue(oathAxe.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches description`() {
+        val filter = MagicalItemFilter(query = "command word")
+        assertTrue(oathAxe.matches(filter))
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellApplyFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellApplyFilterTest.kt
@@ -1,0 +1,58 @@
+package com.cyrillrx.rpg.spell.domain
+
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.spell.data.SampleSpellRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SpellApplyFilterTest {
+
+    private val allSpells = SampleSpellRepository.getAll()
+
+    @Test
+    fun `null filter returns the full list`() {
+        val result = allSpells.applyFilter(null)
+        assertEquals(allSpells, result)
+    }
+
+    @Test
+    fun `default filter returns all spells`() {
+        val result = allSpells.applyFilter(SpellFilter())
+        assertEquals(allSpells.size, result.size)
+    }
+
+    @Test
+    fun `filter by school keeps only matching spells`() {
+        val result = allSpells.applyFilter(SpellFilter(schools = setOf(Spell.School.EVOCATION)))
+        assertTrue(result.all { it.schools.contains(Spell.School.EVOCATION) })
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `filter by level keeps only matching spells`() {
+        val result = allSpells.applyFilter(SpellFilter(levels = setOf(3)))
+        assertTrue(result.all { it.level == 3 })
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `filter by class keeps only matching spells`() {
+        val result = allSpells.applyFilter(SpellFilter(playerClasses = setOf(PlayerCharacter.Class.BARD)))
+        assertTrue(result.all { it.availableClasses.contains(PlayerCharacter.Class.BARD) })
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `filter by query keeps only matching spells`() {
+        val result = allSpells.applyFilter(SpellFilter(query = "fireball"))
+        assertEquals(1, result.size)
+        assertEquals("Fireball", result.first().title)
+    }
+
+    @Test
+    fun `filter with no match returns empty list`() {
+        val result = allSpells.applyFilter(SpellFilter(playerClasses = setOf(PlayerCharacter.Class.PALADIN)))
+        assertTrue(result.isEmpty())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
@@ -1,76 +1,11 @@
 package com.cyrillrx.rpg.spell.domain
 
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
-import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SpellFilterTest {
-
-    private val fireball = SampleSpellRepository.fireball()
-    private val mageArmor = SampleSpellRepository.mageArmor()
-
-    @Test
-    fun `default filter matches any spell`() {
-        val filter = SpellFilter()
-        assertTrue(fireball.matches(filter))
-        assertTrue(mageArmor.matches(filter))
-    }
-
-    @Test
-    fun `filter by matching school matches`() {
-        val filter = SpellFilter(schools = setOf(Spell.School.EVOCATION))
-        assertTrue(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by non-matching school does not match`() {
-        val filter = SpellFilter(schools = setOf(Spell.School.ABJURATION))
-        assertFalse(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by matching level matches`() {
-        val filter = SpellFilter(levels = setOf(3))
-        assertTrue(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by non-matching level does not match`() {
-        val filter = SpellFilter(levels = setOf(1))
-        assertFalse(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by matching class matches`() {
-        val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.SORCERER))
-        assertTrue(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by non-matching class does not match`() {
-        val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.PALADIN))
-        assertFalse(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches title`() {
-        val filter = SpellFilter(query = "fireball")
-        assertTrue(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches title with different case`() {
-        val filter = SpellFilter(query = "FIREBALL")
-        assertTrue(fireball.matches(filter))
-    }
-
-    @Test
-    fun `filter by text query matches description`() {
-        val filter = SpellFilter(query = "explosion of flame")
-        assertTrue(fireball.matches(filter))
-    }
 
     @Test
     fun `hasActiveFilters is false for default filter`() {

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
@@ -14,62 +14,62 @@ class SpellFilterTest {
     @Test
     fun `default filter matches any spell`() {
         val filter = SpellFilter()
-        assertTrue(filter.matches(fireball))
-        assertTrue(filter.matches(mageArmor))
+        assertTrue(fireball.matches(filter))
+        assertTrue(mageArmor.matches(filter))
     }
 
     @Test
     fun `filter by matching school matches`() {
         val filter = SpellFilter(schools = setOf(Spell.School.EVOCATION))
-        assertTrue(filter.matches(fireball))
+        assertTrue(fireball.matches(filter))
     }
 
     @Test
     fun `filter by non-matching school does not match`() {
         val filter = SpellFilter(schools = setOf(Spell.School.ABJURATION))
-        assertFalse(filter.matches(fireball))
+        assertFalse(fireball.matches(filter))
     }
 
     @Test
     fun `filter by matching level matches`() {
         val filter = SpellFilter(levels = setOf(3))
-        assertTrue(filter.matches(fireball))
+        assertTrue(fireball.matches(filter))
     }
 
     @Test
     fun `filter by non-matching level does not match`() {
         val filter = SpellFilter(levels = setOf(1))
-        assertFalse(filter.matches(fireball))
+        assertFalse(fireball.matches(filter))
     }
 
     @Test
     fun `filter by matching class matches`() {
         val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.SORCERER))
-        assertTrue(filter.matches(fireball))
+        assertTrue(fireball.matches(filter))
     }
 
     @Test
     fun `filter by non-matching class does not match`() {
         val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.PALADIN))
-        assertFalse(filter.matches(fireball))
+        assertFalse(fireball.matches(filter))
     }
 
     @Test
     fun `filter by text query matches title`() {
         val filter = SpellFilter(query = "fireball")
-        assertTrue(filter.matches(fireball))
+        assertTrue(fireball.matches(filter))
     }
 
     @Test
     fun `filter by text query matches title with different case`() {
         val filter = SpellFilter(query = "FIREBALL")
-        assertTrue(filter.matches(fireball))
+        assertTrue(fireball.matches(filter))
     }
 
     @Test
     fun `filter by text query matches description`() {
         val filter = SpellFilter(query = "explosion of flame")
-        assertTrue(filter.matches(fireball))
+        assertTrue(fireball.matches(filter))
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilterTest.kt
@@ -9,25 +9,31 @@ class SpellFilterTest {
 
     @Test
     fun `hasActiveFilters is false for default filter`() {
-        val defaultSpellFilter = SpellFilter()
-        assertFalse(defaultSpellFilter.hasActiveFilters)
+        val defaultFilter = SpellFilter()
+        assertFalse(defaultFilter.hasActiveFilters)
     }
 
     @Test
     fun `hasActiveFilters is true when schools are set`() {
-        val evocationSchoolFilter = SpellFilter(schools = setOf(Spell.School.EVOCATION))
-        assertTrue(evocationSchoolFilter.hasActiveFilters)
+        val schoolsFilter = SpellFilter(schools = setOf(Spell.School.EVOCATION))
+        assertTrue(schoolsFilter.hasActiveFilters)
     }
 
     @Test
     fun `hasActiveFilters is true when levels are set`() {
-        val lvl3SpellFilter = SpellFilter(levels = setOf(3))
-        assertTrue(lvl3SpellFilter.hasActiveFilters)
+        val levelsFilter = SpellFilter(levels = setOf(3))
+        assertTrue(levelsFilter.hasActiveFilters)
     }
 
     @Test
     fun `hasActiveFilters is true when classes are set`() {
-        val wizardSpellFilter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.WIZARD))
-        assertTrue(wizardSpellFilter.hasActiveFilters)
+        val classesFilter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.WIZARD))
+        assertTrue(classesFilter.hasActiveFilters)
+    }
+
+    @Test
+    fun `hasActiveFilters is false when only query is set`() {
+        val queryFilter = SpellFilter(query = "fireball")
+        assertFalse(queryFilter.hasActiveFilters)
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
@@ -1,0 +1,74 @@
+package com.cyrillrx.rpg.spell.domain
+
+import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.spell.data.SampleSpellRepository
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SpellMatchesFilterTest {
+
+    private val fireball = SampleSpellRepository.fireball()
+    private val mageArmor = SampleSpellRepository.mageArmor()
+
+    @Test
+    fun `default filter matches any spell`() {
+        val filter = SpellFilter()
+        assertTrue(fireball.matches(filter))
+        assertTrue(mageArmor.matches(filter))
+    }
+
+    @Test
+    fun `filter by matching school matches`() {
+        val filter = SpellFilter(schools = setOf(Spell.School.EVOCATION))
+        assertTrue(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by non-matching school does not match`() {
+        val filter = SpellFilter(schools = setOf(Spell.School.ABJURATION))
+        assertFalse(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by matching level matches`() {
+        val filter = SpellFilter(levels = setOf(3))
+        assertTrue(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by non-matching level does not match`() {
+        val filter = SpellFilter(levels = setOf(1))
+        assertFalse(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by matching class matches`() {
+        val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.SORCERER))
+        assertTrue(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by non-matching class does not match`() {
+        val filter = SpellFilter(playerClasses = setOf(PlayerCharacter.Class.PALADIN))
+        assertFalse(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches title`() {
+        val filter = SpellFilter(query = "fireball")
+        assertTrue(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches title with different case`() {
+        val filter = SpellFilter(query = "FIREBALL")
+        assertTrue(fireball.matches(filter))
+    }
+
+    @Test
+    fun `filter by text query matches description`() {
+        val filter = SpellFilter(query = "explosion of flame")
+        assertTrue(fireball.matches(filter))
+    }
+}


### PR DESCRIPTION
## 📝 Description

Refactors the filter API across all domains and splits test files by concern.

**API changes:**
- Inverts the matches API from `filter.matches(item)` to `item.matches(filter)` (extension on the domain object)
- Adds `applyFilter` extension on `List<T>` for each domain
- Extracts `CampaignFilter` from `CampaignRepository`
- Restricts `matches(filter)` extensions to `internal` visibility

**Test organisation:**
Each `*FilterTest.kt` is split into three focused files:
- `*MatchesFilterTest` — `item.matches(filter)` tests
- `*FilterTest` — `hasActiveFilters` tests
- `*ApplyFilterTest` — `List<T>.applyFilter(filter)` tests

Domains covered: `spell`, `magicalitem`, `creature`.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed