### PR TITLE
refactor(spell): rename SpellBook to SpellList for consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,8 @@ No Hilt/Koin. Repositories and routers are instantiated inside `NavGraphBuilder`
 // In handleSpellRoutes(navController, fileReader):
 composable<SpellRoute.List> {
     val router = SpellRouterImpl(navController)
-    val factory = SpellBookViewModelFactory(router, JsonSpellRepository(fileReader))
-    val viewModel = viewModel<SpellBookViewModel>(factory = factory)
+    val factory = SpellListViewModelFactory(router, JsonSpellRepository(fileReader))
+    val viewModel = viewModel<SpellListViewModel>(factory = factory)
     SpellListScreen(viewModel, router)
 }
 ```

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -27,14 +27,14 @@ import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.SpellListState
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouter
-import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellBookViewModel
+import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellListViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_spell
 
 @Composable
-fun SpellCardCarouselScreen(viewModel: SpellBookViewModel, router: SpellRouter) {
+fun SpellCardCarouselScreen(viewModel: SpellListViewModel, router: SpellRouter) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     SpellCardCarouselScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -31,14 +31,14 @@ import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.SpellListState
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouter
-import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellBookViewModel
+import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellListViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_spell
 
 @Composable
-fun SpellListScreen(viewModel: SpellBookViewModel, router: SpellRouter) {
+fun SpellListScreen(viewModel: SpellListViewModel, router: SpellRouter) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     SpellListScreen(
@@ -137,7 +137,7 @@ private val stateWithSampleData = SpellListState(
 
 @Preview
 @Composable
-fun PreviewSpellBookPeekScreenLight() {
+fun PreviewSpellListPeekScreenLight() {
     AppThemePreview(darkTheme = false) {
         SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
@@ -145,7 +145,7 @@ fun PreviewSpellBookPeekScreenLight() {
 
 @Preview
 @Composable
-fun PreviewSpellBookPeekScreenDark() {
+fun PreviewSpellListPeekScreenDark() {
     AppThemePreview(darkTheme = true) {
         SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -11,8 +11,8 @@ import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardCarouselScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellListScreen
-import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellBookViewModel
-import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellBookViewModelFactory
+import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellListViewModel
+import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellListViewModelFactory
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModelFactory
 import kotlinx.serialization.Serializable
@@ -34,15 +34,15 @@ fun NavGraphBuilder.handleSpellRoutes(navController: NavController, repository: 
         exitTransition = { slideOutHorizontally { initialOffset -> initialOffset } },
     ) {
         val router = SpellRouterImpl(navController)
-        val viewModelFactory = SpellBookViewModelFactory(router, repository)
-        val viewModel = viewModel<SpellBookViewModel>(factory = viewModelFactory)
+        val viewModelFactory = SpellListViewModelFactory(router, repository)
+        val viewModel = viewModel<SpellListViewModel>(factory = viewModelFactory)
         SpellListScreen(viewModel, router)
     }
 
     composable<SpellRoute.CardCarousel> {
         val router = SpellRouterImpl(navController)
-        val viewModelFactory = SpellBookViewModelFactory(router, repository)
-        val viewModel = viewModel<SpellBookViewModel>(factory = viewModelFactory)
+        val viewModelFactory = SpellListViewModelFactory(router, repository)
+        val viewModel = viewModel<SpellListViewModel>(factory = viewModelFactory)
         SpellCardCarouselScreen(viewModel, router)
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -19,7 +19,7 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_spells
 import kotlin.coroutines.cancellation.CancellationException
 
-class SpellBookViewModel(
+class SpellListViewModel(
     private val router: SpellRouter,
     private val repository: SpellRepository,
 ) : ViewModel() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelFactory.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelFactory.kt
@@ -7,12 +7,12 @@ import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouter
 import kotlin.reflect.KClass
 
-class SpellBookViewModelFactory(
+class SpellListViewModelFactory(
     private val router: SpellRouter,
     private val repository: SpellRepository,
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
-        return SpellBookViewModel(router, repository) as T
+        return SpellListViewModel(router, repository) as T
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SpellBookViewModelTest {
+class SpellListViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private val repository = SampleSpellRepository()
@@ -44,7 +44,7 @@ class SpellBookViewModelTest {
 
     @Test
     fun `initial state loads all spells`() = runTest(testDispatcher) {
-        val viewModel = SpellBookViewModel(router, repository)
+        val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -59,7 +59,7 @@ class SpellBookViewModelTest {
 
     @Test
     fun `onSchoolToggled filters spells by school`() = runTest(testDispatcher) {
-        val viewModel = SpellBookViewModel(router, repository)
+        val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -79,7 +79,7 @@ class SpellBookViewModelTest {
 
     @Test
     fun `onLevelToggled filters spells by level`() = runTest(testDispatcher) {
-        val viewModel = SpellBookViewModel(router, repository)
+        val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -98,7 +98,7 @@ class SpellBookViewModelTest {
 
     @Test
     fun `onClassToggled filters spells by class`() = runTest(testDispatcher) {
-        val viewModel = SpellBookViewModel(router, repository)
+        val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -117,7 +117,7 @@ class SpellBookViewModelTest {
 
     @Test
     fun `onSearchQueryChanged filters spells by title`() = runTest(testDispatcher) {
-        val viewModel = SpellBookViewModel(router, repository)
+        val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -137,7 +137,7 @@ class SpellBookViewModelTest {
 
     @Test
     fun `onResetFilters clears active filters`() = runTest(testDispatcher) {
-        val viewModel = SpellBookViewModel(router, repository)
+        val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -163,7 +163,7 @@ class SpellBookViewModelTest {
 
     @Test
     fun `state is Empty when no spells match filter`() = runTest(testDispatcher) {
-        val viewModel = SpellBookViewModel(router, repository)
+        val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -181,7 +181,7 @@ class SpellBookViewModelTest {
     @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
         val failingRepository = FailingSpellRepository()
-        val viewModel = SpellBookViewModel(router, failingRepository)
+        val viewModel = SpellListViewModel(router, failingRepository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}


### PR DESCRIPTION
## 📝 Description

This PR renames the `SpellBook` related classes and files to `SpellList` to align with the domain naming convention and improve overall consistency.

- Renamed `SpellBookViewModel` to `SpellListViewModel`
- Renamed `SpellBookViewModelFactory` to `SpellListViewModelFactory`
- Renamed `SpellBookViewModelTest` to `SpellListViewModelTest`
- Updated all references in `SpellListScreen.kt`, `SpellCardCarouselScreen.kt`, `SpellRoute.kt` and `AGENTS.md`.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed