### PR TITLE
feat(userlist): replace delete button with swipe-to-delete in ListDetailScreen

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -23,7 +23,7 @@
 
     <string name="message_list_is_empty">La liste est vide</string>
 
-    <string name="snackbar_removed_from_list">%s supprimé de la liste</string>
+    <string name="snackbar_removed_from_list">'%s' a été supprimé de la liste</string>
     <string name="btn_undo">Annuler</string>
 
     <string name="empty_list_browse_spells">Parcourir les sorts</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -24,6 +24,7 @@
     <string name="message_list_is_empty">La liste est vide</string>
 
     <string name="snackbar_removed_from_list">'%1$s' a été supprimé de la liste</string>
+    <string name="snackbar_error_removing_from_list">Erreur lors de la suppression de '%1$s'.</string>
     <string name="btn_undo">Annuler</string>
 
     <string name="empty_list_browse_spells">Parcourir les sorts</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -23,7 +23,7 @@
 
     <string name="message_list_is_empty">La liste est vide</string>
 
-    <string name="snackbar_removed_from_list">'%s' a été supprimé de la liste</string>
+    <string name="snackbar_removed_from_list">'%1$s' a été supprimé de la liste</string>
     <string name="btn_undo">Annuler</string>
 
     <string name="empty_list_browse_spells">Parcourir les sorts</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -23,6 +23,9 @@
 
     <string name="message_list_is_empty">La liste est vide</string>
 
+    <string name="snackbar_removed_from_list">%s supprimé de la liste</string>
+    <string name="btn_undo">Annuler</string>
+
     <string name="empty_list_browse_spells">Parcourir les sorts</string>
     <string name="empty_list_browse_creatures">Parcourir les créatures</string>
     <string name="empty_list_browse_magical_items">Parcourir les objets magiques</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -23,7 +23,7 @@
 
     <string name="message_list_is_empty">The list is empty</string>
 
-    <string name="snackbar_removed_from_list">'%s' was removed from the list</string>
+    <string name="snackbar_removed_from_list">'%1$s' was removed from the list</string>
     <string name="btn_undo">Undo</string>
 
     <string name="empty_list_browse_spells">Browse spells</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -23,7 +23,7 @@
 
     <string name="message_list_is_empty">The list is empty</string>
 
-    <string name="snackbar_removed_from_list">%s removed from list</string>
+    <string name="snackbar_removed_from_list">'%s' was removed from the list</string>
     <string name="btn_undo">Undo</string>
 
     <string name="empty_list_browse_spells">Browse spells</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -24,6 +24,7 @@
     <string name="message_list_is_empty">The list is empty</string>
 
     <string name="snackbar_removed_from_list">'%1$s' was removed from the list</string>
+    <string name="snackbar_error_removing_from_list">Error removing '%1$s' from the list.</string>
     <string name="btn_undo">Undo</string>
 
     <string name="empty_list_browse_spells">Browse spells</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -23,6 +23,9 @@
 
     <string name="message_list_is_empty">The list is empty</string>
 
+    <string name="snackbar_removed_from_list">%s removed from list</string>
+    <string name="btn_undo">Undo</string>
+
     <string name="empty_list_browse_spells">Browse spells</string>
     <string name="empty_list_browse_creatures">Browse creatures</string>
     <string name="empty_list_browse_magical_items">Browse magical items</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -4,8 +4,8 @@ import androidx.navigation.NavController
 
 interface CreatureRouter {
     fun navigateUp()
-    fun openDetail(id: String)
-    fun openAddToList(creatureId: String) {}
+    fun openDetail(creatureId: String)
+    fun openAddToList(creatureId: String)
 }
 
 class CreatureRouterImpl(private val navController: NavController) : CreatureRouter {
@@ -13,8 +13,8 @@ class CreatureRouterImpl(private val navController: NavController) : CreatureRou
         navController.navigateUp()
     }
 
-    override fun openDetail(id: String) {
-        navController.navigate(CreatureRoute.Detail(id))
+    override fun openDetail(creatureId: String) {
+        navController.navigate(CreatureRoute.Detail(creatureId))
     }
 
     override fun openAddToList(creatureId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
@@ -4,8 +4,8 @@ import androidx.navigation.NavController
 
 interface MagicalItemRouter {
     fun navigateUp()
-    fun openDetail(id: String)
-    fun openAddToList(magicalItemId: String) {}
+    fun openDetail(magicalItemId: String)
+    fun openAddToList(magicalItemId: String)
 }
 
 class MagicalItemRouterImpl(private val navController: NavController) : MagicalItemRouter {
@@ -13,8 +13,8 @@ class MagicalItemRouterImpl(private val navController: NavController) : MagicalI
         navController.navigateUp()
     }
 
-    override fun openDetail(id: String) {
-        navController.navigate(MagicalItemRoute.Detail(id))
+    override fun openDetail(magicalItemId: String) {
+        navController.navigate(MagicalItemRoute.Detail(magicalItemId))
     }
 
     override fun openAddToList(magicalItemId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
@@ -4,10 +4,8 @@ import androidx.navigation.NavController
 
 interface SpellRouter {
     fun navigateUp()
-    fun openDetail(id: String)
-    fun openMySpellLists() {}
-    fun openSpellListDetail(listId: String) {}
-    fun openAddToList(spellId: String) {}
+    fun openDetail(spellId: String)
+    fun openAddToList(spellId: String)
 }
 
 class SpellRouterImpl(private val navController: NavController) : SpellRouter {
@@ -15,16 +13,8 @@ class SpellRouterImpl(private val navController: NavController) : SpellRouter {
         navController.navigateUp()
     }
 
-    override fun openDetail(id: String) {
-        navController.navigate(SpellRoute.Detail(id))
-    }
-
-    override fun openMySpellLists() {
-        navController.navigate(SpellRoute.UserLists)
-    }
-
-    override fun openSpellListDetail(listId: String) {
-        navController.navigate(SpellRoute.UserListDetail(listId))
+    override fun openDetail(spellId: String) {
+        navController.navigate(SpellRoute.Detail(spellId))
     }
 
     override fun openAddToList(spellId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -138,6 +138,7 @@ private fun <T> EntityDetailList(
                 item = item,
                 uiProvider = uiProvider,
                 onRemoveItem = onRemoveItem,
+                modifier = Modifier.animateItem(),
             )
         }
     }
@@ -148,6 +149,7 @@ private fun <T> SwipeableListItem(
     item: T,
     uiProvider: ListItemProvider<T>,
     onRemoveItem: (T) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val dismissState = rememberSwipeToDismissBoxState(
         confirmValueChange = { value ->
@@ -159,6 +161,7 @@ private fun <T> SwipeableListItem(
     )
     SwipeToDismissBox(
         state = dismissState,
+        modifier = modifier,
         enableDismissFromStartToEnd = false,
         enableDismissFromEndToStart = true,
         backgroundContent = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -1,9 +1,10 @@
 package com.cyrillrx.rpg.userlist.presentation.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,9 +13,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -115,23 +119,54 @@ private fun <T> EntityDetailList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(items, key = { uiProvider.getId(it) }) { item ->
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                uiProvider.ListItem(
-                    entity = item,
-                    modifier = Modifier.weight(1f),
-                )
-                IconButton(onClick = { onRemoveItem(item) }) {
-                    Icon(
-                        imageVector = Icons.Filled.Delete,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error,
-                    )
-                }
-            }
+            SwipeableListItem(
+                item = item,
+                uiProvider = uiProvider,
+                onRemoveItem = onRemoveItem,
+            )
         }
+    }
+}
+
+@Composable
+private fun <T> SwipeableListItem(
+    item: T,
+    uiProvider: ListItemProvider<T>,
+    onRemoveItem: (T) -> Unit,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onRemoveItem(item)
+            }
+            false
+        },
+    )
+    SwipeToDismissBox(
+        state = dismissState,
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = true,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(end = spacingMedium),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        },
+    ) {
+        uiProvider.ListItem(
+            entity = item,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -15,14 +15,17 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,7 +33,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
-import com.cyrillrx.rpg.core.presentation.component.dialog.ConfirmDeleteDialog
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -39,10 +41,12 @@ import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.dialog_remove_from_list_message
+import rpg_companion.composeapp.generated.resources.btn_undo
+import rpg_companion.composeapp.generated.resources.snackbar_removed_from_list
 
 @Composable
 fun <T> ListDetailScreen(
@@ -55,7 +59,9 @@ fun <T> ListDetailScreen(
         state = state,
         itemProvider = itemProvider,
         onNavigateUpClicked = onNavigateUp,
-        onRemoveItemClicked = viewModel::removeItem,
+        onRemoveItemOptimistically = viewModel::removeItemOptimistically,
+        onUndoRemoval = viewModel::undoRemoval,
+        onCommitRemoval = viewModel::commitRemoval,
     )
 }
 
@@ -64,9 +70,14 @@ fun <T> ListDetailScreen(
     state: ListDetailState<T>,
     itemProvider: ListItemProvider<T>,
     onNavigateUpClicked: () -> Unit,
-    onRemoveItemClicked: (String) -> Unit,
+    onRemoveItemOptimistically: (id: String, item: T) -> Unit,
+    onUndoRemoval: () -> Unit,
+    onCommitRemoval: () -> Unit,
 ) {
-    var itemToRemove by remember { mutableStateOf<T?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    val removedMessage = stringResource(Res.string.snackbar_removed_from_list)
+    val undoLabel = stringResource(Res.string.btn_undo)
 
     Scaffold(
         topBar = {
@@ -75,6 +86,7 @@ fun <T> ListDetailScreen(
                 navigateUp = onNavigateUpClicked,
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -89,21 +101,24 @@ fun <T> ListDetailScreen(
                 is ListDetailState.Body.WithData -> EntityDetailList(
                     items = body.items,
                     uiProvider = itemProvider,
-                    onRemoveItem = { itemToRemove = it },
+                    onRemoveItem = { item ->
+                        val message = removedMessage.replace("%s", itemProvider.getDisplayName(item))
+                        onRemoveItemOptimistically(itemProvider.getId(item), item)
+                        coroutineScope.launch {
+                            val result = snackbarHostState.showSnackbar(
+                                message = message,
+                                actionLabel = undoLabel,
+                                duration = SnackbarDuration.Short,
+                            )
+                            when (result) {
+                                SnackbarResult.ActionPerformed -> onUndoRemoval()
+                                SnackbarResult.Dismissed -> onCommitRemoval()
+                            }
+                        }
+                    },
                 )
             }
         }
-    }
-
-    itemToRemove?.let { item ->
-        ConfirmDeleteDialog(
-            message = stringResource(Res.string.dialog_remove_from_list_message, itemProvider.getDisplayName(item)),
-            onConfirm = {
-                onRemoveItemClicked(itemProvider.getId(item))
-                itemToRemove = null
-            },
-            onDismiss = { itemToRemove = null },
-        )
     }
 }
 
@@ -192,7 +207,9 @@ private fun ListDetailScreenPreview(darkTheme: Boolean) {
             ),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
-            onRemoveItemClicked = {},
+            onRemoveItemOptimistically = { _, _ -> },
+            onUndoRemoval = {},
+            onCommitRemoval = {},
         )
     }
 }
@@ -219,7 +236,9 @@ private fun EmptyListDetailScreenPreview(darkTheme: Boolean) {
             ),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
-            onRemoveItemClicked = {},
+            onRemoveItemOptimistically = { _, _ -> },
+            onUndoRemoval = {},
+            onCommitRemoval = {},
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -41,12 +42,15 @@ import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_undo
+import rpg_companion.composeapp.generated.resources.snackbar_error_removing_from_list
 import rpg_companion.composeapp.generated.resources.snackbar_removed_from_list
 
 @Composable
@@ -58,6 +62,7 @@ fun <T> ListDetailScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     ListDetailScreen(
         state = state,
+        events = viewModel.events,
         itemProvider = itemProvider,
         onNavigateUpClicked = onNavigateUp,
         onRemoveItemOptimistically = viewModel::removeItemOptimistically,
@@ -69,6 +74,7 @@ fun <T> ListDetailScreen(
 @Composable
 fun <T> ListDetailScreen(
     state: ListDetailState<T>,
+    events: SharedFlow<ListDetailViewModel.Event<T>>,
     itemProvider: ListItemProvider<T>,
     onNavigateUpClicked: () -> Unit,
     onRemoveItemOptimistically: (id: String, item: T) -> ListDetailViewModel.PendingRemoval<T>?,
@@ -78,6 +84,21 @@ fun <T> ListDetailScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val undoLabel = stringResource(Res.string.btn_undo)
+
+    LaunchedEffect(events) {
+        events.collect { event ->
+            when (event) {
+                is ListDetailViewModel.Event.RemovalError -> {
+                    val displayName = itemProvider.getDisplayName(event.item)
+                    val errorMessage = getString(Res.string.snackbar_error_removing_from_list, displayName)
+                    snackbarHostState.showSnackbar(
+                        message = errorMessage,
+                        duration = SnackbarDuration.Short,
+                    )
+                }
+            }
+        }
+    }
 
     fun onRemoveItem(item: T) {
         val pending = onRemoveItemOptimistically(itemProvider.getId(item), item) ?: return
@@ -212,6 +233,7 @@ private fun ListDetailScreenPreview(darkTheme: Boolean) {
                 listName = "Gandalf's Spells",
                 body = ListDetailState.Body.WithData(SampleSpellRepository.getAll()),
             ),
+            events = MutableSharedFlow(),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
             onRemoveItemOptimistically = { _, _ -> null },
@@ -241,6 +263,7 @@ private fun EmptyListDetailScreenPreview(darkTheme: Boolean) {
                 listName = "Gandalf's Spells",
                 body = ListDetailState.Body.EmptyList,
             ),
+            events = MutableSharedFlow(),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
             onRemoveItemOptimistically = { _, _ -> null },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -42,6 +42,7 @@ import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -76,16 +77,16 @@ fun <T> ListDetailScreen(
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
-    val removedMessage = stringResource(Res.string.snackbar_removed_from_list)
     val undoLabel = stringResource(Res.string.btn_undo)
 
     fun onRemoveItem(item: T) {
-        val message = removedMessage.replace("%s", itemProvider.getDisplayName(item))
         val pending = onRemoveItemOptimistically(itemProvider.getId(item), item) ?: return
 
         coroutineScope.launch {
+            val displayName = itemProvider.getDisplayName(item)
+            val removedMessage = getString(Res.string.snackbar_removed_from_list, displayName)
             val result = snackbarHostState.showSnackbar(
-                message = message,
+                message = removedMessage,
                 actionLabel = undoLabel,
                 duration = SnackbarDuration.Short,
             )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -70,14 +70,31 @@ fun <T> ListDetailScreen(
     state: ListDetailState<T>,
     itemProvider: ListItemProvider<T>,
     onNavigateUpClicked: () -> Unit,
-    onRemoveItemOptimistically: (id: String, item: T) -> Unit,
-    onUndoRemoval: () -> Unit,
-    onCommitRemoval: () -> Unit,
+    onRemoveItemOptimistically: (id: String, item: T) -> ListDetailViewModel.PendingRemoval<T>?,
+    onUndoRemoval: (ListDetailViewModel.PendingRemoval<T>) -> Unit,
+    onCommitRemoval: (ListDetailViewModel.PendingRemoval<T>) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val removedMessage = stringResource(Res.string.snackbar_removed_from_list)
     val undoLabel = stringResource(Res.string.btn_undo)
+
+    fun onRemoveItem(item: T) {
+        val message = removedMessage.replace("%s", itemProvider.getDisplayName(item))
+        val pending = onRemoveItemOptimistically(itemProvider.getId(item), item) ?: return
+
+        coroutineScope.launch {
+            val result = snackbarHostState.showSnackbar(
+                message = message,
+                actionLabel = undoLabel,
+                duration = SnackbarDuration.Short,
+            )
+            when (result) {
+                SnackbarResult.ActionPerformed -> onUndoRemoval(pending)
+                SnackbarResult.Dismissed -> onCommitRemoval(pending)
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -101,21 +118,7 @@ fun <T> ListDetailScreen(
                 is ListDetailState.Body.WithData -> EntityDetailList(
                     items = body.items,
                     uiProvider = itemProvider,
-                    onRemoveItem = { item ->
-                        val message = removedMessage.replace("%s", itemProvider.getDisplayName(item))
-                        onRemoveItemOptimistically(itemProvider.getId(item), item)
-                        coroutineScope.launch {
-                            val result = snackbarHostState.showSnackbar(
-                                message = message,
-                                actionLabel = undoLabel,
-                                duration = SnackbarDuration.Short,
-                            )
-                            when (result) {
-                                SnackbarResult.ActionPerformed -> onUndoRemoval()
-                                SnackbarResult.Dismissed -> onCommitRemoval()
-                            }
-                        }
-                    },
+                    onRemoveItem = ::onRemoveItem,
                 )
             }
         }
@@ -210,7 +213,7 @@ private fun ListDetailScreenPreview(darkTheme: Boolean) {
             ),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
-            onRemoveItemOptimistically = { _, _ -> },
+            onRemoveItemOptimistically = { _, _ -> null },
             onUndoRemoval = {},
             onCommitRemoval = {},
         )
@@ -239,7 +242,7 @@ private fun EmptyListDetailScreenPreview(darkTheme: Boolean) {
             ),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
-            onRemoveItemOptimistically = { _, _ -> },
+            onRemoveItemOptimistically = { _, _ -> null },
             onUndoRemoval = {},
             onCommitRemoval = {},
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
@@ -8,7 +8,7 @@ import com.cyrillrx.rpg.userlist.domain.UserList
 
 interface UserListRouter {
     fun navigateUp()
-    fun openUserList(list: UserList) {}
+    fun openUserList(list: UserList)
 }
 
 class UserListRouterImpl(private val navController: NavController) : UserListRouter {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.domain.EntityRepository
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -28,6 +30,12 @@ class ListDetailViewModel<T>(
 
     init {
         loadDetail()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+
+        commitAllPendingRemovals()
     }
 
     fun removeItemOptimistically(itemId: String, item: T): PendingRemoval<T>? {
@@ -65,6 +73,18 @@ class ListDetailViewModel<T>(
 
         viewModelScope.launch {
             userListRepository.removeFromList(listId, pending.itemId)
+        }
+    }
+
+    internal fun commitAllPendingRemovals() {
+        val toCommit = pendingRemovals.toList()
+        pendingRemovals.clear()
+        if (toCommit.isEmpty()) return
+
+        CoroutineScope(Dispatchers.Main).launch {
+            toCommit.forEach { pending ->
+                userListRepository.removeFromList(listId, pending.itemId)
+            }
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -22,21 +22,22 @@ class ListDetailViewModel<T>(
     val state: StateFlow<ListDetailState<T>>
         field = MutableStateFlow(ListDetailState())
 
-    private data class PendingRemoval<T>(val itemId: String, val index: Int, val item: T)
+    data class PendingRemoval<T>(val itemId: String, val index: Int, val item: T)
 
-    private var pendingRemoval: PendingRemoval<T>? = null
+    private val pendingRemovals: MutableList<PendingRemoval<T>> = mutableListOf()
 
     init {
         loadDetail()
     }
 
-    fun removeItemOptimistically(itemId: String, item: T) {
-        pendingRemoval?.let { commitRemoval() }
-
-        val currentState = state.value.body as? ListDetailState.Body.WithData ?: return
+    fun removeItemOptimistically(itemId: String, item: T): PendingRemoval<T>? {
+        val currentState = state.value.body as? ListDetailState.Body.WithData ?: return null
 
         val index = currentState.items.indexOf(item)
-        pendingRemoval = PendingRemoval(itemId, index, item)
+        if (index == -1) return null
+
+        val pending = PendingRemoval(itemId, index, item)
+        pendingRemovals.add(pending)
         val updatedItems = currentState.items - item
         val newBody = if (updatedItems.isEmpty()) {
             ListDetailState.Body.EmptyList
@@ -44,25 +45,26 @@ class ListDetailViewModel<T>(
             ListDetailState.Body.WithData(updatedItems)
         }
         state.update { it.copy(body = newBody) }
+        return pending
     }
 
-    fun undoRemoval() {
-        val (_, index, item) = pendingRemoval ?: return
-        pendingRemoval = null
+    fun undoRemoval(pending: PendingRemoval<T>) {
+        if (!pendingRemovals.remove(pending)) return
+
         val currentItems = when (val body = state.value.body) {
             is ListDetailState.Body.WithData -> body.items
             is ListDetailState.Body.EmptyList -> emptyList()
             else -> return
         }
-        val restoredItems = currentItems.toMutableList().apply { add(index.coerceAtMost(size), item) }
+        val restoredItems = currentItems.toMutableList().apply { add(pending.index.coerceAtMost(size), pending.item) }
         state.update { it.copy(body = ListDetailState.Body.WithData(restoredItems)) }
     }
 
-    fun commitRemoval() {
-        val (itemId, _, _) = pendingRemoval ?: return
-        pendingRemoval = null
+    fun commitRemoval(pending: PendingRemoval<T>) {
+        if (!pendingRemovals.remove(pending)) return
+
         viewModelScope.launch {
-            userListRepository.removeFromList(listId, itemId)
+            userListRepository.removeFromList(listId, pending.itemId)
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -7,7 +7,9 @@ import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -24,7 +26,14 @@ class ListDetailViewModel<T>(
     val state: StateFlow<ListDetailState<T>>
         field = MutableStateFlow(ListDetailState())
 
+    val events: SharedFlow<Event<T>>
+        field = MutableSharedFlow<Event<T>>()
+
     data class PendingRemoval<T>(val itemId: String, val index: Int, val item: T)
+
+    sealed interface Event<out T> {
+        data class RemovalError<T>(val item: T) : Event<T>
+    }
 
     private val pendingRemovals: MutableList<PendingRemoval<T>> = mutableListOf()
 
@@ -74,7 +83,9 @@ class ListDetailViewModel<T>(
         viewModelScope.launch {
             val result = userListRepository.removeFromList(listId, pending.itemId)
             if (result !is UserListRepository.Result.Success) {
+                pendingRemovals.add(pending)
                 undoRemoval(pending)
+                events.emit(Event.RemovalError(pending.item))
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -72,7 +72,10 @@ class ListDetailViewModel<T>(
         if (!pendingRemovals.remove(pending)) return
 
         viewModelScope.launch {
-            userListRepository.removeFromList(listId, pending.itemId)
+            val result = userListRepository.removeFromList(listId, pending.itemId)
+            if (result !is UserListRepository.Result.Success) {
+                undoRemoval(pending)
+            }
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -22,16 +22,44 @@ class ListDetailViewModel<T>(
     val state: StateFlow<ListDetailState<T>>
         field = MutableStateFlow(ListDetailState())
 
+    private var pendingRemoval: Pair<String, T>? = null
+
     init {
         loadDetail()
     }
 
-    fun removeItem(itemId: String) {
+    fun removeItemOptimistically(itemId: String, item: T) {
+        pendingRemoval?.let { commitRemoval() }
+
+        val currentState = state.value.body as? ListDetailState.Body.WithData ?: return
+
+        pendingRemoval = Pair(itemId, item)
+        val updatedItems = currentState.items - item
+        val newBody = if (updatedItems.isEmpty()) {
+            ListDetailState.Body.EmptyList
+        } else {
+            ListDetailState.Body.WithData(updatedItems)
+        }
+        state.update { it.copy(body = newBody) }
+    }
+
+    fun undoRemoval() {
+        val (_, item) = pendingRemoval ?: return
+
+        pendingRemoval = null
+        val currentItems = when (val body = state.value.body) {
+            is ListDetailState.Body.WithData -> body.items
+            is ListDetailState.Body.EmptyList -> emptyList()
+            else -> return
+        }
+        state.update { it.copy(body = ListDetailState.Body.WithData(currentItems + item)) }
+    }
+
+    fun commitRemoval() {
+        val (itemId, _) = pendingRemoval ?: return
+        pendingRemoval = null
         viewModelScope.launch {
-            val result = userListRepository.removeFromList(listId, itemId)
-            if (result is UserListRepository.Result.Success) {
-                loadDetail()
-            }
+            userListRepository.removeFromList(listId, itemId)
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -22,7 +22,9 @@ class ListDetailViewModel<T>(
     val state: StateFlow<ListDetailState<T>>
         field = MutableStateFlow(ListDetailState())
 
-    private var pendingRemoval: Pair<String, T>? = null
+    private data class PendingRemoval<T>(val itemId: String, val index: Int, val item: T)
+
+    private var pendingRemoval: PendingRemoval<T>? = null
 
     init {
         loadDetail()
@@ -33,7 +35,8 @@ class ListDetailViewModel<T>(
 
         val currentState = state.value.body as? ListDetailState.Body.WithData ?: return
 
-        pendingRemoval = Pair(itemId, item)
+        val index = currentState.items.indexOf(item)
+        pendingRemoval = PendingRemoval(itemId, index, item)
         val updatedItems = currentState.items - item
         val newBody = if (updatedItems.isEmpty()) {
             ListDetailState.Body.EmptyList
@@ -44,19 +47,19 @@ class ListDetailViewModel<T>(
     }
 
     fun undoRemoval() {
-        val (_, item) = pendingRemoval ?: return
-
+        val (_, index, item) = pendingRemoval ?: return
         pendingRemoval = null
         val currentItems = when (val body = state.value.body) {
             is ListDetailState.Body.WithData -> body.items
             is ListDetailState.Body.EmptyList -> emptyList()
             else -> return
         }
-        state.update { it.copy(body = ListDetailState.Body.WithData(currentItems + item)) }
+        val restoredItems = currentItems.toMutableList().apply { add(index.coerceAtMost(size), item) }
+        state.update { it.copy(body = ListDetailState.Body.WithData(restoredItems)) }
     }
 
     fun commitRemoval() {
-        val (itemId, _) = pendingRemoval ?: return
+        val (itemId, _, _) = pendingRemoval ?: return
         pendingRemoval = null
         viewModelScope.launch {
             userListRepository.removeFromList(listId, itemId)

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModelTest.kt
@@ -177,7 +177,8 @@ class CreatureListViewModelTest {
 
 private class NoOpCreatureRouter : CreatureRouter {
     override fun navigateUp() = Unit
-    override fun openCreatureDetail(creature: Creature) = Unit
+    override fun openDetail(creatureId: String) = Unit
+    override fun openAddToList(creatureId: String) = Unit
 }
 
 private class FailingCreatureRepository : CreatureRepository {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -176,7 +176,8 @@ class MagicalItemListViewModelTest {
 
 private class NoOpMagicalItemRouter : MagicalItemRouter {
     override fun navigateUp() = Unit
-    override fun openMagicalItemDetail(magicalItem: MagicalItem) = Unit
+    override fun openDetail(magicalItemId: String) = Unit
+    override fun openAddToList(magicalItemId: String) = Unit
 }
 
 private class FailingMagicalItemRepository : MagicalItemRepository {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
@@ -195,7 +195,8 @@ class SpellListViewModelTest {
 
 private class NoOpSpellRouter : SpellRouter {
     override fun navigateUp() = Unit
-    override fun openSpellDetail(spell: Spell) = Unit
+    override fun openDetail(spellId: String) = Unit
+    override fun openAddToList(spellId: String) = Unit
 }
 
 private class FailingSpellRepository : SpellRepository {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -113,7 +113,7 @@ class ListDetailViewModelTest {
     }
 
     @Test
-    fun `removeItem removes spell from list`() = runTest(testDispatcher) {
+    fun `removeItemOptimistically then commit removes spell from list`() = runTest(testDispatcher) {
         val allSpells = SampleSpellRepository.getAll()
         val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, allSpells.map { it.id })
         userListRepository.save(list)
@@ -126,7 +126,8 @@ class ListDetailViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.removeItem(spell.id)
+        val pending = requireNotNull(viewModel.removeItemOptimistically(spell.id, spell))
+        viewModel.commitRemoval(pending)
 
         advanceUntilIdle()
 
@@ -136,7 +137,7 @@ class ListDetailViewModelTest {
     }
 
     @Test
-    fun `removeItem transitions to Empty when last spell removed`() = runTest(testDispatcher) {
+    fun `removeItemOptimistically then commit transitions to Empty when last spell removed`() = runTest(testDispatcher) {
         val list = UserList("list1", "My spellbook", UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
@@ -148,7 +149,8 @@ class ListDetailViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.removeItem(spell.id)
+        val pending = requireNotNull(viewModel.removeItemOptimistically(spell.id, spell))
+        viewModel.commitRemoval(pending)
 
         advanceUntilIdle()
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -137,8 +137,30 @@ class ListDetailViewModelTest {
     }
 
     @Test
-    fun `removeItemOptimistically then commit transitions to Empty when last spell removed`() = runTest(testDispatcher) {
-        val list = UserList("list1", "My spellbook", UserList.Type.SPELL, listOf(spell.id))
+    fun `removeItemOptimistically then commit transitions to Empty when last spell removed`() =
+        runTest(testDispatcher) {
+            val list = UserList("list1", "My spellbook", UserList.Type.SPELL, listOf(spell.id))
+            userListRepository.save(list)
+
+            val viewModel = buildViewModel("list1")
+
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.state.collect {}
+            }
+
+            advanceUntilIdle()
+
+            val pending = requireNotNull(viewModel.removeItemOptimistically(spell.id, spell))
+            viewModel.commitRemoval(pending)
+
+            advanceUntilIdle()
+
+            assertIs<ListDetailState.Body.EmptyList>(viewModel.state.value.body)
+        }
+
+    @Test
+    fun `onCleared commits pending removals that were never confirmed`() = runTest(testDispatcher) {
+        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
         val viewModel = buildViewModel("list1")
@@ -146,14 +168,13 @@ class ListDetailViewModelTest {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
         }
-
         advanceUntilIdle()
 
-        val pending = requireNotNull(viewModel.removeItemOptimistically(spell.id, spell))
-        viewModel.commitRemoval(pending)
-
+        viewModel.removeItemOptimistically(spell.id, spell) // no commit
+        viewModel.commitAllPendingRemovals() // simulate navigation away
         advanceUntilIdle()
 
-        assertIs<ListDetailState.Body.EmptyList>(viewModel.state.value.body)
+        val updatedList = userListRepository.get("list1")!!
+        assertTrue(updatedList.itemIds.none { it == spell.id })
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -153,6 +153,7 @@ class UserListsViewModelTest {
 
 private class NoOpUserListRouter : UserListRouter {
     override fun navigateUp() = Unit
+    override fun openUserList(list: UserList) = Unit
 }
 
 private class TrackingUserListRouter : UserListRouter {


### PR DESCRIPTION
## 📝 Description

Replace the delete button with a swipe-to-delete gesture in `ListDetailScreen`.

Swiping an item left reveals a red delete background; releasing triggers an optimistic removal with an undo snackbar. Tapping **Undo** restores the item at its original position; letting the snackbar expire commits the deletion to the repository.

Rapid consecutive swipes are handled correctly: each swipe owns its own `PendingRemoval` token, so the undo/commit callbacks never affect the wrong item.
A guard against `indexOf == -1` prevents a crash when `SwipeToDismissBox` fires `confirmValueChange` a second time on an item that is already animating out.

## 🖼️ Media

[Screen_recording_20260406_005947.webm](https://github.com/user-attachments/assets/313069d8-5f6d-4276-a778-47fa23b4c112)

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed