### PR TITLE
feat(userlist): refresh UserListsScreen on resume to fix stale data

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -109,7 +109,7 @@ fun <T> ListDetailScreen(
             val result = snackbarHostState.showSnackbar(
                 message = removedMessage,
                 actionLabel = undoLabel,
-                duration = SnackbarDuration.Long,
+                duration = SnackbarDuration.Short,
             )
             when (result) {
                 SnackbarResult.ActionPerformed -> onUndoRemoval(pending)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +35,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -62,6 +66,16 @@ import rpg_companion.composeapp.generated.resources.snackbar_list_deleted
 @Composable
 fun UserListsScreen(viewModel: UserListsViewModel, title: String) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.silentRefresh()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     UserListsScreen(
         state = state,
         title = title,
@@ -114,7 +128,7 @@ fun UserListsScreen(
             val result = snackbarHostState.showSnackbar(
                 message = deletedMessage,
                 actionLabel = undoLabel,
-                duration = SnackbarDuration.Long,
+                duration = SnackbarDuration.Short,
             )
             when (result) {
                 SnackbarResult.ActionPerformed -> onUndoDeletion(pending)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,9 +35,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
@@ -67,13 +65,8 @@ import rpg_companion.composeapp.generated.resources.snackbar_list_deleted
 fun UserListsScreen(viewModel: UserListsViewModel, title: String) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) viewModel.silentRefresh()
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.silentRefresh()
     }
 
     UserListsScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -16,10 +16,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.time.Clock
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_user_lists
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -135,23 +135,40 @@ class UserListsViewModel(
         }
     }
 
+    fun silentRefresh() {
+        viewModelScope.launch {
+            // No loader to prevent view from flashing
+            try {
+                fetchAndUpdateUserLists()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Keep existing state on refresh failure
+            }
+        }
+    }
+
     private fun loadLists() {
         viewModelScope.launch {
             state.update { it.copy(body = UserListsState.Body.Loading) }
 
             try {
-                val lists = userListRepository.getAll(listType)
-                val body = if (lists.isEmpty()) {
-                    UserListsState.Body.Empty
-                } else {
-                    UserListsState.Body.WithData(lists)
-                }
-                state.update { it.copy(body = body) }
+                fetchAndUpdateUserLists()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 state.update { it.copy(body = UserListsState.Body.Error(errorMessage = Res.string.error_while_loading_user_lists)) }
             }
         }
+    }
+
+    private suspend fun fetchAndUpdateUserLists() {
+        val lists = userListRepository.getAll(listType)
+        val body = if (lists.isEmpty()) {
+            UserListsState.Body.Empty
+        } else {
+            UserListsState.Body.WithData(lists)
+        }
+        state.update { it.copy(body = body) }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -136,6 +136,8 @@ class UserListsViewModel(
     }
 
     fun silentRefresh() {
+        if (state.value.body is UserListsState.Body.Loading) return
+
         viewModelScope.launch {
             // No loader to prevent view from flashing
             try {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -199,6 +199,34 @@ class UserListsViewModelTest {
     }
 
     @Test
+    fun `refresh updates state with fresh data without showing Loading`() = runTest(testDispatcher) {
+        val spellList = UserList("1", "Spellbook", UserList.Type.SPELL, emptyList())
+        repository.save(spellList)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val updatedList = spellList.copy(name = "Updated Spellbook")
+        repository.save(updatedList)
+
+        viewModel.silentRefresh()
+
+        // State must not be Loading during refresh
+        assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
+
+        advanceUntilIdle()
+
+        val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(expected = 1, actual = body.lists.size)
+        assertEquals(expected = "Updated Spellbook", actual = body.lists.first().name)
+    }
+
+    @Test
     fun `openList delegates to router`() = runTest(testDispatcher) {
         val trackingRouter = TrackingUserListRouter()
         val viewModel = UserListsViewModel(UserList.Type.SPELL, trackingRouter, repository)


### PR DESCRIPTION
## 📝 Description

`UserListsScreen` loaded data once in `ViewModel.init`. After navigating to `ListDetailScreen` and modifying a list (remove/add items), returning to `UserListsScreen` would show stale item count and `lastModified`.

Expose `silentRefresh()` on `UserListsViewModel` and call it on every `ON_RESUME` lifecycle event. The refresh is silent (no `Loading` flash). It updates the state only when new data arrives, keeping current data visible during the fetch. The existing `lastModified DESC` SQL ordering + `animateItem()` on the `LazyColumn` automatically animates reordering at no extra cost.

Also aligns snackbar duration to `Short` in both `UserListsScreen` and `ListDetailScreen`.

## 🖼️ Media

[Screen_recording_20260408_133811.webm](https://github.com/user-attachments/assets/f91d15f7-0071-4bb7-bc64-a8b1c5c0c30f)

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed