### PR TITLE
feat(compendium): swipe a compendium item to add it to a custom list

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -31,5 +31,5 @@
     <string name="empty_list_browse_creatures">Parcourir les créatures</string>
     <string name="empty_list_browse_magical_items">Parcourir les objets magiques</string>
 
-    <string name="time_ago_now">À l\'instant</string>
+    <string name="time_ago_now">À l'instant</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAddBox.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAddBox.kt
@@ -13,6 +13,11 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,14 +31,21 @@ fun SwipeToAddBox(
     modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit,
 ) {
+    var confirmed by remember { mutableStateOf(false) }
     val dismissState = rememberSwipeToDismissBoxState(
         confirmValueChange = { value ->
-            if (value == SwipeToDismissBoxValue.StartToEnd) {
+            if (value == SwipeToDismissBoxValue.StartToEnd && !confirmed) {
+                confirmed = true
                 onAdd()
             }
             false
         },
     )
+    LaunchedEffect(dismissState.targetValue) {
+        if (dismissState.targetValue == SwipeToDismissBoxValue.Settled) {
+            confirmed = false
+        }
+    }
     SwipeToDismissBox(
         state = dismissState,
         modifier = modifier,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAddBox.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAddBox.kt
@@ -1,0 +1,60 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import com.cyrillrx.rpg.core.presentation.theme.Green500
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+
+@Composable
+fun SwipeToAddBox(
+    onAdd: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.StartToEnd) {
+                onAdd()
+            }
+            false
+        },
+    )
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = modifier,
+        enableDismissFromStartToEnd = true,
+        enableDismissFromEndToStart = false,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(Green500)
+                    .padding(start = spacingMedium),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    contentDescription = null,
+                    tint = Color.White,
+                )
+            }
+        },
+        content = content,
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Color.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Color.kt
@@ -22,5 +22,7 @@ val Purple800 = Color(0xFF4527A0)
 val Purple900 = Color(0xFF311B92)
 val Scarlet = Color(0xff9b1c47)
 
+val Green500 = Color(0xFF4CAF50)
+
 val DarkerGrey = Color(0xFF2C2C2C)
 val DarkGrey = Color(0xFF414040)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -19,6 +19,7 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
+import com.cyrillrx.rpg.core.presentation.component.SwipeToAddBox
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
@@ -37,6 +38,7 @@ fun CreatureListScreen(viewModel: CreatureListViewModel) {
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onCreatureClicked = viewModel::onCreatureClicked,
+        onAddToListClicked = viewModel::onCreatureAddToListClicked,
         onTypeToggled = viewModel::onTypeToggled,
         onChallengeRatingToggled = viewModel::onChallengeRatingToggled,
         onResetFilters = viewModel::onResetFilters,
@@ -49,6 +51,7 @@ fun CreatureListScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onCreatureClicked: (Creature) -> Unit,
+    onAddToListClicked: (Creature) -> Unit,
     onTypeToggled: (Creature.Type) -> Unit,
     onChallengeRatingToggled: (Float) -> Unit,
     onResetFilters: () -> Unit,
@@ -72,7 +75,7 @@ fun CreatureListScreen(
                 is CreatureListState.Body.Loading -> Loader()
                 is CreatureListState.Body.Empty -> EmptySearch(state.filter.query)
                 is CreatureListState.Body.Error -> ErrorLayout(body.errorMessage)
-                is CreatureListState.Body.WithData -> CreatureList(body.searchResults, onCreatureClicked)
+                is CreatureListState.Body.WithData -> CreatureList(body.searchResults, onCreatureClicked, onAddToListClicked)
             }
         }
     }
@@ -92,13 +95,16 @@ fun CreatureListScreen(
 private fun CreatureList(
     creatures: List<Creature>,
     onCreatureClicked: (Creature) -> Unit,
+    onAddToListClicked: (Creature) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         items(creatures) { creature ->
-            CreatureItem(
-                creature = creature,
-                modifier = Modifier.clickable { onCreatureClicked(creature) },
-            )
+            SwipeToAddBox(onAdd = { onAddToListClicked(creature) }) {
+                CreatureItem(
+                    creature = creature,
+                    modifier = Modifier.clickable { onCreatureClicked(creature) },
+                )
+            }
             HorizontalDivider()
         }
     }
@@ -112,7 +118,7 @@ private val stateWithSampleData = CreatureListState(
 @Composable
 private fun PreviewCreatureListScreenLight() {
     AppThemePreview(darkTheme = false) {
-        CreatureListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
+        CreatureListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -120,6 +126,6 @@ private fun PreviewCreatureListScreenLight() {
 @Composable
 private fun PreviewCreatureListScreenDark() {
     AppThemePreview(darkTheme = true) {
-        CreatureListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
+        CreatureListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -98,7 +98,7 @@ private fun CreatureList(
     onAddToListClicked: (Creature) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(creatures) { creature ->
+        items(creatures, key = { it.id }) { creature ->
             SwipeToAddBox(onAdd = { onAddToListClicked(creature) }) {
                 CreatureItem(
                     creature = creature,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -42,6 +42,10 @@ class CreatureListViewModel(
         router.openDetail(creature.id)
     }
 
+    fun onCreatureAddToListClicked(creature: Creature) {
+        router.openAddToList(creature.id)
+    }
+
     fun onTypeToggled(type: Creature.Type) {
         updateFilter { it.copy(types = it.types.toggled(type)) }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -120,7 +120,7 @@ private fun MagicalItemList(
         contentPadding = PaddingValues(spacingMedium),
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
-        items(magicalItems) { item ->
+        items(magicalItems, key = { it.id }) { item ->
             SwipeToAddBox(onAdd = { onAddToListClicked(item) }) {
                 MagicalItemListItem(
                     magicalItem = item,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -23,6 +23,7 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
+import com.cyrillrx.rpg.core.presentation.component.SwipeToAddBox
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -44,6 +45,7 @@ fun MagicalItemListScreen(viewModel: MagicalItemListViewModel) {
         onNavigateUpClicked = viewModel::onNavigateUpClicked,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onMagicalItemClicked = viewModel::onItemClicked,
+        onAddToListClicked = viewModel::onItemAddToListClicked,
         onTypeToggled = viewModel::onTypeToggled,
         onRarityToggled = viewModel::onRarityToggled,
         onResetFilters = viewModel::onResetFilters,
@@ -56,6 +58,7 @@ fun MagicalItemListScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onMagicalItemClicked: (MagicalItem) -> Unit,
+    onAddToListClicked: (MagicalItem) -> Unit,
     onTypeToggled: (MagicalItem.Type) -> Unit,
     onRarityToggled: (MagicalItem.Rarity) -> Unit,
     onResetFilters: () -> Unit,
@@ -84,7 +87,7 @@ fun MagicalItemListScreen(
                 is MagicalItemListState.Body.Loading -> Loader()
                 is MagicalItemListState.Body.Empty -> EmptySearch(state.filter.query)
                 is MagicalItemListState.Body.Error -> ErrorLayout(body.errorMessage)
-                is MagicalItemListState.Body.WithData -> MagicalItemList(body.searchResults, onMagicalItemClicked)
+                is MagicalItemListState.Body.WithData -> MagicalItemList(body.searchResults, onMagicalItemClicked, onAddToListClicked)
             }
         }
     }
@@ -104,6 +107,7 @@ fun MagicalItemListScreen(
 private fun MagicalItemList(
     magicalItems: List<MagicalItem>,
     onMagicalItemClicked: (MagicalItem) -> Unit,
+    onAddToListClicked: (MagicalItem) -> Unit,
 ) {
     val listState = rememberLazyListState()
     LaunchedEffect(magicalItems) {
@@ -117,11 +121,13 @@ private fun MagicalItemList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(magicalItems) { item ->
-            MagicalItemListItem(
-                magicalItem = item,
-                onClick = { onMagicalItemClicked(item) },
-                modifier = Modifier.fillMaxWidth(),
-            )
+            SwipeToAddBox(onAdd = { onAddToListClicked(item) }) {
+                MagicalItemListItem(
+                    magicalItem = item,
+                    onClick = { onMagicalItemClicked(item) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 }
@@ -134,7 +140,7 @@ private val stateWithSampleData = MagicalItemListState(
 @Composable
 private fun PreviewMagicalItemListScreenLight() {
     AppThemePreview(darkTheme = false) {
-        MagicalItemListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
+        MagicalItemListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -142,6 +148,6 @@ private fun PreviewMagicalItemListScreenLight() {
 @Composable
 private fun PreviewMagicalItemListScreenDark() {
     AppThemePreview(darkTheme = true) {
-        MagicalItemListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
+        MagicalItemListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -42,6 +42,10 @@ class MagicalItemListViewModel(
         router.openDetail(magicalItem.id)
     }
 
+    fun onItemAddToListClicked(item: MagicalItem) {
+        router.openAddToList(item.id)
+    }
+
     fun onTypeToggled(type: MagicalItem.Type) {
         updateFilter { it.copy(types = it.types.toggled(type)) }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -125,7 +125,7 @@ private fun SpellList(
         contentPadding = PaddingValues(spacingMedium),
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
-        items(spells) { spell ->
+        items(spells, key = { it.id }) { spell ->
             SwipeToAddBox(onAdd = { onAddToListClicked(spell) }) {
                 SpellListItem(
                     spell = spell,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -24,6 +24,7 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
+import com.cyrillrx.rpg.core.presentation.component.SwipeToAddBox
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -46,6 +47,7 @@ fun SpellListScreen(viewModel: SpellListViewModel, router: SpellRouter) {
         onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onSpellClicked = { spell -> router.openDetail(spell.id) },
+        onAddToListClicked = { spell -> router.openAddToList(spell.id) },
         onLevelToggled = viewModel::onLevelToggled,
         onSchoolToggled = viewModel::onSchoolToggled,
         onClassToggled = viewModel::onClassToggled,
@@ -59,6 +61,7 @@ fun SpellListScreen(
     onNavigateUpClicked: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onSpellClicked: (Spell) -> Unit,
+    onAddToListClicked: (Spell) -> Unit,
     onLevelToggled: (Int) -> Unit,
     onSchoolToggled: (Spell.School) -> Unit,
     onClassToggled: (PlayerCharacter.Class) -> Unit,
@@ -88,7 +91,7 @@ fun SpellListScreen(
                 is SpellListState.Body.Loading -> Loader()
                 is SpellListState.Body.Empty -> EmptySearch(state.filter.query)
                 is SpellListState.Body.Error -> ErrorLayout(body.errorMessage)
-                is SpellListState.Body.WithData -> SpellList(body.searchResults, onSpellClicked)
+                is SpellListState.Body.WithData -> SpellList(body.searchResults, onSpellClicked, onAddToListClicked)
             }
         }
     }
@@ -109,6 +112,7 @@ fun SpellListScreen(
 private fun SpellList(
     spells: List<Spell>,
     onSpellClicked: (Spell) -> Unit,
+    onAddToListClicked: (Spell) -> Unit,
 ) {
     val searchResultsListState = rememberLazyListState()
     LaunchedEffect(spells) {
@@ -122,11 +126,13 @@ private fun SpellList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(spells) { spell ->
-            SpellListItem(
-                spell = spell,
-                onClick = { onSpellClicked(spell) },
-                modifier = Modifier.fillMaxWidth(),
-            )
+            SwipeToAddBox(onAdd = { onAddToListClicked(spell) }) {
+                SpellListItem(
+                    spell = spell,
+                    onClick = { onSpellClicked(spell) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 }
@@ -139,7 +145,7 @@ private val stateWithSampleData = SpellListState(
 @Composable
 fun PreviewSpellListPeekScreenLight() {
     AppThemePreview(darkTheme = false) {
-        SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
+        SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -147,6 +153,6 @@ fun PreviewSpellListPeekScreenLight() {
 @Composable
 fun PreviewSpellListPeekScreenDark() {
     AppThemePreview(darkTheme = true) {
-        SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
+        SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {}, {})
     }
 }


### PR DESCRIPTION
## 📝 Description

Adds swipe-to-add-to-list on the Spells, Creatures, and Magical Items list screens. Swiping right on any item opens the `AddToListScreen`, allowing the user to add it to an existing list.

Note: `SwipeToAddBox` was calling `onAdd()` multiple times per swipe because Compose's `AnchoredDraggableState` invokes `confirmValueChange` several times during a single gesture. A `confirmed` guard flag prevents `onAdd()` from firing more than once, and a `LaunchedEffect` resets it when the swipe snaps back so subsequent swipes keep working.

## 🖼️ Media

[Screen_recording_20260407_003557.webm](https://github.com/user-attachments/assets/f15ee781-6c4e-47e3-b19b-91e3546eaf8e)

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed