### PR TITLE
feat(spell): add light and dark previews for SpellCardScreen

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
@@ -10,11 +10,12 @@ import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.state.DetailState
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_spell_not_found
 
@@ -48,7 +49,18 @@ fun SpellCardScreen(
 
 @Preview
 @Composable
-fun PreviewSpellCardScreen() {
+fun PreviewSpellCardScreenLight() {
     val spell = SampleSpellRepository.getFirst()
-    SpellCardScreen(spell, {})
+    AppThemePreview(darkTheme = false) {
+        SpellCardScreen(spell, {})
+    }
+}
+
+@Preview
+@Composable
+fun PreviewSpellCardScreenDark() {
+    val spell = SampleSpellRepository.getFirst()
+    AppThemePreview(darkTheme = true) {
+        SpellCardScreen(spell, {})
+    }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardScreen.kt
@@ -50,17 +50,19 @@ fun SpellCardScreen(
 @Preview
 @Composable
 fun PreviewSpellCardScreenLight() {
-    val spell = SampleSpellRepository.getFirst()
-    AppThemePreview(darkTheme = false) {
-        SpellCardScreen(spell, {})
-    }
+    PreviewSpellCardScreen(darkTheme = false)
 }
 
 @Preview
 @Composable
 fun PreviewSpellCardScreenDark() {
-    val spell = SampleSpellRepository.getFirst()
-    AppThemePreview(darkTheme = true) {
+    PreviewSpellCardScreen(darkTheme = true)
+}
+
+@Composable
+private fun PreviewSpellCardScreen(darkTheme: Boolean) {
+    val spell = SampleSpellRepository.fireball()
+    AppThemePreview(darkTheme = darkTheme) {
         SpellCardScreen(spell, {})
     }
 }


### PR DESCRIPTION
## 📝 Description

This PR adds preview views (Light and Dark) for the SpellCardScreen component.
It replaces the old single PreviewSpellCardScreen with two distinct previews using the project's AppThemePreview container, adhering to the UI conventions defined in the project.

## 🖼️ Media

<img width="668" height="708" alt="image" src="https://github.com/user-attachments/assets/1e915504-0022-4031-9863-7ed3b12947eb" />

## ✅ Checklist

- [x] Code follows the conventions in AGENTS.md and docs/conventions/
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed