### PR TITLE
feat(nav): add Material3 slide transitions between screens

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -41,7 +42,9 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
         NavHost(
             navController = navController,
             startDestination = MainRoute.Home,
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
             enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
             exitTransition = { slideOutHorizontally(targetOffsetX = { -it }) + fadeOut() },
             popEnterTransition = { slideInHorizontally(initialOffsetX = { -it }) + fadeIn() },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -1,6 +1,13 @@
 package com.cyrillrx.rpg.app
 
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -34,6 +41,11 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
         NavHost(
             navController = navController,
             startDestination = MainRoute.Home,
+            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
+            exitTransition = { slideOutHorizontally(targetOffsetX = { -it }) + fadeOut() },
+            popEnterTransition = { slideInHorizontally(initialOffsetX = { -it }) + fadeIn() },
+            popExitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() },
         ) {
             val homeRouter = HomeRouterImpl(navController)
             composable<MainRoute.Home> { HomeScreen(homeRouter) }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -1,7 +1,5 @@
 package com.cyrillrx.rpg.spell.presentation.navigation
 
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -55,10 +53,7 @@ fun NavGraphBuilder.handleSpellRoutes(
     spellRepository: SpellRepository,
     userListRepository: UserListRepository,
 ) {
-    composable<SpellRoute.List>(
-        enterTransition = { slideInHorizontally { initialOffset -> initialOffset } },
-        exitTransition = { slideOutHorizontally { initialOffset -> initialOffset } },
-    ) {
+    composable<SpellRoute.List> {
         val router = SpellRouterImpl(navController)
         val viewModelFactory = SpellListViewModelFactory(router, spellRepository)
         val viewModel = viewModel<SpellListViewModel>(factory = viewModelFactory)


### PR DESCRIPTION
## 📝 Description

Add global Material3 horizontal slide and fade transitions to `NavHost` so all routes have consistent animations when navigating forwards and backwards.

`SpellRoute.List` previously had its own local transitions. These are now replaced with the global `NavHost`-level transitions.

A `Modifier.background(MaterialTheme.colorScheme.background)` is also added to `NavHost` to prevent the white flash visible during the slide: without it, the system background shows through while both screens are simultaneously rendered.

## 🖼️ Media

[Screen_recording_20260408_094601.webm](https://github.com/user-attachments/assets/e0397474-8265-4fd1-a189-35bbf066f199)

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed