### PR TITLE
refactor(viewmodel): migrate to Kotlin explicit backing fields

### DIFF
--- a/cmp-ttrpg-companion/composeApp/build.gradle.kts
+++ b/cmp-ttrpg-companion/composeApp/build.gradle.kts
@@ -12,6 +12,11 @@ plugins {
 }
 
 kotlin {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xexplicit-backing-fields")
+    }
+
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
@@ -9,7 +9,6 @@ import com.cyrillrx.rpg.campaign.domain.RuleSet
 import com.cyrillrx.rpg.campaign.navigation.CampaignRouter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -18,35 +17,33 @@ class CreateCampaignViewModel(
     private val repository: CampaignRepository,
 ) : ViewModel() {
 
-    private val _state: MutableStateFlow<CreateCampaignState> = MutableStateFlow(
-        CreateCampaignState(campaignName = "", selectedRuleSet = RuleSet.UNDEFINED, error = null),
-    )
-    val state: StateFlow<CreateCampaignState> = _state.asStateFlow()
+    val state: StateFlow<CreateCampaignState>
+        field = MutableStateFlow(CreateCampaignState(campaignName = "", selectedRuleSet = RuleSet.UNDEFINED, error = null))
 
     fun onNavigateUpClicked() {
         router.navigateUp()
     }
 
     fun onCampaignNameChanged(name: String) {
-        _state.update { _state.value.copy(campaignName = name) }
+        state.update { state.value.copy(campaignName = name) }
     }
 
     fun onRuleSetSelected(ruleSet: RuleSet) {
-        _state.update { _state.value.copy(selectedRuleSet = ruleSet) }
+        state.update { state.value.copy(selectedRuleSet = ruleSet) }
     }
 
     fun onCreateCampaignClicked() {
-        val state = _state.value
-        val campaignName = state.campaignName.trim()
-        val selectedRuleSet = state.selectedRuleSet
+        val currentState = state.value
+        val campaignName = currentState.campaignName.trim()
+        val selectedRuleSet = currentState.selectedRuleSet
 
         if (campaignName.isBlank()) {
-            _state.update { _state.value.copy(error = CreateCampaignError.EmptyCampaignName) }
+            state.update { state.value.copy(error = CreateCampaignError.EmptyCampaignName) }
             return
         }
 
         if (selectedRuleSet == RuleSet.UNDEFINED) {
-            _state.update { _state.value.copy(error = CreateCampaignError.UndefinedRuleSet) }
+            state.update { state.value.copy(error = CreateCampaignError.UndefinedRuleSet) }
             return
         }
 
@@ -59,7 +56,7 @@ class CreateCampaignViewModel(
         viewModelScope.launch {
             val campaignAlreadyExists = repository.get(newCampaign.id) != null
             if (campaignAlreadyExists) {
-                _state.update { _state.value.copy(error = CreateCampaignError.CampaignAlreadyExists) }
+                state.update { state.value.copy(error = CreateCampaignError.CampaignAlreadyExists) }
                 return@launch
             }
 
@@ -69,6 +66,6 @@ class CreateCampaignViewModel(
     }
 
     fun clearError() {
-        _state.update { _state.value.copy(error = null) }
+        state.update { state.value.copy(error = null) }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
@@ -25,11 +25,11 @@ class CreateCampaignViewModel(
     }
 
     fun onCampaignNameChanged(name: String) {
-        state.update { state.value.copy(campaignName = name) }
+        state.update { it.copy(campaignName = name) }
     }
 
     fun onRuleSetSelected(ruleSet: RuleSet) {
-        state.update { state.value.copy(selectedRuleSet = ruleSet) }
+        state.update { it.copy(selectedRuleSet = ruleSet) }
     }
 
     fun onCreateCampaignClicked() {
@@ -38,12 +38,12 @@ class CreateCampaignViewModel(
         val selectedRuleSet = currentState.selectedRuleSet
 
         if (campaignName.isBlank()) {
-            state.update { state.value.copy(error = CreateCampaignError.EmptyCampaignName) }
+            state.update { it.copy(error = CreateCampaignError.EmptyCampaignName) }
             return
         }
 
         if (selectedRuleSet == RuleSet.UNDEFINED) {
-            state.update { state.value.copy(error = CreateCampaignError.UndefinedRuleSet) }
+            state.update { it.copy(error = CreateCampaignError.UndefinedRuleSet) }
             return
         }
 
@@ -56,7 +56,7 @@ class CreateCampaignViewModel(
         viewModelScope.launch {
             val campaignAlreadyExists = repository.get(newCampaign.id) != null
             if (campaignAlreadyExists) {
-                state.update { state.value.copy(error = CreateCampaignError.CampaignAlreadyExists) }
+                state.update { it.copy(error = CreateCampaignError.CampaignAlreadyExists) }
                 return@launch
             }
 
@@ -66,6 +66,6 @@ class CreateCampaignViewModel(
     }
 
     fun clearError() {
-        state.update { state.value.copy(error = null) }
+        state.update { it.copy(error = null) }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -49,14 +49,14 @@ class CampaignListViewModel(
             val filter = CampaignFilter(query = query)
             val campaigns = repository.getAll(filter)
             if (campaigns.isEmpty()) {
-                state.update { state.value.copy(body = CampaignListState.Body.Empty) }
+                state.update { it.copy(body = CampaignListState.Body.Empty) }
             } else {
-                state.update { state.value.copy(body = CampaignListState.Body.WithData(campaigns)) }
+                state.update { it.copy(body = CampaignListState.Body.WithData(campaigns)) }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            state.update { state.value.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
+            state.update { it.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -10,7 +10,6 @@ import com.cyrillrx.rpg.campaign.navigation.CampaignRouter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -23,10 +22,8 @@ class CampaignListViewModel(
 ) : ViewModel() {
 
     private var updateJob: Job? = null
-    private val _state: MutableStateFlow<CampaignListState> = MutableStateFlow(
-        CampaignListState(searchQuery = "", body = CampaignListState.Body.Empty),
-    )
-    val state: StateFlow<CampaignListState> = _state.asStateFlow()
+    val state: StateFlow<CampaignListState>
+        field = MutableStateFlow(CampaignListState(searchQuery = "", body = CampaignListState.Body.Empty))
 
     fun onNavigateUpClicked() {
         router.navigateUp()
@@ -46,20 +43,20 @@ class CampaignListViewModel(
     }
 
     private suspend fun updateData(query: String) {
-        _state.update { CampaignListState(searchQuery = query, body = CampaignListState.Body.Loading) }
+        state.update { CampaignListState(searchQuery = query, body = CampaignListState.Body.Loading) }
 
         try {
             val filter = CampaignFilter(query = query)
             val campaigns = repository.getAll(filter)
             if (campaigns.isEmpty()) {
-                _state.update { _state.value.copy(body = CampaignListState.Body.Empty) }
+                state.update { state.value.copy(body = CampaignListState.Body.Empty) }
             } else {
-                _state.update { _state.value.copy(body = CampaignListState.Body.WithData(campaigns)) }
+                state.update { state.value.copy(body = CampaignListState.Body.WithData(campaigns)) }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _state.update { _state.value.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
+            state.update { state.value.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
@@ -53,14 +53,14 @@ class PlayerCharacterListViewModel(
             val filter = PlayerCharacterFilter(query = query)
             val characters = repository.getAll(filter)
             if (characters.isEmpty()) {
-                state.update { state.value.copy(body = PlayerCharacterListState.Body.Empty) }
+                state.update { it.copy(body = PlayerCharacterListState.Body.Empty) }
             } else {
-                state.update { state.value.copy(body = PlayerCharacterListState.Body.WithData(characters)) }
+                state.update { it.copy(body = PlayerCharacterListState.Body.WithData(characters)) }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            state.update { state.value.copy(body = PlayerCharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
+            state.update { it.copy(body = PlayerCharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
@@ -10,7 +10,6 @@ import com.cyrillrx.rpg.character.presentation.navigation.PlayerCharacterRouter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -23,10 +22,8 @@ class PlayerCharacterListViewModel(
 ) : ViewModel() {
 
     private var updateJob: Job? = null
-    private val _state: MutableStateFlow<PlayerCharacterListState> = MutableStateFlow(
-        PlayerCharacterListState(searchQuery = "", body = PlayerCharacterListState.Body.Empty),
-    )
-    val state: StateFlow<PlayerCharacterListState> = _state.asStateFlow()
+    val state: StateFlow<PlayerCharacterListState>
+        field = MutableStateFlow(PlayerCharacterListState(searchQuery = "", body = PlayerCharacterListState.Body.Empty))
 
     init {
         onSearchQueryChanged(query = "")
@@ -50,20 +47,20 @@ class PlayerCharacterListViewModel(
     }
 
     private suspend fun updateData(query: String) {
-        _state.update { PlayerCharacterListState(searchQuery = "", body = PlayerCharacterListState.Body.Loading) }
+        state.update { PlayerCharacterListState(searchQuery = "", body = PlayerCharacterListState.Body.Loading) }
 
         try {
             val filter = PlayerCharacterFilter(query = query)
             val characters = repository.getAll(filter)
             if (characters.isEmpty()) {
-                _state.update { _state.value.copy(body = PlayerCharacterListState.Body.Empty) }
+                state.update { state.value.copy(body = PlayerCharacterListState.Body.Empty) }
             } else {
-                _state.update { _state.value.copy(body = PlayerCharacterListState.Body.WithData(characters)) }
+                state.update { state.value.copy(body = PlayerCharacterListState.Body.WithData(characters)) }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _state.update { _state.value.copy(body = PlayerCharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
+            state.update { state.value.copy(body = PlayerCharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
@@ -47,7 +47,7 @@ class PlayerCharacterListViewModel(
     }
 
     private suspend fun updateData(query: String) {
-        state.update { PlayerCharacterListState(searchQuery = "", body = PlayerCharacterListState.Body.Loading) }
+        state.update { PlayerCharacterListState(searchQuery = query, body = PlayerCharacterListState.Body.Loading) }
 
         try {
             val filter = PlayerCharacterFilter(query = query)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -11,7 +11,6 @@ import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRouter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -24,10 +23,8 @@ class CreatureListViewModel(
 ) : ViewModel() {
 
     private var updateJob: Job? = null
-    private val _state: MutableStateFlow<CreatureListState> = MutableStateFlow(
-        CreatureListState(body = CreatureListState.Body.Empty),
-    )
-    val state: StateFlow<CreatureListState> = _state.asStateFlow()
+    val state: StateFlow<CreatureListState>
+        field = MutableStateFlow(CreatureListState(body = CreatureListState.Body.Empty))
 
     init {
         refreshData()
@@ -58,7 +55,7 @@ class CreatureListViewModel(
     }
 
     private fun updateFilter(transform: (CreatureFilter) -> CreatureFilter) {
-        _state.update { it.copy(filter = transform(it.filter)) }
+        state.update { it.copy(filter = transform(it.filter)) }
         refreshData()
     }
 
@@ -68,8 +65,8 @@ class CreatureListViewModel(
     }
 
     private suspend fun updateData() {
-        val filter = _state.value.filter
-        _state.update { it.copy(body = CreatureListState.Body.Loading) }
+        val filter = state.value.filter
+        state.update { it.copy(body = CreatureListState.Body.Loading) }
 
         try {
             val creatures = repository.getAll(filter)
@@ -78,11 +75,11 @@ class CreatureListViewModel(
             } else {
                 CreatureListState.Body.WithData(searchResults = creatures)
             }
-            _state.update { it.copy(body = body) }
+            state.update { it.copy(body = body) }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _state.update { it.copy(body = CreatureListState.Body.Error(errorMessage = Res.string.error_while_loading_creatures)) }
+            state.update { it.copy(body = CreatureListState.Body.Error(errorMessage = Res.string.error_while_loading_creatures)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -11,7 +11,6 @@ import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -24,10 +23,8 @@ class MagicalItemListViewModel(
 ) : ViewModel() {
 
     private var updateJob: Job? = null
-    private val _state: MutableStateFlow<MagicalItemListState> = MutableStateFlow(
-        MagicalItemListState(body = MagicalItemListState.Body.Empty),
-    )
-    val state: StateFlow<MagicalItemListState> = _state.asStateFlow()
+    val state: StateFlow<MagicalItemListState>
+        field = MutableStateFlow(MagicalItemListState(body = MagicalItemListState.Body.Empty))
 
     init {
         refreshData()
@@ -58,7 +55,7 @@ class MagicalItemListViewModel(
     }
 
     private fun updateFilter(transform: (MagicalItemFilter) -> MagicalItemFilter) {
-        _state.update { it.copy(filter = transform(it.filter)) }
+        state.update { it.copy(filter = transform(it.filter)) }
         refreshData()
     }
 
@@ -68,8 +65,8 @@ class MagicalItemListViewModel(
     }
 
     private suspend fun updateData() {
-        val filter = _state.value.filter
-        _state.update { it.copy(body = MagicalItemListState.Body.Loading) }
+        val filter = state.value.filter
+        state.update { it.copy(body = MagicalItemListState.Body.Loading) }
 
         try {
             val magicalItems = repository.getAll(filter)
@@ -78,11 +75,11 @@ class MagicalItemListViewModel(
             } else {
                 MagicalItemListState.Body.WithData(searchResults = magicalItems)
             }
-            _state.update { it.copy(body = body) }
+            state.update { it.copy(body = body) }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _state.update { it.copy(body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)) }
+            state.update { it.copy(body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListDetailViewModel.kt
@@ -7,7 +7,6 @@ import com.cyrillrx.rpg.spell.presentation.SpellListDetailState
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -20,8 +19,8 @@ class SpellListDetailViewModel(
     private val spellRepository: SpellRepository,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(SpellListDetailState())
-    val state: StateFlow<SpellListDetailState> = _state.asStateFlow()
+    val state: StateFlow<SpellListDetailState>
+        field = MutableStateFlow(SpellListDetailState())
 
     init {
         loadDetail()
@@ -38,11 +37,11 @@ class SpellListDetailViewModel(
 
     private fun loadDetail() {
         viewModelScope.launch {
-            _state.update { it.copy(body = SpellListDetailState.Body.Loading) }
+            state.update { it.copy(body = SpellListDetailState.Body.Loading) }
 
             try {
                 val list = userListRepository.get(listId) ?: error("error_while_loading_user_list")
-                _state.update { it.copy(listName = list.name) }
+                state.update { it.copy(listName = list.name) }
 
                 val spells = list.itemIds.mapNotNull { spellRepository.getById(it) }
                 val body = if (spells.isEmpty()) {
@@ -50,11 +49,11 @@ class SpellListDetailViewModel(
                 } else {
                     SpellListDetailState.Body.WithData(spells)
                 }
-                _state.update { it.copy(body = body) }
+                state.update { it.copy(body = body) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _state.update { it.copy(body = SpellListDetailState.Body.Error(errorMessage = Res.string.error_while_loading_user_list)) }
+                state.update { it.copy(body = SpellListDetailState.Body.Error(errorMessage = Res.string.error_while_loading_user_list)) }
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -12,7 +12,6 @@ import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -25,10 +24,8 @@ class SpellListViewModel(
 ) : ViewModel() {
 
     private var updateJob: Job? = null
-    private val _state: MutableStateFlow<SpellListState> = MutableStateFlow(
-        SpellListState(body = SpellListState.Body.Empty),
-    )
-    val state: StateFlow<SpellListState> = _state.asStateFlow()
+    val state: StateFlow<SpellListState>
+        field = MutableStateFlow(SpellListState(body = SpellListState.Body.Empty))
 
     init {
         refreshData()
@@ -63,7 +60,7 @@ class SpellListViewModel(
     }
 
     private fun updateFilter(transform: (SpellFilter) -> SpellFilter) {
-        _state.update { it.copy(filter = transform(it.filter)) }
+        state.update { it.copy(filter = transform(it.filter)) }
         refreshData()
     }
 
@@ -73,8 +70,8 @@ class SpellListViewModel(
     }
 
     private suspend fun updateData() {
-        val filter = _state.value.filter
-        _state.update { it.copy(body = SpellListState.Body.Loading) }
+        val filter = state.value.filter
+        state.update { it.copy(body = SpellListState.Body.Loading) }
 
         try {
             val spells = repository.getAll(filter)
@@ -83,11 +80,11 @@ class SpellListViewModel(
             } else {
                 SpellListState.Body.WithData(spells)
             }
-            _state.update { it.copy(body = body) }
+            state.update { it.copy(body = body) }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _state.update { it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
+            state.update { it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddSpellToListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddSpellToListViewModel.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -28,11 +26,11 @@ class AddSpellToListViewModel(
     private val spellRepository: SpellRepository,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(AddToListState())
-    val state: StateFlow<AddToListState> = _state.asStateFlow()
+    val state: StateFlow<AddToListState>
+        field = MutableStateFlow(AddToListState())
 
-    private val _events = MutableSharedFlow<Event>()
-    val events: SharedFlow<Event> = _events.asSharedFlow()
+    val events: SharedFlow<Event>
+        field = MutableSharedFlow<Event>()
 
     init {
         loadLists()
@@ -40,7 +38,7 @@ class AddSpellToListViewModel(
 
     private fun loadLists() {
         viewModelScope.launch {
-            _state.update { it.copy(body = AddToListState.Body.Loading) }
+            state.update { it.copy(body = AddToListState.Body.Loading) }
 
             try {
                 val spell = spellRepository.getById(itemId) ?: error("Could Not find spell $itemId")
@@ -52,17 +50,17 @@ class AddSpellToListViewModel(
                     spell = spell,
                     selectableLists = selectableLists,
                 )
-                _state.update { it.copy(body = body) }
+                state.update { it.copy(body = body) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _state.update { it.copy(body = AddToListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
+                state.update { it.copy(body = AddToListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
             }
         }
     }
 
     fun toggleSelection(listId: String) {
-        _state.update { state ->
+        state.update { state ->
             val body = state.body as? AddToListState.Body.WithData ?: return@update state
 
             val selectableLists = body.selectableLists.map { item ->
@@ -84,7 +82,7 @@ class AddSpellToListViewModel(
             )
             userListRepository.save(newList)
 
-            _state.update { state ->
+            state.update { state ->
                 val body = state.body as? AddToListState.Body.WithData ?: return@update state
 
                 val newLists = body.selectableLists + SelectableUserList(newList, alreadyAdded = true)
@@ -95,10 +93,10 @@ class AddSpellToListViewModel(
 
     fun confirmSelection() {
         viewModelScope.launch {
-            val body = _state.value.body as? AddToListState.Body.WithData ?: return@launch
+            val body = state.value.body as? AddToListState.Body.WithData ?: return@launch
 
             body.selectableLists.forEach { selectableList -> selectableList.confirmSelection() }
-            _events.emit(Event.Dismiss)
+            events.emit(Event.Dismiss)
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -8,7 +8,6 @@ import com.cyrillrx.rpg.userlist.presentation.UserListsState
 import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
@@ -23,8 +22,8 @@ class UserListsViewModel(
     private val userListRepository: UserListRepository,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(UserListsState())
-    val state: StateFlow<UserListsState> = _state.asStateFlow()
+    val state: StateFlow<UserListsState>
+        field = MutableStateFlow(UserListsState())
 
     init {
         loadLists()
@@ -61,7 +60,7 @@ class UserListsViewModel(
 
     private fun loadLists() {
         viewModelScope.launch {
-            _state.update { it.copy(body = UserListsState.Body.Loading) }
+            state.update { it.copy(body = UserListsState.Body.Loading) }
 
             try {
                 val lists = userListRepository.getAll(listType)
@@ -70,11 +69,11 @@ class UserListsViewModel(
                 } else {
                     UserListsState.Body.WithData(lists)
                 }
-                _state.update { it.copy(body = body) }
+                state.update { it.copy(body = body) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _state.update { it.copy(body = UserListsState.Body.Error(errorMessage = Res.string.error_while_loading_user_lists)) }
+                state.update { it.copy(body = UserListsState.Body.Error(errorMessage = Res.string.error_while_loading_user_lists)) }
             }
         }
     }


### PR DESCRIPTION
## 📝 Description

Replace the `private val _state`/`_events` + `.asStateFlow()`/`.asSharedFlow()` pattern with Kotlin Explicit Backing Fields (EBF) across all 9 ViewModels.
EBF exposes the mutable backing field type only inside the class, removing the need for the underscore convention and the wrapper calls.

Also enables the `-Xexplicit-backing-fields` compiler flag in `composeApp/build.gradle.kts`.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed