### PR TITLE
feat(userlist): add UserList data layer (domain, SQLDelight, repositories, tests)

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <string name="section_my_lists">Mes listes</string>
+
+    <string name="btn_my_spell_lists">Grimoires</string>
+    <string name="btn_my_item_lists">Objets</string>
+    <string name="btn_my_bestiary_lists">Bestiaires</string>
+
+    <string name="btn_create_list">Nouvelle liste</string>
+    <string name="btn_add_to_list">Ajouter à une liste</string>
+
+    <string name="hint_list_name">Nom de la liste</string>
+</resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <string name="section_my_lists">My Lists</string>
+
+    <string name="btn_my_spell_lists">Spellbooks</string>
+    <string name="btn_my_item_lists">Items</string>
+    <string name="btn_my_bestiary_lists">Bestiaries</string>
+
+    <string name="btn_create_list">New List</string>
+    <string name="btn_add_to_list">Add to a list</string>
+
+    <string name="hint_list_name">List name</string>
+</resources>

--- a/cmp-ttrpg-companion/shared/core/build.gradle.kts
+++ b/cmp-ttrpg-companion/shared/core/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
         androidMain.dependencies {
             implementation(libs.sqldelight.android)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/Serializer.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/Serializer.kt
@@ -1,7 +1,6 @@
 package com.cyrillrx.core.data
 
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 val defaultSerializer: Json = Json {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -68,6 +68,6 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
 
     companion object {
         const val DATABASE_NAME = "ttrpg_companion.db"
-        const val LIST_DELIMITER = "|"
+        const val LIST_DELIMITER = "\u001F"
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.core.data.cache
 import com.cyrillrx.rpg.cache.AppDatabase
 import com.cyrillrx.rpg.campaign.domain.Campaign
 import com.cyrillrx.rpg.campaign.domain.RuleSet
+import com.cyrillrx.rpg.userlist.domain.UserList
 
 internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     private val database = AppDatabase(databaseDriverFactory.createDriver())
@@ -31,7 +32,42 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     private fun mapCampaignSelecting(id: String, name: String, ruleSet: Long): Campaign =
         Campaign(id = id, name = name, ruleSet = RuleSet.fromInt(ruleSet.toInt()))
 
+    fun getAllUserLists(type: UserList.Type): List<UserList> =
+        dbQuery.selectAllUserListsByType(type.name, ::mapUserListSelecting).executeAsList()
+
+    fun getUserList(id: String): UserList? = dbQuery.selectUserListById(id, ::mapUserListSelecting).executeAsOneOrNull()
+
+    fun insertUserList(list: UserList) {
+        dbQuery.insertUserList(
+            id = list.id,
+            name = list.name,
+            type = list.type.name,
+            itemIds = list.itemIds.joinToString(LIST_DELIMITER),
+        )
+    }
+
+    fun updateUserList(list: UserList) {
+        dbQuery.updateUserList(
+            name = list.name,
+            itemIds = list.itemIds.joinToString(LIST_DELIMITER),
+            id = list.id,
+        )
+    }
+
+    fun deleteUserList(id: String) {
+        dbQuery.deleteUserList(id)
+    }
+
+    private fun mapUserListSelecting(id: String, name: String, type: String, itemIds: String): UserList =
+        UserList(
+            id = id,
+            name = name,
+            type = UserList.Type.valueOf(type),
+            itemIds = if (itemIds.isEmpty()) emptyList() else itemIds.split(LIST_DELIMITER),
+        )
+
     companion object {
         const val DATABASE_NAME = "ttrpg_companion.db"
+        const val LIST_DELIMITER = "|"
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -37,20 +37,12 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
 
     fun getUserList(id: String): UserList? = dbQuery.selectUserListById(id, ::mapUserListSelecting).executeAsOneOrNull()
 
-    fun insertUserList(list: UserList) {
-        dbQuery.insertUserList(
+    fun saveUserList(list: UserList) {
+        dbQuery.saveUserList(
             id = list.id,
             name = list.name,
             type = list.type.name,
             itemIds = list.itemIds.joinToString(LIST_DELIMITER),
-        )
-    }
-
-    fun updateUserList(list: UserList) {
-        dbQuery.updateUserList(
-            name = list.name,
-            itemIds = list.itemIds.joinToString(LIST_DELIMITER),
-            id = list.id,
         )
     }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/RamUserListRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/RamUserListRepository.kt
@@ -1,0 +1,20 @@
+package com.cyrillrx.rpg.userlist.data
+
+import com.cyrillrx.rpg.userlist.domain.UserList
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+
+class RamUserListRepository : UserListRepository {
+    private val lists = mutableMapOf<String, UserList>()
+
+    override suspend fun getAll(type: UserList.Type): List<UserList> = lists.values.filter { it.type == type }
+
+    override suspend fun get(id: String): UserList? = lists[id]
+
+    override suspend fun save(list: UserList) {
+        lists[list.id] = list
+    }
+
+    override suspend fun delete(id: String) {
+        lists.remove(id)
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/SQLDelightUserListRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/SQLDelightUserListRepository.kt
@@ -1,0 +1,27 @@
+package com.cyrillrx.rpg.userlist.data
+
+import com.cyrillrx.rpg.core.data.cache.Database
+import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
+import com.cyrillrx.rpg.userlist.domain.UserList
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+
+class SQLDelightUserListRepository(databaseDriverFactory: DatabaseDriverFactory) : UserListRepository {
+    private val database = Database(databaseDriverFactory)
+
+    override suspend fun getAll(type: UserList.Type): List<UserList> = database.getAllUserLists(type)
+
+    override suspend fun get(id: String): UserList? = database.getUserList(id)
+
+    override suspend fun save(list: UserList) {
+        val existing = database.getUserList(list.id)
+        if (existing == null) {
+            database.insertUserList(list)
+        } else {
+            database.updateUserList(list)
+        }
+    }
+
+    override suspend fun delete(id: String) {
+        database.deleteUserList(id)
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/SQLDelightUserListRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/SQLDelightUserListRepository.kt
@@ -13,12 +13,7 @@ class SQLDelightUserListRepository(databaseDriverFactory: DatabaseDriverFactory)
     override suspend fun get(id: String): UserList? = database.getUserList(id)
 
     override suspend fun save(list: UserList) {
-        val existing = database.getUserList(list.id)
-        if (existing == null) {
-            database.insertUserList(list)
-        } else {
-            database.updateUserList(list)
-        }
+        database.saveUserList(list)
     }
 
     override suspend fun delete(id: String) {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/domain/UserList.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/domain/UserList.kt
@@ -1,0 +1,10 @@
+package com.cyrillrx.rpg.userlist.domain
+
+data class UserList(
+    val id: String,
+    val name: String,
+    val type: Type,
+    val itemIds: List<String>,
+) {
+    enum class Type { SPELL, MAGICAL_ITEM, CREATURE }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/domain/UserListRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/domain/UserListRepository.kt
@@ -2,10 +2,7 @@ package com.cyrillrx.rpg.userlist.domain
 
 interface UserListRepository {
     suspend fun getAll(type: UserList.Type): List<UserList>
-
     suspend fun get(id: String): UserList?
-
     suspend fun save(list: UserList)
-
     suspend fun delete(id: String)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/domain/UserListRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/domain/UserListRepository.kt
@@ -1,0 +1,11 @@
+package com.cyrillrx.rpg.userlist.domain
+
+interface UserListRepository {
+    suspend fun getAll(type: UserList.Type): List<UserList>
+
+    suspend fun get(id: String): UserList?
+
+    suspend fun save(list: UserList)
+
+    suspend fun delete(id: String)
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
@@ -24,11 +24,8 @@ CREATE TABLE UserList (
     itemIds TEXT NOT NULL DEFAULT ''
 );
 
-insertUserList:
-INSERT INTO UserList(id, name, type, itemIds) VALUES(?, ?, ?, ?);
-
-updateUserList:
-UPDATE UserList SET name = ?, itemIds = ? WHERE id = ?;
+saveUserList:
+INSERT OR REPLACE INTO UserList(id, name, type, itemIds) VALUES(?, ?, ?, ?);
 
 selectAllUserListsByType:
 SELECT * FROM UserList WHERE type = ?;

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
@@ -16,3 +16,25 @@ DELETE FROM Campaign WHERE id = ?;
 
 selectAllCampaigns:
 SELECT Campaign.* FROM Campaign;
+
+CREATE TABLE UserList (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    itemIds TEXT NOT NULL DEFAULT ''
+);
+
+insertUserList:
+INSERT INTO UserList(id, name, type, itemIds) VALUES(?, ?, ?, ?);
+
+updateUserList:
+UPDATE UserList SET name = ?, itemIds = ? WHERE id = ?;
+
+selectAllUserListsByType:
+SELECT * FROM UserList WHERE type = ?;
+
+selectUserListById:
+SELECT * FROM UserList WHERE id = ?;
+
+deleteUserList:
+DELETE FROM UserList WHERE id = ?;

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
@@ -61,7 +61,7 @@ class UserListRepositoryTest {
             repository.save(updated)
 
             val result = repository.get("1")
-            assertEquals(expected = listOf("spell1", "spell2"), actual = result?.itemIds)
+            assertEquals(expected = updated, actual = result)
         }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
@@ -1,0 +1,91 @@
+package com.cyrillrx.rpg.userlist.data
+
+import com.cyrillrx.rpg.userlist.domain.UserList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UserListRepositoryTest {
+    private fun buildRepository() = RamUserListRepository()
+
+    @Test
+    fun `save and getAll returns list filtered by type`() =
+        runTest {
+            val repository = buildRepository()
+
+            val spellList = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+            val itemList = UserList(id = "2", name = "Artefacts", type = UserList.Type.MAGICAL_ITEM, itemIds = emptyList())
+
+            repository.save(spellList)
+            repository.save(itemList)
+
+            val spellLists = repository.getAll(UserList.Type.SPELL)
+            assertEquals(expected = 1, actual = spellLists.size)
+            assertEquals(expected = spellList, actual = spellLists.first())
+
+            val itemLists = repository.getAll(UserList.Type.MAGICAL_ITEM)
+            assertEquals(expected = 1, actual = itemLists.size)
+            assertEquals(expected = itemList, actual = itemLists.first())
+        }
+
+    @Test
+    fun `get returns the list by id`() =
+        runTest {
+            val repository = buildRepository()
+            val list = UserList(id = "abc", name = "Test", type = UserList.Type.SPELL, itemIds = emptyList())
+
+            repository.save(list)
+
+            val result = repository.get("abc")
+            assertEquals(expected = list, actual = result)
+        }
+
+    @Test
+    fun `get returns null for unknown id`() =
+        runTest {
+            val repository = buildRepository()
+            assertNull(repository.get("missing"))
+        }
+
+    @Test
+    fun `save updates itemIds on existing list`() =
+        runTest {
+            val repository = buildRepository()
+            val list = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+
+            repository.save(list)
+
+            val updated = list.copy(itemIds = listOf("spell1", "spell2"))
+            repository.save(updated)
+
+            val result = repository.get("1")
+            assertEquals(expected = listOf("spell1", "spell2"), actual = result?.itemIds)
+        }
+
+    @Test
+    fun `delete removes list by id`() =
+        runTest {
+            val repository = buildRepository()
+            val list = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+
+            repository.save(list)
+            repository.delete("1")
+
+            assertNull(repository.get("1"))
+            assertTrue(repository.getAll(UserList.Type.SPELL).isEmpty())
+        }
+
+    @Test
+    fun `getAll returns empty list when no lists of given type exist`() =
+        runTest {
+            val repository = buildRepository()
+            val list = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+
+            repository.save(list)
+
+            val creatureLists = repository.getAll(UserList.Type.CREATURE)
+            assertTrue(creatureLists.isEmpty())
+        }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
@@ -15,7 +15,7 @@ class UserListRepositoryTest {
         runTest {
             val repository = buildRepository()
 
-            val spellList = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+            val spellList = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
             val itemList = UserList(id = "2", name = "Artefacts", type = UserList.Type.MAGICAL_ITEM, itemIds = emptyList())
 
             repository.save(spellList)
@@ -53,7 +53,7 @@ class UserListRepositoryTest {
     fun `save updates itemIds on existing list`() =
         runTest {
             val repository = buildRepository()
-            val list = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+            val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
 
             repository.save(list)
 
@@ -68,7 +68,7 @@ class UserListRepositoryTest {
     fun `delete removes list by id`() =
         runTest {
             val repository = buildRepository()
-            val list = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+            val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
 
             repository.save(list)
             repository.delete("1")
@@ -81,7 +81,7 @@ class UserListRepositoryTest {
     fun `getAll returns empty list when no lists of given type exist`() =
         runTest {
             val repository = buildRepository()
-            val list = UserList(id = "1", name = "Grimoire", type = UserList.Type.SPELL, itemIds = emptyList())
+            val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
 
             repository.save(list)
 


### PR DESCRIPTION
## 📝 Description

Introduces the `UserList` data layer entirely within `shared/core`.
This is the foundation for the local spell-list UI feature (follow-up PR).

- add EN/FR string resources for custom lists
- remove unused `encodeToString` import in `Serializer.kt`
- new `UserList` domain model (id, name, type, itemIds) + `UserListRepository` interface
- SQLDelight `UserList` table with 5 queries; `Database.kt` CRUD wrappers
- `SQLDelightUserListRepository` (prod) + `RamUserListRepository` (testing/previews)
- contract tests covering create, read, update itemIds, delete, filter by type

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed

## Test plan

- [x] `./gradlew :shared:core:jvmTest` — all 6 `UserListRepositoryTest` tests pass