### PR TITLE
ci(kmp): add GitHub Actions workflow to block PR merges on test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  kmp-tests:
+    name: KMP Client - JVM Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Make gradlew executable
+        working-directory: cmp-ttrpg-companion
+        run: chmod +x gradlew
+
+      - name: Run JVM tests
+        working-directory: cmp-ttrpg-companion
+        run: ./gradlew jvmTest --no-daemon

--- a/docs/conventions/GIT_AND_COLLABORATION.md
+++ b/docs/conventions/GIT_AND_COLLABORATION.md
@@ -84,6 +84,6 @@ feat(spell): redesign spell list screen with new item, samples, and strings
 ## 6. CI & Policies
 
 - **Pull Requests**: All code must be reviewed via PRs before merging into `main`.
-- **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline.
+- **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline. The CI pipeline (`.github/workflows/ci.yml`) runs `KMP Client - JVM Tests` (`./gradlew jvmTest` in `cmp-ttrpg-companion/`) on every PR targeting the default branch. It must pass for a PR to be mergeable.
 - **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
 - **Security Scans**: Integrate automated security scanning where applicable.


### PR DESCRIPTION
## 📝 Description

Adds a GitHub Actions CI workflow that runs KMP JVM tests on every PR targeting `main`. Merges are blocked if tests don't compile or fail.

Also documents the CI jobs in `GIT_AND_COLLABORATION.md` (section 6).

### What

- New file: `.github/workflows/ci.yml` — runs `./gradlew jvmTest` from `cmp-ttrpg-companion/` on `ubuntu-latest` with Java 17
- Updated: `docs/conventions/GIT_AND_COLLABORATION.md` — documents the required CI check

### Why

Tests stopped compiling during a recent feature without being caught before merge. This workflow enforces compilation and test passage as a hard gate on PRs.

## Post-merge manual step

After this PR is merged and the workflow has run once, enable branch protection in **Settings > Branches** for `main`:
- Require status checks: `KMP Client — JVM Tests`
- Require branches to be up to date before merging

## ✅ Checklist

- [x] Code follows AGENTS.md and conventions
- [x] Author has proofread
- [x] No sensitive data committed
- [x] Documentation updated (`GIT_AND_COLLABORATION.md`)