### PR TITLE
feat(creature): add custom creature lists

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -43,7 +43,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
             handleSpellRoutes(navController, JsonSpellRepository(fileReader), userListRepository)
             handleMagicalItemRoutes(navController, JsonMagicalItemRepository(fileReader), userListRepository)
-            handleCreatureRoutes(navController, JsonCreatureRepository(fileReader))
+            handleCreatureRoutes(navController, JsonCreatureRepository(fileReader), userListRepository)
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureListDetailState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureListDetailState.kt
@@ -1,0 +1,16 @@
+package com.cyrillrx.rpg.creature.presentation
+
+import com.cyrillrx.rpg.creature.domain.Creature
+import org.jetbrains.compose.resources.StringResource
+
+data class CreatureListDetailState(
+    val listName: String = "",
+    val body: Body = Body.Loading,
+) {
+    sealed interface Body {
+        data object Loading : Body
+        data object EmptyList : Body
+        data class Error(val errorMessage: StringResource) : Body
+        data class WithData(val creatures: List<Creature>) : Body
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
@@ -1,9 +1,12 @@
 package com.cyrillrx.rpg.creature.presentation.component
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -13,30 +16,38 @@ import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRouter
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_add_to_list
 import rpg_companion.composeapp.generated.resources.error_creature_not_found
 
 @Composable
 fun CreatureDetailScreen(
     viewModel: CreatureDetailViewModel,
-    onNavigateUpClicked: () -> Unit,
+    router: CreatureRouter,
 ) {
     val state by viewModel.state.collectAsState()
     when (val s = state) {
         DetailState.Loading -> Loader()
         is DetailState.NotFound -> ErrorLayout(stringResource(Res.string.error_creature_not_found, s.id))
-        is DetailState.Found -> CreatureDetailScreen(s.item, onNavigateUpClicked)
+        is DetailState.Found -> CreatureDetailScreen(
+            creature = s.item,
+            onAddToListClicked = router::openAddToList,
+            onNavigateUpClicked = router::navigateUp,
+        )
     }
 }
 
 @Composable
 fun CreatureDetailScreen(
     creature: Creature,
+    onAddToListClicked: (creatureId: String) -> Unit,
     onNavigateUpClicked: () -> Unit,
 ) {
     Scaffold(
@@ -45,6 +56,16 @@ fun CreatureDetailScreen(
                 title = creature.name,
                 navigateUp = onNavigateUpClicked,
             )
+        },
+        bottomBar = {
+            Button(
+                onClick = { onAddToListClicked(creature.id) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacingMedium),
+            ) {
+                Text(stringResource(Res.string.btn_add_to_list))
+            }
         },
     ) { paddingValues ->
         CreatureItem(
@@ -60,7 +81,11 @@ fun CreatureDetailScreen(
 @Composable
 private fun PreviewCreatureDetailScreenLight() {
     AppThemePreview(darkTheme = false) {
-        CreatureDetailScreen(creature = SampleCreatureRepository.getFirst(), onNavigateUpClicked = {})
+        CreatureDetailScreen(
+            creature = SampleCreatureRepository.getFirst(),
+            onAddToListClicked = {},
+            onNavigateUpClicked = {},
+        )
     }
 }
 
@@ -68,6 +93,10 @@ private fun PreviewCreatureDetailScreenLight() {
 @Composable
 private fun PreviewCreatureDetailScreenDark() {
     AppThemePreview(darkTheme = true) {
-        CreatureDetailScreen(creature = SampleCreatureRepository.getFirst(), onNavigateUpClicked = {})
+        CreatureDetailScreen(
+            creature = SampleCreatureRepository.getFirst(),
+            onAddToListClicked = {},
+            onNavigateUpClicked = {},
+        )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListDetailScreen.kt
@@ -1,0 +1,159 @@
+package com.cyrillrx.rpg.creature.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.component.dialog.ConfirmDeleteDialog
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.presentation.CreatureListDetailState
+import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListDetailViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.dialog_remove_from_list_message
+import rpg_companion.composeapp.generated.resources.message_list_is_empty
+
+@Composable
+fun CreatureListDetailScreen(
+    viewModel: CreatureListDetailViewModel,
+    onNavigateUpClicked: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    CreatureListDetailScreen(
+        state = state,
+        onNavigateUpClicked = onNavigateUpClicked,
+        onRemoveCreatureClicked = viewModel::removeCreature,
+    )
+}
+
+@Composable
+fun CreatureListDetailScreen(
+    state: CreatureListDetailState,
+    onNavigateUpClicked: () -> Unit,
+    onRemoveCreatureClicked: (String) -> Unit,
+) {
+    var itemToRemove by remember { mutableStateOf<Creature?>(null) }
+
+    Scaffold(
+        topBar = {
+            SimpleTopBar(
+                title = state.listName,
+                navigateUp = onNavigateUpClicked,
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            when (val body = state.body) {
+                is CreatureListDetailState.Body.Loading -> Loader()
+                is CreatureListDetailState.Body.EmptyList -> ErrorLayout(Res.string.message_list_is_empty)
+                is CreatureListDetailState.Body.Error -> ErrorLayout(body.errorMessage)
+                is CreatureListDetailState.Body.WithData -> CreatureDetailList(
+                    creatures = body.creatures,
+                    onRemoveCreature = { itemToRemove = it },
+                )
+            }
+        }
+    }
+
+    itemToRemove?.let { creature ->
+        ConfirmDeleteDialog(
+            message = stringResource(Res.string.dialog_remove_from_list_message, creature.name),
+            onConfirm = {
+                onRemoveCreatureClicked(creature.id)
+                itemToRemove = null
+            },
+            onDismiss = { itemToRemove = null },
+        )
+    }
+}
+
+@Composable
+private fun CreatureDetailList(
+    creatures: List<Creature>,
+    onRemoveCreature: (Creature) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(spacingMedium),
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+    ) {
+        items(creatures, key = { it.id }) { creature ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                CreatureCompactListItem(
+                    creature = creature,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = { onRemoveCreature(creature) }) {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureListDetailScreenLight() {
+    CreatureListDetailScreenPreview(darkTheme = false)
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureListDetailScreenDark() {
+    CreatureListDetailScreenPreview(darkTheme = true)
+}
+
+@Composable
+private fun CreatureListDetailScreenPreview(darkTheme: Boolean) {
+    val creatures = SampleCreatureRepository.getAll()
+    AppThemePreview(darkTheme = darkTheme) {
+        CreatureListDetailScreen(
+            state = CreatureListDetailState(
+                listName = "Bestiary",
+                body = CreatureListDetailState.Body.WithData(creatures),
+            ),
+            onNavigateUpClicked = {},
+            onRemoveCreatureClicked = {},
+        )
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -8,12 +8,27 @@ import androidx.navigation.toRoute
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailScreen
+import com.cyrillrx.rpg.creature.presentation.component.CreatureListDetailScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureListScreen
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModelFactory
+import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListDetailViewModel
+import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListDetailViewModelFactory
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModelFactory
+import com.cyrillrx.rpg.userlist.domain.UserList
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+import com.cyrillrx.rpg.userlist.presentation.component.AddCreatureToListScreen
+import com.cyrillrx.rpg.userlist.presentation.component.UserListsScreen
+import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouterImpl
+import com.cyrillrx.rpg.userlist.presentation.viewmodel.AddCreatureToListViewModel
+import com.cyrillrx.rpg.userlist.presentation.viewmodel.AddCreatureToListViewModelFactory
+import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
+import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
 import kotlinx.serialization.Serializable
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.title_my_bestiary_lists
 
 interface CreatureRoute {
     @Serializable
@@ -24,9 +39,22 @@ interface CreatureRoute {
 
     @Serializable
     data class Detail(val creatureId: String)
+
+    @Serializable
+    data object UserLists
+
+    @Serializable
+    data class UserListDetail(val listId: String)
+
+    @Serializable
+    data class AddToList(val creatureId: String)
 }
 
-fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repository: CreatureRepository) {
+fun NavGraphBuilder.handleCreatureRoutes(
+    navController: NavController,
+    repository: CreatureRepository,
+    userListRepository: UserListRepository,
+) {
     composable<CreatureRoute.CompactList> {
         val router = CreatureRouterImpl(navController)
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
@@ -42,10 +70,49 @@ fun NavGraphBuilder.handleCreatureRoutes(navController: NavController, repositor
     }
 
     composable<CreatureRoute.Detail> { entry ->
+        val router = CreatureRouterImpl(navController)
         val id = entry.toRoute<CreatureRoute.Detail>().creatureId
         val viewModel = viewModel<CreatureDetailViewModel>(
             factory = CreatureDetailViewModelFactory(id, repository),
         )
-        CreatureDetailScreen(viewModel, onNavigateUpClicked = { navController.navigateUp() })
+        CreatureDetailScreen(viewModel = viewModel, router = router)
+    }
+
+    composable<CreatureRoute.AddToList> { entry ->
+        val route = entry.toRoute<CreatureRoute.AddToList>()
+        val viewModel = viewModel<AddCreatureToListViewModel>(
+            factory = AddCreatureToListViewModelFactory(
+                itemId = route.creatureId,
+                listType = UserList.Type.CREATURE,
+                userListRepository = userListRepository,
+                creatureRepository = repository,
+            ),
+        )
+        AddCreatureToListScreen(
+            viewModel = viewModel,
+            onNavigateUp = { navController.navigateUp() },
+        )
+    }
+
+    composable<CreatureRoute.UserLists> {
+        val router = UserListRouterImpl(navController)
+        val viewModel = viewModel<UserListsViewModel>(
+            factory = UserListsViewModelFactory(UserList.Type.CREATURE, router, userListRepository),
+        )
+        UserListsScreen(
+            viewModel = viewModel,
+            title = stringResource(Res.string.title_my_bestiary_lists),
+        )
+    }
+
+    composable<CreatureRoute.UserListDetail> { entry ->
+        val listId = entry.toRoute<CreatureRoute.UserListDetail>().listId
+        val viewModel = viewModel<CreatureListDetailViewModel>(
+            factory = CreatureListDetailViewModelFactory(listId, userListRepository, repository),
+        )
+        CreatureListDetailScreen(
+            viewModel = viewModel,
+            onNavigateUpClicked = { navController.navigateUp() },
+        )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -6,6 +6,7 @@ import com.cyrillrx.rpg.creature.domain.Creature
 interface CreatureRouter {
     fun navigateUp()
     fun openCreatureDetail(creature: Creature)
+    fun openAddToList(creatureId: String) {}
 }
 
 class CreatureRouterImpl(private val navController: NavController) : CreatureRouter {
@@ -15,5 +16,9 @@ class CreatureRouterImpl(private val navController: NavController) : CreatureRou
 
     override fun openCreatureDetail(creature: Creature) {
         navController.navigate(CreatureRoute.Detail(creature.id))
+    }
+
+    override fun openAddToList(creatureId: String) {
+        navController.navigate(CreatureRoute.AddToList(creatureId))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListDetailViewModel.kt
@@ -1,0 +1,60 @@
+package com.cyrillrx.rpg.creature.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import com.cyrillrx.rpg.creature.presentation.CreatureListDetailState
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.error_while_loading_user_list
+import kotlin.coroutines.cancellation.CancellationException
+
+class CreatureListDetailViewModel(
+    private val listId: String,
+    private val userListRepository: UserListRepository,
+    private val creatureRepository: CreatureRepository,
+) : ViewModel() {
+
+    val state: StateFlow<CreatureListDetailState>
+        field = MutableStateFlow(CreatureListDetailState())
+
+    init {
+        loadDetail()
+    }
+
+    fun removeCreature(creatureId: String) {
+        viewModelScope.launch {
+            val result = userListRepository.removeFromList(listId, creatureId)
+            if (result is UserListRepository.Result.Success) {
+                loadDetail()
+            }
+        }
+    }
+
+    private fun loadDetail() {
+        viewModelScope.launch {
+            state.update { it.copy(body = CreatureListDetailState.Body.Loading) }
+
+            try {
+                val list = userListRepository.get(listId) ?: error("error_while_loading_user_list")
+                state.update { it.copy(listName = list.name) }
+
+                val creatures = creatureRepository.getByIds(list.itemIds)
+                val body = if (creatures.isEmpty()) {
+                    CreatureListDetailState.Body.EmptyList
+                } else {
+                    CreatureListDetailState.Body.WithData(creatures)
+                }
+                state.update { it.copy(body = body) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                state.update { it.copy(body = CreatureListDetailState.Body.Error(errorMessage = Res.string.error_while_loading_user_list)) }
+            }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListDetailViewModelFactory.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListDetailViewModelFactory.kt
@@ -1,0 +1,19 @@
+package com.cyrillrx.rpg.creature.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+import kotlin.reflect.KClass
+
+class CreatureListDetailViewModelFactory(
+    private val listId: String,
+    private val userListRepository: UserListRepository,
+    private val creatureRepository: CreatureRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+        @Suppress("UNCHECKED_CAST")
+        return CreatureListDetailViewModel(listId, userListRepository, creatureRepository) as T
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -63,6 +63,6 @@ class HomeRouterImpl(private val navController: NavController) : HomeRouter {
     }
 
     override fun openMyCreatureLists() {
-        // TODO: navigate to CreatureRoute.MyCreatureLists when implemented
+        navController.navigate(CreatureRoute.UserLists)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/AddCreatureToListState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/AddCreatureToListState.kt
@@ -1,0 +1,20 @@
+package com.cyrillrx.rpg.userlist.presentation
+
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.userlist.domain.UserList
+import org.jetbrains.compose.resources.StringResource
+
+data class AddCreatureToListState(
+    val body: Body = Body.Loading,
+) {
+    data class SelectableUserList(val list: UserList, val alreadyAdded: Boolean, val isSelected: Boolean = alreadyAdded)
+
+    sealed interface Body {
+        data object Loading : Body
+        data class Error(val errorMessage: StringResource) : Body
+        data class WithData(
+            val creature: Creature,
+            val selectableLists: List<SelectableUserList>,
+        ) : Body
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/AddCreatureHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/AddCreatureHeader.kt
@@ -1,0 +1,67 @@
+package com.cyrillrx.rpg.userlist.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import com.cyrillrx.rpg.creature.domain.Creature
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun AddCreatureHeader(creature: Creature, modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = creature.name,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        Text(
+            text = creature.type.toFormattedString(),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(spacingMedium))
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewAddCreatureHeaderLight() {
+    AddCreatureHeaderPreview(darkTheme = false)
+}
+
+@Preview
+@Composable
+private fun PreviewAddCreatureHeaderDark() {
+    AddCreatureHeaderPreview(darkTheme = true)
+}
+
+@Composable
+private fun AddCreatureHeaderPreview(darkTheme: Boolean) {
+    val creature = SampleCreatureRepository.getFirst()
+    AppThemePreview(darkTheme = darkTheme) {
+        AddCreatureHeader(creature)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/AddCreatureToListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/AddCreatureToListScreen.kt
@@ -1,0 +1,167 @@
+package com.cyrillrx.rpg.userlist.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.component.dialog.CreateListDialog
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
+import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
+import com.cyrillrx.rpg.userlist.presentation.AddCreatureToListState
+import com.cyrillrx.rpg.userlist.presentation.viewmodel.AddCreatureToListViewModel
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_add_to_list
+import rpg_companion.composeapp.generated.resources.btn_confirm
+import rpg_companion.composeapp.generated.resources.btn_create_list
+
+@Composable
+fun AddCreatureToListScreen(
+    viewModel: AddCreatureToListViewModel,
+    onNavigateUp: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    var showCreateDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect {
+            when (it) {
+                AddCreatureToListViewModel.Event.Dismiss -> onNavigateUp()
+            }
+        }
+    }
+
+    AddCreatureToListScreenContent(
+        body = state.body,
+        onNavigateUp = onNavigateUp,
+        onToggleSelection = { viewModel.toggleSelection(it) },
+        onConfirm = { viewModel.confirmSelection() },
+        onCreateListClicked = { showCreateDialog = true },
+    )
+
+    if (showCreateDialog) {
+        CreateListDialog(
+            onConfirm = { name ->
+                viewModel.createAndAdd(name)
+                showCreateDialog = false
+            },
+            onDismiss = { showCreateDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun AddCreatureToListScreenContent(
+    body: AddCreatureToListState.Body,
+    onNavigateUp: () -> Unit,
+    onToggleSelection: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onCreateListClicked: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SimpleTopBar(
+                title = stringResource(Res.string.btn_add_to_list),
+                navigateUp = onNavigateUp,
+            )
+        },
+        bottomBar = {
+            Button(
+                onClick = onConfirm,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacingMedium, vertical = spacingCommon),
+            ) {
+                Text(stringResource(Res.string.btn_confirm))
+            }
+        },
+    ) { paddingValues ->
+        LazyColumn(
+            contentPadding = PaddingValues(
+                start = spacingMedium,
+                end = spacingMedium,
+                top = paddingValues.calculateTopPadding(),
+                bottom = paddingValues.calculateBottomPadding() + spacingMedium,
+            ),
+            verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        ) {
+            when (body) {
+                is AddCreatureToListState.Body.Loading -> item { Loader() }
+                is AddCreatureToListState.Body.Error -> item { ErrorLayout(body.errorMessage) }
+                is AddCreatureToListState.Body.WithData -> {
+                    item { AddCreatureHeader(body.creature) }
+                    items(body.selectableLists, key = { it.list.id }) { item ->
+                        SelectableUserListItem(
+                            name = item.list.name,
+                            isSelected = item.isSelected,
+                            onClick = { onToggleSelection(item.list.id) },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+
+            item {
+                TextButton(
+                    onClick = onCreateListClicked,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(Res.string.btn_create_list))
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewAddCreatureToListScreenLight() {
+    PreviewAddCreatureToListScreen(darkTheme = false)
+}
+
+@Preview
+@Composable
+fun PreviewAddCreatureToListScreenDark() {
+    PreviewAddCreatureToListScreen(darkTheme = true)
+}
+
+@Composable
+private fun PreviewAddCreatureToListScreen(darkTheme: Boolean) {
+    val creature = SampleCreatureRepository.getFirst()
+    val lists = SampleUserListRepository.getAll()
+    val body = AddCreatureToListState.Body.WithData(
+        creature = creature,
+        selectableLists = lists.map { AddCreatureToListState.SelectableUserList(it, alreadyAdded = false) },
+    )
+    AppThemePreview(darkTheme = darkTheme) {
+        AddCreatureToListScreenContent(
+            body = body,
+            onNavigateUp = {},
+            onToggleSelection = {},
+            onConfirm = {},
+            onCreateListClicked = {},
+        )
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.userlist.presentation.navigation
 
 import androidx.navigation.NavController
+import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRoute
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRoute
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRoute
 import com.cyrillrx.rpg.userlist.domain.UserList
@@ -19,7 +20,7 @@ class UserListRouterImpl(private val navController: NavController) : UserListRou
         when (list.type) {
             UserList.Type.SPELL -> navController.navigate(SpellRoute.UserListDetail(list.id))
             UserList.Type.MAGICAL_ITEM -> navController.navigate(MagicalItemRoute.UserListDetail(list.id))
-            UserList.Type.CREATURE -> TODO()
+            UserList.Type.CREATURE -> navController.navigate(CreatureRoute.UserListDetail(list.id))
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddCreatureToListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddCreatureToListViewModel.kt
@@ -1,0 +1,113 @@
+package com.cyrillrx.rpg.userlist.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import com.cyrillrx.rpg.userlist.domain.UserList
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+import com.cyrillrx.rpg.userlist.presentation.AddCreatureToListState
+import com.cyrillrx.rpg.userlist.presentation.AddCreatureToListState.SelectableUserList
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.error_while_loading_creatures
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class AddCreatureToListViewModel(
+    private val itemId: String,
+    private val listType: UserList.Type,
+    private val userListRepository: UserListRepository,
+    private val creatureRepository: CreatureRepository,
+) : ViewModel() {
+
+    val state: StateFlow<AddCreatureToListState>
+        field = MutableStateFlow(AddCreatureToListState())
+
+    val events: SharedFlow<Event>
+        field = MutableSharedFlow<Event>()
+
+    init {
+        loadLists()
+    }
+
+    private fun loadLists() {
+        viewModelScope.launch {
+            state.update { it.copy(body = AddCreatureToListState.Body.Loading) }
+
+            try {
+                val creature = creatureRepository.getById(itemId) ?: error("Could not find creature $itemId")
+
+                val userLists = userListRepository.getAll(listType)
+                val selectableLists = userLists
+                    .map { list -> SelectableUserList(list, alreadyAdded = itemId in list.itemIds) }
+                val body = AddCreatureToListState.Body.WithData(
+                    creature = creature,
+                    selectableLists = selectableLists,
+                )
+                state.update { it.copy(body = body) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                state.update { it.copy(body = AddCreatureToListState.Body.Error(errorMessage = Res.string.error_while_loading_creatures)) }
+            }
+        }
+    }
+
+    fun toggleSelection(listId: String) {
+        state.update { state ->
+            val body = state.body as? AddCreatureToListState.Body.WithData ?: return@update state
+
+            val selectableLists = body.selectableLists.map { item ->
+                if (item.list.id == listId) item.copy(isSelected = !item.isSelected) else item
+            }
+
+            state.copy(body = body.copy(selectableLists = selectableLists))
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun createAndAdd(name: String) {
+        viewModelScope.launch {
+            val newList = UserList(
+                id = Uuid.random().toString(),
+                name = name,
+                type = listType,
+                itemIds = listOf(itemId),
+            )
+            userListRepository.save(newList)
+
+            state.update { state ->
+                val body = state.body as? AddCreatureToListState.Body.WithData ?: return@update state
+
+                val newLists = body.selectableLists + SelectableUserList(newList, alreadyAdded = true)
+                state.copy(body = body.copy(selectableLists = newLists))
+            }
+        }
+    }
+
+    fun confirmSelection() {
+        viewModelScope.launch {
+            val body = state.value.body as? AddCreatureToListState.Body.WithData ?: return@launch
+
+            body.selectableLists.forEach { selectableList -> selectableList.confirmSelection() }
+            events.emit(Event.Dismiss)
+        }
+    }
+
+    private suspend fun SelectableUserList.confirmSelection() {
+        when {
+            !alreadyAdded && isSelected -> userListRepository.addToList(list, itemId)
+            alreadyAdded && !isSelected -> userListRepository.removeFromList(list, itemId)
+        }
+    }
+
+    sealed class Event {
+        data object Dismiss : Event()
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddCreatureToListViewModelFactory.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddCreatureToListViewModelFactory.kt
@@ -1,0 +1,21 @@
+package com.cyrillrx.rpg.userlist.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.creature.domain.CreatureRepository
+import com.cyrillrx.rpg.userlist.domain.UserList
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+import kotlin.reflect.KClass
+
+class AddCreatureToListViewModelFactory(
+    private val itemId: String,
+    private val listType: UserList.Type,
+    private val userListRepository: UserListRepository,
+    private val creatureRepository: CreatureRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+        @Suppress("UNCHECKED_CAST")
+        return AddCreatureToListViewModel(itemId, listType, userListRepository, creatureRepository) as T
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonCreatureRepository.kt
@@ -28,6 +28,11 @@ class JsonCreatureRepository(private val fileReader: FileReader) : CreatureRepos
     override suspend fun getById(id: String): Creature? =
         getAll(null).firstOrNull { it.id == id }
 
+    override suspend fun getByIds(ids: List<String>): List<Creature> {
+        val all = getAll(null).associateBy { it.id }
+        return ids.mapNotNull { all[it] }
+    }
+
     private suspend fun loadFromFile(): List<ApiBestiaryItem> {
         val result = fileReader.readFile("files/bestiaire.json")
         if (result is Result.Success) {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/CreatureRepository.kt
@@ -3,4 +3,5 @@ package com.cyrillrx.rpg.creature.domain
 interface CreatureRepository {
     suspend fun getAll(filter: CreatureFilter?): List<Creature>
     suspend fun getById(id: String): Creature?
+    suspend fun getByIds(ids: List<String>): List<Creature> = ids.mapNotNull { getById(it) }
 }


### PR DESCRIPTION
## 📝 Description

Implements user-managed creature lists (bestiaries), mirroring the existing spell and magical item list features.

- Adds `CreatureRepository.getByIds()` (default + optimised cache override in `JsonCreatureRepository`)
- New state classes: `AddCreatureToListState`, `CreatureListDetailState`
- New ViewModels: `AddCreatureToListViewModel/Factory`, `CreatureListDetailViewModel/Factory`
- New screens: `AddCreatureToListScreen`, `CreatureListDetailScreen`, `AddCreatureHeader`
- Extends `CreatureRoute` with `UserLists`, `UserListDetail`, `AddToList` routes
- Adds `openAddToList()` to `CreatureRouter`
- Updates `CreatureDetailScreen` to accept `CreatureRouter` and shows "Add to List" bottom bar button
- Resolves `TODO()` in `UserListRouter` for `UserList.Type.CREATURE`
- Implements `openMyCreatureLists()` in `HomeRouter`
- Passes `userListRepository` to `handleCreatureRoutes` in `App.kt`

## 🖼️ Media
<img width="1026" height="1086" alt="image" src="https://github.com/user-attachments/assets/0d2c6e09-7664-4645-b2d1-413b19dc02c4" />

<img width="1108" height="1184" alt="image" src="https://github.com/user-attachments/assets/632ef0d9-e844-4ef2-97bb-34eff6485fc3" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed