### PR TITLE
feat(userlist): navigate to item detail on row click in ListDetailScreen

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureHeaderProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureHeaderProvider.kt
@@ -1,4 +1,4 @@
-package com.cyrillrx.rpg.magicalitem.presentation
+package com.cyrillrx.rpg.creature.presentation
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,32 +15,26 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
-import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
-import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListItem
+import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.userlist.presentation.HeaderProvider
-import com.cyrillrx.rpg.userlist.presentation.DeletableItemProvider
 
-class MagicalItemUiProvider : DeletableItemProvider<MagicalItem>, HeaderProvider<MagicalItem> {
-
-    override fun getId(entity: MagicalItem): String = entity.id
-
-    override fun getDisplayName(entity: MagicalItem): String = entity.title
+class CreatureHeaderProvider : HeaderProvider<Creature> {
 
     @Composable
-    override fun Header(entity: MagicalItem) {
+    override fun Header(entity: Creature) {
         Column(
             verticalArrangement = Arrangement.spacedBy(spacingSmall),
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
-                text = entity.title,
+                text = entity.name,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = "${entity.type.toFormattedString()} · ${entity.rarity.toFormattedString()}",
+                text = entity.type.toFormattedString(),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -48,10 +42,5 @@ class MagicalItemUiProvider : DeletableItemProvider<MagicalItem>, HeaderProvider
             )
             HorizontalDivider(modifier = Modifier.padding(spacingMedium))
         }
-    }
-
-    @Composable
-    override fun ListItem(entity: MagicalItem, modifier: Modifier) {
-        MagicalItemListItem(magicalItem = entity, onClick = {}, modifier = modifier)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
@@ -1,0 +1,21 @@
+package com.cyrillrx.rpg.creature.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListItem
+import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
+
+class CreatureItemProvider(
+    private val onItemClicked: (String) -> Unit,
+) : ListItemProvider<Creature> {
+
+    override fun getId(entity: Creature): String = entity.id
+
+    override fun getDisplayName(entity: Creature): String = entity.name
+
+    @Composable
+    override fun ListItem(entity: Creature, modifier: Modifier) {
+        CreatureCompactListItem(creature = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -8,7 +8,8 @@ import androidx.navigation.toRoute
 import com.cyrillrx.rpg.creature.data.CreatureEntityRepository
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
-import com.cyrillrx.rpg.creature.presentation.CreatureUiProvider
+import com.cyrillrx.rpg.creature.presentation.CreatureHeaderProvider
+import com.cyrillrx.rpg.creature.presentation.CreatureItemProvider
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureListScreen
@@ -75,9 +76,9 @@ fun NavGraphBuilder.handleCreatureRoutes(
 
     composable<CreatureRoute.Detail> { entry ->
         val router = CreatureRouterImpl(navController)
-        val id = entry.toRoute<CreatureRoute.Detail>().creatureId
+        val creatureId = entry.toRoute<CreatureRoute.Detail>().creatureId
         val viewModel = viewModel<CreatureDetailViewModel>(
-            factory = CreatureDetailViewModelFactory(id, repository),
+            factory = CreatureDetailViewModelFactory(creatureId, repository),
         )
         CreatureDetailScreen(viewModel = viewModel, router = router)
     }
@@ -95,7 +96,7 @@ fun NavGraphBuilder.handleCreatureRoutes(
         )
         AddToListScreen(
             viewModel = viewModel,
-            headerProvider = CreatureUiProvider(),
+            headerProvider = CreatureHeaderProvider(),
             onNavigateUp = { navController.navigateUp() },
         )
     }
@@ -119,8 +120,8 @@ fun NavGraphBuilder.handleCreatureRoutes(
         val router = CreatureRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
-            router = router,
-            uiProvider = CreatureUiProvider(),
+            itemProvider = CreatureItemProvider(onItemClicked = router::openDetail),
+            onNavigateUp = { navController.navigateUp() },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -116,10 +116,11 @@ fun NavGraphBuilder.handleCreatureRoutes(
         val viewModel = viewModel<ListDetailViewModel<Creature>>(
             factory = ListDetailViewModelFactory(listId, userListRepository, CreatureEntityRepository(repository)),
         )
+        val router = CreatureRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
+            router = router,
             uiProvider = CreatureUiProvider(),
-            onNavigateUpClicked = { navController.navigateUp() },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -1,7 +1,6 @@
 package com.cyrillrx.rpg.creature.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
 
 interface CreatureRouter {
     fun navigateUp()
@@ -9,7 +8,7 @@ interface CreatureRouter {
     fun openAddToList(creatureId: String) {}
 }
 
-class CreatureRouterImpl(private val navController: NavController) : CreatureRouter, ListDetailRouter {
+class CreatureRouterImpl(private val navController: NavController) : CreatureRouter {
     override fun navigateUp() {
         navController.navigateUp()
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -1,21 +1,21 @@
 package com.cyrillrx.rpg.creature.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
 
 interface CreatureRouter {
     fun navigateUp()
-    fun openCreatureDetail(creature: Creature)
+    fun openDetail(id: String)
     fun openAddToList(creatureId: String) {}
 }
 
-class CreatureRouterImpl(private val navController: NavController) : CreatureRouter {
+class CreatureRouterImpl(private val navController: NavController) : CreatureRouter, ListDetailRouter {
     override fun navigateUp() {
         navController.navigateUp()
     }
 
-    override fun openCreatureDetail(creature: Creature) {
-        navController.navigate(CreatureRoute.Detail(creature.id))
+    override fun openDetail(id: String) {
+        navController.navigate(CreatureRoute.Detail(id))
     }
 
     override fun openAddToList(creatureId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -39,7 +39,7 @@ class CreatureListViewModel(
     }
 
     fun onCreatureClicked(creature: Creature) {
-        router.openCreatureDetail(creature)
+        router.openDetail(creature.id)
     }
 
     fun onTypeToggled(type: Creature.Type) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemHeaderProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemHeaderProvider.kt
@@ -1,4 +1,4 @@
-package com.cyrillrx.rpg.creature.presentation
+package com.cyrillrx.rpg.magicalitem.presentation
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,32 +15,26 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
-import com.cyrillrx.rpg.creature.domain.Creature
-import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListItem
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.userlist.presentation.HeaderProvider
-import com.cyrillrx.rpg.userlist.presentation.DeletableItemProvider
 
-class CreatureUiProvider : DeletableItemProvider<Creature>, HeaderProvider<Creature> {
-
-    override fun getId(entity: Creature): String = entity.id
-
-    override fun getDisplayName(entity: Creature): String = entity.name
+class MagicalItemHeaderProvider : HeaderProvider<MagicalItem> {
 
     @Composable
-    override fun Header(entity: Creature) {
+    override fun Header(entity: MagicalItem) {
         Column(
             verticalArrangement = Arrangement.spacedBy(spacingSmall),
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
-                text = entity.name,
+                text = entity.title,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = entity.type.toFormattedString(),
+                text = "${entity.type.toFormattedString()} · ${entity.rarity.toFormattedString()}",
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -48,10 +42,5 @@ class CreatureUiProvider : DeletableItemProvider<Creature>, HeaderProvider<Creat
             )
             HorizontalDivider(modifier = Modifier.padding(spacingMedium))
         }
-    }
-
-    @Composable
-    override fun ListItem(entity: Creature, modifier: Modifier) {
-        CreatureCompactListItem(creature = entity, onClick = {}, modifier = modifier)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
@@ -1,0 +1,21 @@
+package com.cyrillrx.rpg.magicalitem.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListItem
+import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
+
+class MagicalItemItemProvider(
+    private val onItemClicked: (String) -> Unit,
+) : ListItemProvider<MagicalItem> {
+
+    override fun getId(entity: MagicalItem): String = entity.id
+
+    override fun getDisplayName(entity: MagicalItem): String = entity.title
+
+    @Composable
+    override fun ListItem(entity: MagicalItem, modifier: Modifier) {
+        MagicalItemListItem(magicalItem = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -116,10 +116,11 @@ fun NavGraphBuilder.handleMagicalItemRoutes(
         val viewModel = viewModel<ListDetailViewModel<MagicalItem>>(
             factory = ListDetailViewModelFactory(listId, userListRepository, MagicalItemEntityRepository(repository)),
         )
+        val router = MagicalItemRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
+            router = router,
             uiProvider = MagicalItemUiProvider(),
-            onNavigateUpClicked = { navController.navigateUp() },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -8,7 +8,8 @@ import androidx.navigation.toRoute
 import com.cyrillrx.rpg.magicalitem.data.MagicalItemEntityRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
-import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemUiProvider
+import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemHeaderProvider
+import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemItemProvider
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardCarouselScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListScreen
@@ -95,7 +96,7 @@ fun NavGraphBuilder.handleMagicalItemRoutes(
         )
         AddToListScreen(
             viewModel = viewModel,
-            headerProvider = MagicalItemUiProvider(),
+            headerProvider = MagicalItemHeaderProvider(),
             onNavigateUp = { navController.navigateUp() },
         )
     }
@@ -119,8 +120,8 @@ fun NavGraphBuilder.handleMagicalItemRoutes(
         val router = MagicalItemRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
-            router = router,
-            uiProvider = MagicalItemUiProvider(),
+            itemProvider = MagicalItemItemProvider(onItemClicked = router::openDetail),
+            onNavigateUp = { navController.navigateUp() },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
@@ -1,7 +1,6 @@
 package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
 
 interface MagicalItemRouter {
     fun navigateUp()
@@ -9,7 +8,7 @@ interface MagicalItemRouter {
     fun openAddToList(magicalItemId: String) {}
 }
 
-class MagicalItemRouterImpl(private val navController: NavController) : MagicalItemRouter, ListDetailRouter {
+class MagicalItemRouterImpl(private val navController: NavController) : MagicalItemRouter {
     override fun navigateUp() {
         navController.navigateUp()
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
@@ -1,21 +1,21 @@
 package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
 
 interface MagicalItemRouter {
     fun navigateUp()
-    fun openMagicalItemDetail(magicalItem: MagicalItem)
+    fun openDetail(id: String)
     fun openAddToList(magicalItemId: String) {}
 }
 
-class MagicalItemRouterImpl(private val navController: NavController) : MagicalItemRouter {
+class MagicalItemRouterImpl(private val navController: NavController) : MagicalItemRouter, ListDetailRouter {
     override fun navigateUp() {
         navController.navigateUp()
     }
 
-    override fun openMagicalItemDetail(magicalItem: MagicalItem) {
-        navController.navigate(MagicalItemRoute.Detail(magicalItem.id))
+    override fun openDetail(id: String) {
+        navController.navigate(MagicalItemRoute.Detail(id))
     }
 
     override fun openAddToList(magicalItemId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -39,7 +39,7 @@ class MagicalItemListViewModel(
     }
 
     fun onItemClicked(magicalItem: MagicalItem) {
-        router.openMagicalItemDetail(magicalItem)
+        router.openDetail(magicalItem.id)
     }
 
     fun onTypeToggled(type: MagicalItem.Type) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellHeaderProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellHeaderProvider.kt
@@ -21,15 +21,9 @@ import com.cyrillrx.rpg.core.presentation.theme.iconSizeMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.domain.Spell
-import com.cyrillrx.rpg.spell.presentation.component.SpellListItem
 import com.cyrillrx.rpg.userlist.presentation.HeaderProvider
-import com.cyrillrx.rpg.userlist.presentation.DeletableItemProvider
 
-class SpellUiProvider : DeletableItemProvider<Spell>, HeaderProvider<Spell> {
-
-    override fun getId(entity: Spell): String = entity.id
-
-    override fun getDisplayName(entity: Spell): String = entity.title
+class SpellHeaderProvider : HeaderProvider<Spell> {
 
     @Composable
     override fun Header(entity: Spell) {
@@ -65,10 +59,5 @@ class SpellUiProvider : DeletableItemProvider<Spell>, HeaderProvider<Spell> {
             }
             HorizontalDivider(modifier = Modifier.padding(spacingMedium))
         }
-    }
-
-    @Composable
-    override fun ListItem(entity: Spell, modifier: Modifier) {
-        SpellListItem(spell = entity, onClick = {}, modifier = modifier)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
@@ -1,0 +1,21 @@
+package com.cyrillrx.rpg.spell.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.spell.domain.Spell
+import com.cyrillrx.rpg.spell.presentation.component.SpellListItem
+import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
+
+class SpellItemProvider(
+    private val onItemClicked: (String) -> Unit,
+) : ListItemProvider<Spell> {
+
+    override fun getId(entity: Spell): String = entity.id
+
+    override fun getDisplayName(entity: Spell): String = entity.title
+
+    @Composable
+    override fun ListItem(entity: Spell, modifier: Modifier) {
+        SpellListItem(spell = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -41,7 +41,7 @@ fun SpellCardCarouselScreen(viewModel: SpellListViewModel, router: SpellRouter) 
         state = state,
         onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
-        onSpellClicked = router::openSpellDetail,
+        onSpellClicked = { spell -> router.openDetail(spell.id) },
         onLevelToggled = viewModel::onLevelToggled,
         onSchoolToggled = viewModel::onSchoolToggled,
         onClassToggled = viewModel::onClassToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -45,7 +45,7 @@ fun SpellListScreen(viewModel: SpellListViewModel, router: SpellRouter) {
         state = state,
         onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
-        onSpellClicked = router::openSpellDetail,
+        onSpellClicked = { spell -> router.openDetail(spell.id) },
         onLevelToggled = viewModel::onLevelToggled,
         onSchoolToggled = viewModel::onSchoolToggled,
         onClassToggled = viewModel::onClassToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -121,10 +121,11 @@ fun NavGraphBuilder.handleSpellRoutes(
         val viewModel = viewModel<ListDetailViewModel<Spell>>(
             factory = ListDetailViewModelFactory(listId, userListRepository, SpellEntityRepository(spellRepository)),
         )
+        val router = SpellRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
+            router = router,
             uiProvider = SpellUiProvider(),
-            onNavigateUpClicked = { navController.navigateUp() },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -10,7 +10,8 @@ import androidx.navigation.toRoute
 import com.cyrillrx.rpg.spell.data.SpellEntityRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellRepository
-import com.cyrillrx.rpg.spell.presentation.SpellUiProvider
+import com.cyrillrx.rpg.spell.presentation.SpellHeaderProvider
+import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardCarouselScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellListScreen
@@ -80,9 +81,9 @@ fun NavGraphBuilder.handleSpellRoutes(
 
     composable<SpellRoute.Detail> { entry ->
         val router = SpellRouterImpl(navController)
-        val id = entry.toRoute<SpellRoute.Detail>().spellId
+        val spellId = entry.toRoute<SpellRoute.Detail>().spellId
         val viewModel = viewModel<SpellDetailViewModel>(
-            factory = SpellDetailViewModelFactory(id, spellRepository),
+            factory = SpellDetailViewModelFactory(spellId, spellRepository),
         )
         SpellCardScreen(viewModel = viewModel, router = router)
     }
@@ -100,7 +101,7 @@ fun NavGraphBuilder.handleSpellRoutes(
         )
         AddToListScreen(
             viewModel = viewModel,
-            headerProvider = SpellUiProvider(),
+            headerProvider = SpellHeaderProvider(),
             onNavigateUp = { navController.navigateUp() },
         )
     }
@@ -124,8 +125,8 @@ fun NavGraphBuilder.handleSpellRoutes(
         val router = SpellRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
-            router = router,
-            uiProvider = SpellUiProvider(),
+            itemProvider = SpellItemProvider(onItemClicked = router::openDetail),
+            onNavigateUp = { navController.navigateUp() },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
@@ -1,23 +1,23 @@
 package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.rpg.spell.domain.Spell
+import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
 
 interface SpellRouter {
     fun navigateUp()
-    fun openSpellDetail(spell: Spell)
+    fun openDetail(id: String)
     fun openMySpellLists() {}
     fun openSpellListDetail(listId: String) {}
     fun openAddToList(spellId: String) {}
 }
 
-class SpellRouterImpl(private val navController: NavController) : SpellRouter {
+class SpellRouterImpl(private val navController: NavController) : SpellRouter, ListDetailRouter {
     override fun navigateUp() {
         navController.navigateUp()
     }
 
-    override fun openSpellDetail(spell: Spell) {
-        navController.navigate(SpellRoute.Detail(spell.id))
+    override fun openDetail(id: String) {
+        navController.navigate(SpellRoute.Detail(id))
     }
 
     override fun openMySpellLists() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
@@ -1,7 +1,6 @@
 package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.navigation.NavController
-import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
 
 interface SpellRouter {
     fun navigateUp()
@@ -11,7 +10,7 @@ interface SpellRouter {
     fun openAddToList(spellId: String) {}
 }
 
-class SpellRouterImpl(private val navController: NavController) : SpellRouter, ListDetailRouter {
+class SpellRouterImpl(private val navController: NavController) : SpellRouter {
     override fun navigateUp() {
         navController.navigateUp()
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -40,7 +40,7 @@ class SpellListViewModel(
     }
 
     fun onSpellClicked(spell: Spell) {
-        router.openSpellDetail(spell)
+        router.openDetail(spell.id)
     }
 
     fun onLevelToggled(level: Int) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.userlist.presentation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
-interface DeletableItemProvider<T> {
+interface ListItemProvider<T> {
     fun getId(entity: T): String
     fun getDisplayName(entity: T): String
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/AddToListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/AddToListScreen.kt
@@ -27,7 +27,7 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
-import com.cyrillrx.rpg.spell.presentation.SpellUiProvider
+import com.cyrillrx.rpg.spell.presentation.SpellHeaderProvider
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListState
 import com.cyrillrx.rpg.userlist.presentation.HeaderProvider
@@ -164,7 +164,7 @@ private fun AddToListScreenPreview(darkTheme: Boolean) {
     AppThemePreview(darkTheme = darkTheme) {
         AddToListScreenContent(
             body = body,
-            headerProvider = SpellUiProvider(),
+            headerProvider = SpellHeaderProvider(),
             onNavigateUp = {},
             onToggleSelection = {},
             onConfirm = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.cyrillrx.rpg.userlist.presentation.component
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -32,10 +31,9 @@ import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
-import com.cyrillrx.rpg.spell.presentation.SpellUiProvider
-import com.cyrillrx.rpg.userlist.presentation.DeletableItemProvider
+import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
-import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
+import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -46,26 +44,24 @@ import rpg_companion.composeapp.generated.resources.message_list_is_empty
 @Composable
 fun <T> ListDetailScreen(
     viewModel: ListDetailViewModel<T>,
-    router: ListDetailRouter,
-    uiProvider: DeletableItemProvider<T>,
+    itemProvider: ListItemProvider<T>,
+    onNavigateUp: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     ListDetailScreen(
         state = state,
-        uiProvider = uiProvider,
-        onNavigateUpClicked = router::navigateUp,
+        itemProvider = itemProvider,
+        onNavigateUpClicked = onNavigateUp,
         onRemoveItemClicked = viewModel::removeItem,
-        onItemClicked = router::openDetail,
     )
 }
 
 @Composable
 fun <T> ListDetailScreen(
     state: ListDetailState<T>,
-    uiProvider: DeletableItemProvider<T>,
+    itemProvider: ListItemProvider<T>,
     onNavigateUpClicked: () -> Unit,
     onRemoveItemClicked: (String) -> Unit,
-    onItemClicked: (String) -> Unit = {},
 ) {
     var itemToRemove by remember { mutableStateOf<T?>(null) }
 
@@ -89,8 +85,7 @@ fun <T> ListDetailScreen(
                 is ListDetailState.Body.Error -> ErrorLayout(body.errorMessage)
                 is ListDetailState.Body.WithData -> EntityDetailList(
                     items = body.items,
-                    uiProvider = uiProvider,
-                    onItemClicked = onItemClicked,
+                    uiProvider = itemProvider,
                     onRemoveItem = { itemToRemove = it },
                 )
             }
@@ -99,9 +94,9 @@ fun <T> ListDetailScreen(
 
     itemToRemove?.let { item ->
         ConfirmDeleteDialog(
-            message = stringResource(Res.string.dialog_remove_from_list_message, uiProvider.getDisplayName(item)),
+            message = stringResource(Res.string.dialog_remove_from_list_message, itemProvider.getDisplayName(item)),
             onConfirm = {
-                onRemoveItemClicked(uiProvider.getId(item))
+                onRemoveItemClicked(itemProvider.getId(item))
                 itemToRemove = null
             },
             onDismiss = { itemToRemove = null },
@@ -112,8 +107,7 @@ fun <T> ListDetailScreen(
 @Composable
 private fun <T> EntityDetailList(
     items: List<T>,
-    uiProvider: DeletableItemProvider<T>,
-    onItemClicked: (String) -> Unit,
+    uiProvider: ListItemProvider<T>,
     onRemoveItem: (T) -> Unit,
 ) {
     LazyColumn(
@@ -124,9 +118,7 @@ private fun <T> EntityDetailList(
         items(items, key = { uiProvider.getId(it) }) { item ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onItemClicked(uiProvider.getId(item)) },
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 uiProvider.ListItem(
                     entity = item,
@@ -164,7 +156,7 @@ private fun ListDetailScreenPreview(darkTheme: Boolean) {
                 listName = "Gandalf's Spells",
                 body = ListDetailState.Body.WithData(SampleSpellRepository.getAll()),
             ),
-            uiProvider = SpellUiProvider(),
+            itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
             onRemoveItemClicked = {},
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.userlist.presentation.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -34,6 +35,7 @@ import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.presentation.SpellUiProvider
 import com.cyrillrx.rpg.userlist.presentation.DeletableItemProvider
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
+import com.cyrillrx.rpg.userlist.presentation.navigation.ListDetailRouter
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -44,15 +46,16 @@ import rpg_companion.composeapp.generated.resources.message_list_is_empty
 @Composable
 fun <T> ListDetailScreen(
     viewModel: ListDetailViewModel<T>,
+    router: ListDetailRouter,
     uiProvider: DeletableItemProvider<T>,
-    onNavigateUpClicked: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     ListDetailScreen(
         state = state,
         uiProvider = uiProvider,
-        onNavigateUpClicked = onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onRemoveItemClicked = viewModel::removeItem,
+        onItemClicked = router::openDetail,
     )
 }
 
@@ -62,6 +65,7 @@ fun <T> ListDetailScreen(
     uiProvider: DeletableItemProvider<T>,
     onNavigateUpClicked: () -> Unit,
     onRemoveItemClicked: (String) -> Unit,
+    onItemClicked: (String) -> Unit = {},
 ) {
     var itemToRemove by remember { mutableStateOf<T?>(null) }
 
@@ -86,6 +90,7 @@ fun <T> ListDetailScreen(
                 is ListDetailState.Body.WithData -> EntityDetailList(
                     items = body.items,
                     uiProvider = uiProvider,
+                    onItemClicked = onItemClicked,
                     onRemoveItem = { itemToRemove = it },
                 )
             }
@@ -108,6 +113,7 @@ fun <T> ListDetailScreen(
 private fun <T> EntityDetailList(
     items: List<T>,
     uiProvider: DeletableItemProvider<T>,
+    onItemClicked: (String) -> Unit,
     onRemoveItem: (T) -> Unit,
 ) {
     LazyColumn(
@@ -118,7 +124,9 @@ private fun <T> EntityDetailList(
         items(items, key = { uiProvider.getId(it) }) { item ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onItemClicked(uiProvider.getId(item)) },
             ) {
                 uiProvider.ListItem(
                     entity = item,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/ListDetailRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/ListDetailRouter.kt
@@ -1,6 +1,0 @@
-package com.cyrillrx.rpg.userlist.presentation.navigation
-
-interface ListDetailRouter {
-    fun navigateUp()
-    fun openDetail(id: String)
-}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/ListDetailRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/ListDetailRouter.kt
@@ -1,0 +1,6 @@
+package com.cyrillrx.rpg.userlist.presentation.navigation
+
+interface ListDetailRouter {
+    fun navigateUp()
+    fun openDetail(id: String)
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/FailingUserListRepository.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/FailingUserListRepository.kt
@@ -1,0 +1,11 @@
+package com.cyrillrx.rpg.userlist.presentation.viewmodel
+
+import com.cyrillrx.rpg.userlist.domain.UserList
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+
+class FailingUserListRepository : UserListRepository {
+    override suspend fun getAll(type: UserList.Type): List<UserList> = error("Repository failure")
+    override suspend fun get(id: String): UserList = error("Repository failure")
+    override suspend fun save(list: UserList) = Unit
+    override suspend fun delete(id: String) = Unit
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.cyrillrx.rpg.spell.presentation.viewmodel
+package com.cyrillrx.rpg.userlist.presentation.viewmodel
 
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.data.SpellEntityRepository
@@ -7,7 +7,6 @@ import com.cyrillrx.rpg.userlist.data.RamUserListRepository
 import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
-import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -25,7 +24,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SpellListDetailViewModelTest {
+class ListDetailViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private val spellRepository = SpellEntityRepository(SampleSpellRepository())
@@ -155,11 +154,4 @@ class SpellListDetailViewModelTest {
 
         assertIs<ListDetailState.Body.EmptyList>(viewModel.state.value.body)
     }
-}
-
-private class FailingUserListRepository : UserListRepository {
-    override suspend fun getAll(type: UserList.Type): List<UserList> = error("Repository failure")
-    override suspend fun get(id: String): UserList = error("Repository failure")
-    override suspend fun save(list: UserList) = Unit
-    override suspend fun delete(id: String) = Unit
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -2,7 +2,6 @@ package com.cyrillrx.rpg.userlist.presentation.viewmodel
 
 import com.cyrillrx.rpg.userlist.data.RamUserListRepository
 import com.cyrillrx.rpg.userlist.domain.UserList
-import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.UserListsState
 import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouter
 import kotlinx.coroutines.Dispatchers
@@ -154,13 +153,6 @@ class UserListsViewModelTest {
 
 private class NoOpUserListRouter : UserListRouter {
     override fun navigateUp() = Unit
-}
-
-private class FailingUserListRepository : UserListRepository {
-    override suspend fun getAll(type: UserList.Type): List<UserList> = error("Repository failure")
-    override suspend fun get(id: String): UserList? = null
-    override suspend fun save(list: UserList) = Unit
-    override suspend fun delete(id: String) = Unit
 }
 
 private class TrackingUserListRouter : UserListRouter {


### PR DESCRIPTION
## 📝 Description

Tapping a row in `ListDetailScreen` now navigates to the item's detail screen.

- Renames `openSpellDetail(spell)` / `openCreatureDetail(creature)` / `openMagicalItemDetail(item)` → `openDetail(id: String)` in the three feature router interfaces and their implementations
- Creates `HeaderProvider<T>`, used by `AddToListScreen`
- Updates `ListDetailScreen` to take a `ListItemProvider<T>`

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed