### PR TITLE
feat(userlist): add illustrated empty state in ListDetailScreen

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -22,4 +22,8 @@
     <string name="dialog_remove_from_list_message">Êtes-vous sûr de vouloir retirer "%1$s" de cette liste ?</string>
 
     <string name="message_list_is_empty">La liste est vide</string>
+
+    <string name="empty_list_browse_spells">Parcourir les sorts</string>
+    <string name="empty_list_browse_creatures">Parcourir les créatures</string>
+    <string name="empty_list_browse_magical_items">Parcourir les objets magiques</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -22,4 +22,8 @@
     <string name="dialog_remove_from_list_message">Are you sure you want to remove "%1$s" from this list?</string>
 
     <string name="message_list_is_empty">The list is empty</string>
+
+    <string name="empty_list_browse_spells">Browse spells</string>
+    <string name="empty_list_browse_creatures">Browse creatures</string>
+    <string name="empty_list_browse_magical_items">Browse magical items</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
@@ -1,33 +1,24 @@
 package com.cyrillrx.rpg.creature.presentation
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Pets
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
-import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.StringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.empty_list_browse_creatures
-import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 class CreatureItemProvider(
     private val onItemClicked: (String) -> Unit,
-    private val onAddItemsClicked: () -> Unit = {},
+    override val onEmptyLayoutBtnClicked: () -> Unit = {},
 ) : ListItemProvider<Creature> {
+
+    override val emptyLayoutIcon: ImageVector = Icons.Outlined.Pets
+    override val emptyLayoutBtnText: StringResource = Res.string.empty_list_browse_creatures
 
     override fun getId(entity: Creature): String = entity.id
 
@@ -36,30 +27,5 @@ class CreatureItemProvider(
     @Composable
     override fun ListItem(entity: Creature, modifier: Modifier) {
         CreatureCompactListItem(creature = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
-    }
-
-    @Composable
-    override fun EmptyLayout() {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.Pets,
-                contentDescription = null,
-                modifier = Modifier.size(72.dp),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(Res.string.message_list_is_empty),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = onAddItemsClicked) {
-                Text(text = stringResource(Res.string.empty_list_browse_creatures))
-            }
-        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
@@ -1,13 +1,32 @@
 package com.cyrillrx.rpg.creature.presentation
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Pets
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.empty_list_browse_creatures
+import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 class CreatureItemProvider(
     private val onItemClicked: (String) -> Unit,
+    private val onAddItemsClicked: () -> Unit = {},
 ) : ListItemProvider<Creature> {
 
     override fun getId(entity: Creature): String = entity.id
@@ -17,5 +36,30 @@ class CreatureItemProvider(
     @Composable
     override fun ListItem(entity: Creature, modifier: Modifier) {
         CreatureCompactListItem(creature = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
+    }
+
+    @Composable
+    override fun EmptyLayout() {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Pets,
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.message_list_is_empty),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onAddItemsClicked) {
+                Text(text = stringResource(Res.string.empty_list_browse_creatures))
+            }
+        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -122,7 +122,7 @@ fun NavGraphBuilder.handleCreatureRoutes(
             viewModel = viewModel,
             itemProvider = CreatureItemProvider(
                 onItemClicked = router::openDetail,
-                onAddItemsClicked = { navController.navigate(CreatureRoute.List) },
+                onEmptyLayoutBtnClicked = { navController.navigate(CreatureRoute.List) },
             ),
             onNavigateUp = { navController.navigateUp() },
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -120,7 +120,10 @@ fun NavGraphBuilder.handleCreatureRoutes(
         val router = CreatureRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
-            itemProvider = CreatureItemProvider(onItemClicked = router::openDetail),
+            itemProvider = CreatureItemProvider(
+                onItemClicked = router::openDetail,
+                onAddItemsClicked = { navController.navigate(CreatureRoute.List) },
+            ),
             onNavigateUp = { navController.navigateUp() },
         )
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
@@ -1,33 +1,24 @@
 package com.cyrillrx.rpg.magicalitem.presentation
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Stars
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
-import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.StringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.empty_list_browse_magical_items
-import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 class MagicalItemItemProvider(
     private val onItemClicked: (String) -> Unit,
-    private val onAddItemsClicked: () -> Unit = {},
+    override val onEmptyLayoutBtnClicked: () -> Unit = {},
 ) : ListItemProvider<MagicalItem> {
+
+    override val emptyLayoutIcon: ImageVector = Icons.Outlined.Stars
+    override val emptyLayoutBtnText: StringResource = Res.string.empty_list_browse_magical_items
 
     override fun getId(entity: MagicalItem): String = entity.id
 
@@ -36,30 +27,5 @@ class MagicalItemItemProvider(
     @Composable
     override fun ListItem(entity: MagicalItem, modifier: Modifier) {
         MagicalItemListItem(magicalItem = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
-    }
-
-    @Composable
-    override fun EmptyLayout() {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.Stars,
-                contentDescription = null,
-                modifier = Modifier.size(72.dp),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(Res.string.message_list_is_empty),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = onAddItemsClicked) {
-                Text(text = stringResource(Res.string.empty_list_browse_magical_items))
-            }
-        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
@@ -1,13 +1,32 @@
 package com.cyrillrx.rpg.magicalitem.presentation
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Stars
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.empty_list_browse_magical_items
+import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 class MagicalItemItemProvider(
     private val onItemClicked: (String) -> Unit,
+    private val onAddItemsClicked: () -> Unit = {},
 ) : ListItemProvider<MagicalItem> {
 
     override fun getId(entity: MagicalItem): String = entity.id
@@ -17,5 +36,30 @@ class MagicalItemItemProvider(
     @Composable
     override fun ListItem(entity: MagicalItem, modifier: Modifier) {
         MagicalItemListItem(magicalItem = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
+    }
+
+    @Composable
+    override fun EmptyLayout() {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Stars,
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.message_list_is_empty),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onAddItemsClicked) {
+                Text(text = stringResource(Res.string.empty_list_browse_magical_items))
+            }
+        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -120,7 +120,10 @@ fun NavGraphBuilder.handleMagicalItemRoutes(
         val router = MagicalItemRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
-            itemProvider = MagicalItemItemProvider(onItemClicked = router::openDetail),
+            itemProvider = MagicalItemItemProvider(
+                onItemClicked = router::openDetail,
+                onAddItemsClicked = { navController.navigate(MagicalItemRoute.List) },
+            ),
             onNavigateUp = { navController.navigateUp() },
         )
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -122,7 +122,7 @@ fun NavGraphBuilder.handleMagicalItemRoutes(
             viewModel = viewModel,
             itemProvider = MagicalItemItemProvider(
                 onItemClicked = router::openDetail,
-                onAddItemsClicked = { navController.navigate(MagicalItemRoute.List) },
+                onEmptyLayoutBtnClicked = { navController.navigate(MagicalItemRoute.List) },
             ),
             onNavigateUp = { navController.navigateUp() },
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
@@ -1,13 +1,32 @@
 package com.cyrillrx.rpg.spell.presentation
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MenuBook
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.component.SpellListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.empty_list_browse_spells
+import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 class SpellItemProvider(
     private val onItemClicked: (String) -> Unit,
+    private val onAddItemsClicked: () -> Unit = {},
 ) : ListItemProvider<Spell> {
 
     override fun getId(entity: Spell): String = entity.id
@@ -17,5 +36,30 @@ class SpellItemProvider(
     @Composable
     override fun ListItem(entity: Spell, modifier: Modifier) {
         SpellListItem(spell = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
+    }
+
+    @Composable
+    override fun EmptyLayout() {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.MenuBook,
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.message_list_is_empty),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onAddItemsClicked) {
+                Text(text = stringResource(Res.string.empty_list_browse_spells))
+            }
+        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
@@ -1,33 +1,24 @@
 package com.cyrillrx.rpg.spell.presentation
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.MenuBook
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.component.SpellListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
-import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.StringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.empty_list_browse_spells
-import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 class SpellItemProvider(
     private val onItemClicked: (String) -> Unit,
-    private val onAddItemsClicked: () -> Unit = {},
+    override val onEmptyLayoutBtnClicked: () -> Unit = {},
 ) : ListItemProvider<Spell> {
+
+    override val emptyLayoutIcon: ImageVector = Icons.Outlined.MenuBook
+    override val emptyLayoutBtnText: StringResource = Res.string.empty_list_browse_spells
 
     override fun getId(entity: Spell): String = entity.id
 
@@ -36,30 +27,5 @@ class SpellItemProvider(
     @Composable
     override fun ListItem(entity: Spell, modifier: Modifier) {
         SpellListItem(spell = entity, onClick = { onItemClicked(entity.id) }, modifier = modifier)
-    }
-
-    @Composable
-    override fun EmptyLayout() {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.MenuBook,
-                contentDescription = null,
-                modifier = Modifier.size(72.dp),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(Res.string.message_list_is_empty),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = onAddItemsClicked) {
-                Text(text = stringResource(Res.string.empty_list_browse_spells))
-            }
-        }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -125,7 +125,10 @@ fun NavGraphBuilder.handleSpellRoutes(
         val router = SpellRouterImpl(navController)
         ListDetailScreen(
             viewModel = viewModel,
-            itemProvider = SpellItemProvider(onItemClicked = router::openDetail),
+            itemProvider = SpellItemProvider(
+                onItemClicked = router::openDetail,
+                onAddItemsClicked = { navController.navigate(SpellRoute.List) },
+            ),
             onNavigateUp = { navController.navigateUp() },
         )
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -127,7 +127,7 @@ fun NavGraphBuilder.handleSpellRoutes(
             viewModel = viewModel,
             itemProvider = SpellItemProvider(
                 onItemClicked = router::openDetail,
-                onAddItemsClicked = { navController.navigate(SpellRoute.List) },
+                onEmptyLayoutBtnClicked = { navController.navigate(SpellRoute.List) },
             ),
             onNavigateUp = { navController.navigateUp() },
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
@@ -1,24 +1,11 @@
 package com.cyrillrx.rpg.userlist.presentation
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
+import com.cyrillrx.rpg.userlist.presentation.component.EmptyListLayout
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 interface ListItemProvider<T> {
     fun getId(entity: T): String
@@ -33,26 +20,10 @@ interface ListItemProvider<T> {
 
     @Composable
     fun EmptyLayout() {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Icon(
-                imageVector = emptyLayoutIcon,
-                contentDescription = null,
-                modifier = Modifier.size(72.dp),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(Res.string.message_list_is_empty),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = onEmptyLayoutBtnClicked) {
-                Text(text = stringResource(emptyLayoutBtnText))
-            }
-        }
+        EmptyListLayout(
+            icon = emptyLayoutIcon,
+            btnText = stringResource(emptyLayoutBtnText),
+            onBtnClicked = onEmptyLayoutBtnClicked,
+        )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
@@ -1,7 +1,24 @@
 package com.cyrillrx.rpg.userlist.presentation
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 interface ListItemProvider<T> {
     fun getId(entity: T): String
@@ -10,6 +27,32 @@ interface ListItemProvider<T> {
     @Composable
     fun ListItem(entity: T, modifier: Modifier)
 
+    val emptyLayoutIcon: ImageVector
+    val emptyLayoutBtnText: StringResource
+    val onEmptyLayoutBtnClicked: () -> Unit get() = {}
+
     @Composable
-    fun EmptyLayout()
+    fun EmptyLayout() {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = emptyLayoutIcon,
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.message_list_is_empty),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onEmptyLayoutBtnClicked) {
+                Text(text = stringResource(emptyLayoutBtnText))
+            }
+        }
+    }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.userlist.presentation.component.EmptyListLayout
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 interface ListItemProvider<T> {
     fun getId(entity: T): String
@@ -22,6 +24,7 @@ interface ListItemProvider<T> {
     fun EmptyLayout() {
         EmptyListLayout(
             icon = emptyLayoutIcon,
+            message = stringResource(Res.string.message_list_is_empty),
             btnText = stringResource(emptyLayoutBtnText),
             onBtnClicked = onEmptyLayoutBtnClicked,
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
@@ -9,4 +9,7 @@ interface ListItemProvider<T> {
 
     @Composable
     fun ListItem(entity: T, modifier: Modifier)
+
+    @Composable
+    fun EmptyLayout()
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/EmptyListLayout.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/EmptyListLayout.kt
@@ -18,14 +18,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
-import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 @Composable
 fun EmptyListLayout(
     icon: ImageVector,
+    message: String,
     btnText: String,
     onBtnClicked: () -> Unit,
 ) {
@@ -42,7 +40,7 @@ fun EmptyListLayout(
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = stringResource(Res.string.message_list_is_empty),
+            text = message,
             color = MaterialTheme.colorScheme.onBackground,
             style = MaterialTheme.typography.bodyLarge,
         )
@@ -70,6 +68,7 @@ private fun EmptyListLayoutPreview(darkTheme: Boolean) {
     AppThemePreview(darkTheme = darkTheme) {
         EmptyListLayout(
             icon = Icons.AutoMirrored.Outlined.MenuBook,
+            message = "The list is empty",
             btnText = "Browse spells",
             onBtnClicked = {},
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/EmptyListLayout.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/EmptyListLayout.kt
@@ -1,0 +1,77 @@
+package com.cyrillrx.rpg.userlist.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.MenuBook
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.message_list_is_empty
+
+@Composable
+fun EmptyListLayout(
+    icon: ImageVector,
+    btnText: String,
+    onBtnClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(Res.string.message_list_is_empty),
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onBtnClicked) {
+            Text(text = btnText)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewEmptyListLayoutLight() {
+    EmptyListLayoutPreview(darkTheme = false)
+}
+
+@Preview
+@Composable
+private fun PreviewEmptyListLayoutDark() {
+    EmptyListLayoutPreview(darkTheme = true)
+}
+
+@Composable
+private fun EmptyListLayoutPreview(darkTheme: Boolean) {
+    AppThemePreview(darkTheme = darkTheme) {
+        EmptyListLayout(
+            icon = Icons.AutoMirrored.Outlined.MenuBook,
+            btnText = "Browse spells",
+            onBtnClicked = {},
+        )
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -161,3 +161,30 @@ private fun ListDetailScreenPreview(darkTheme: Boolean) {
         )
     }
 }
+
+@Preview
+@Composable
+private fun PreviewEmptyListDetailScreenLight() {
+    EmptyListDetailScreenPreview(darkTheme = false)
+}
+
+@Preview
+@Composable
+private fun PreviewEmptyListDetailScreenDark() {
+    EmptyListDetailScreenPreview(darkTheme = true)
+}
+
+@Composable
+private fun EmptyListDetailScreenPreview(darkTheme: Boolean) {
+    AppThemePreview(darkTheme = darkTheme) {
+        ListDetailScreen(
+            state = ListDetailState(
+                listName = "Gandalf's Spells",
+                body = ListDetailState.Body.EmptyList,
+            ),
+            itemProvider = SpellItemProvider(onItemClicked = {}),
+            onNavigateUpClicked = {},
+            onRemoveItemClicked = {},
+        )
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -39,7 +39,6 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.dialog_remove_from_list_message
-import rpg_companion.composeapp.generated.resources.message_list_is_empty
 
 @Composable
 fun <T> ListDetailScreen(
@@ -81,7 +80,7 @@ fun <T> ListDetailScreen(
         ) {
             when (val body = state.body) {
                 is ListDetailState.Body.Loading -> Loader()
-                is ListDetailState.Body.EmptyList -> ErrorLayout(Res.string.message_list_is_empty)
+                is ListDetailState.Body.EmptyList -> itemProvider.EmptyLayout()
                 is ListDetailState.Body.Error -> ErrorLayout(body.errorMessage)
                 is ListDetailState.Body.WithData -> EntityDetailList(
                     items = body.items,


### PR DESCRIPTION
## 📝 Description

Replace the plain error text in `ListDetailScreen` empty state with an illustrated layout: an icon, a message, and a CTA button that navigates to the relevant entity list (spells, creatures, magical items).

- `EmptyListLayout` composable extracted into its own file with light/dark previews
- `ListItemProvider` defines a default `EmptyLayout()` implementation and 3 abstract properties (`emptyLayoutIcon`, `emptyLayoutBtnText`, `onEmptyLayoutBtnClicked`)
- Each provider (`SpellItemProvider`, `CreatureItemProvider`, `MagicalItemItemProvider`) only declares its entity-specific values

## 🖼️ Media

<img width="1030" height="1090" alt="image" src="https://github.com/user-attachments/assets/92a19f53-885d-4fe1-88bd-ef545b3e6b0b" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed