### PR TITLE
feat(userlist): rename a list from ListDetailScreen

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -33,4 +33,7 @@
     <string name="empty_list_browse_magical_items">Parcourir les objets magiques</string>
 
     <string name="time_ago_now">À l'instant</string>
+
+    <string name="btn_rename_list">Renommer</string>
+    <string name="dialog_rename_list_title">Renommer la liste</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -33,4 +33,7 @@
     <string name="empty_list_browse_magical_items">Browse magical items</string>
 
     <string name="time_ago_now">Just now</string>
+
+    <string name="btn_rename_list">Rename</string>
+    <string name="dialog_rename_list_title">Rename list</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SimpleTopBar.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SimpleTopBar.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.core.presentation.component
 
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -16,8 +17,12 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_back
 
 @Composable
-fun SimpleTopBar(titleResource: StringResource, navigateUp: () -> Unit) {
-    SimpleTopBar(stringResource(titleResource), navigateUp)
+fun SimpleTopBar(
+    titleResource: StringResource,
+    navigateUp: () -> Unit,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    SimpleTopBar(stringResource(titleResource), navigateUp, actions)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -25,6 +30,7 @@ fun SimpleTopBar(titleResource: StringResource, navigateUp: () -> Unit) {
 fun SimpleTopBar(
     title: String,
     navigateUp: () -> Unit,
+    actions: @Composable RowScope.() -> Unit = {},
 ) {
     TopAppBar(
         title = { Text(title) },
@@ -36,6 +42,7 @@ fun SimpleTopBar(
                 )
             }
         },
+        actions = actions,
         colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
     )
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
@@ -36,9 +36,10 @@ fun RenameListDialog(
             )
         },
         confirmButton = {
+            val trimmedName = name.trim()
             TextButton(
-                onClick = { onConfirm(name) },
-                enabled = name.isNotBlank() && name != currentName,
+                onClick = { onConfirm(trimmedName) },
+                enabled = trimmedName.isNotBlank() && trimmedName != currentName,
             ) {
                 Text(stringResource(Res.string.btn_confirm))
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
@@ -1,0 +1,52 @@
+package com.cyrillrx.rpg.core.presentation.component.dialog
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_cancel
+import rpg_companion.composeapp.generated.resources.btn_confirm
+import rpg_companion.composeapp.generated.resources.dialog_rename_list_title
+import rpg_companion.composeapp.generated.resources.hint_list_name
+
+@Composable
+fun RenameListDialog(
+    currentName: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf(currentName) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.dialog_rename_list_title)) },
+        text = {
+            TextField(
+                value = name,
+                onValueChange = { name = it },
+                placeholder = { Text(stringResource(Res.string.hint_list_name)) },
+                singleLine = true,
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name) },
+                enabled = name.isNotBlank() && name != currentName,
+            ) {
+                Text(stringResource(Res.string.btn_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.btn_cancel))
+            }
+        },
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
@@ -25,8 +27,10 @@ import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,6 +38,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.component.dialog.RenameListDialog
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -49,6 +54,7 @@ import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_rename_list
 import rpg_companion.composeapp.generated.resources.btn_undo
 import rpg_companion.composeapp.generated.resources.snackbar_error_removing_from_list
 import rpg_companion.composeapp.generated.resources.snackbar_removed_from_list
@@ -65,6 +71,7 @@ fun <T> ListDetailScreen(
         events = viewModel.events,
         itemProvider = itemProvider,
         onNavigateUpClicked = onNavigateUp,
+        onRenameList = viewModel::renameList,
         onRemoveItemOptimistically = viewModel::removeItemOptimistically,
         onUndoRemoval = viewModel::undoRemoval,
         onCommitRemoval = viewModel::commitRemoval,
@@ -77,6 +84,7 @@ fun <T> ListDetailScreen(
     events: SharedFlow<ListDetailViewModel.Event<T>>,
     itemProvider: ListItemProvider<T>,
     onNavigateUpClicked: () -> Unit,
+    onRenameList: (String) -> Unit,
     onRemoveItemOptimistically: (id: String, item: T) -> ListDetailViewModel.PendingRemoval<T>?,
     onUndoRemoval: (ListDetailViewModel.PendingRemoval<T>) -> Unit,
     onCommitRemoval: (ListDetailViewModel.PendingRemoval<T>) -> Unit,
@@ -84,6 +92,7 @@ fun <T> ListDetailScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val undoLabel = stringResource(Res.string.btn_undo)
+    var showRenameDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(events) {
         events.collect { event ->
@@ -118,11 +127,27 @@ fun <T> ListDetailScreen(
         }
     }
 
+    if (showRenameDialog) {
+        RenameListDialog(
+            currentName = state.listName,
+            onConfirm = { newName ->
+                onRenameList(newName)
+                showRenameDialog = false
+            },
+            onDismiss = { showRenameDialog = false },
+        )
+    }
+
     Scaffold(
         topBar = {
             SimpleTopBar(
                 title = state.listName,
                 navigateUp = onNavigateUpClicked,
+                actions = {
+                    IconButton(onClick = { showRenameDialog = true }) {
+                        Icon(Icons.Default.Edit, contentDescription = stringResource(Res.string.btn_rename_list))
+                    }
+                },
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -236,6 +261,7 @@ private fun ListDetailScreenPreview(darkTheme: Boolean) {
             events = MutableSharedFlow(),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
+            onRenameList = {},
             onRemoveItemOptimistically = { _, _ -> null },
             onUndoRemoval = {},
             onCommitRemoval = {},
@@ -266,6 +292,7 @@ private fun EmptyListDetailScreenPreview(darkTheme: Boolean) {
             events = MutableSharedFlow(),
             itemProvider = SpellItemProvider(onItemClicked = {}),
             onNavigateUpClicked = {},
+            onRenameList = {},
             onRemoveItemOptimistically = { _, _ -> null },
             onUndoRemoval = {},
             onCommitRemoval = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.userlist.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.domain.EntityRepository
+import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import kotlinx.coroutines.CoroutineDispatcher
@@ -15,6 +16,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_user_list
 import kotlin.coroutines.cancellation.CancellationException
@@ -39,6 +41,7 @@ class ListDetailViewModel<T>(
     }
 
     private val pendingRemovals: MutableList<PendingRemoval<T>> = mutableListOf()
+    private var currentList: UserList? = null
 
     init {
         loadDetail()
@@ -48,6 +51,15 @@ class ListDetailViewModel<T>(
         super.onCleared()
 
         commitAllPendingRemovals()
+    }
+
+    fun renameList(newName: String) {
+        val list = currentList ?: return
+        viewModelScope.launch {
+            userListRepository.save(list.copy(name = newName, lastModified = Clock.System.now()))
+            currentList = currentList?.copy(name = newName)
+            state.update { it.copy(listName = newName) }
+        }
     }
 
     fun removeItemOptimistically(itemId: String, item: T): PendingRemoval<T>? {
@@ -111,6 +123,7 @@ class ListDetailViewModel<T>(
 
             try {
                 val list = userListRepository.get(listId) ?: error("Could not find list $listId")
+                currentList = list
                 state.update { it.copy(listName = list.name) }
 
                 val items = repository.getByIds(list.itemIds)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -16,10 +16,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.time.Clock
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_user_list
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
 
 class ListDetailViewModel<T>(
     private val listId: String,
@@ -55,10 +55,16 @@ class ListDetailViewModel<T>(
 
     fun renameList(newName: String) {
         val list = currentList ?: return
+
         viewModelScope.launch {
-            userListRepository.save(list.copy(name = newName, lastModified = Clock.System.now()))
-            currentList = currentList?.copy(name = newName)
-            state.update { it.copy(listName = newName) }
+            val updatedList = list.copy(name = newName, lastModified = Clock.System.now())
+            try {
+                userListRepository.save(updatedList)
+                currentList = updatedList
+                state.update { it.copy(listName = newName) }
+            } catch (e: Exception) {
+                // TODO: Emit an event to notify UI about the error
+            }
         }
     }
 


### PR DESCRIPTION
## 📝 Description

Add an edit icon to the top bar of `ListDetailScreen` that opens a pre-filled dialog allowing the user to rename the current list.

- `RenameListDialog` - new dialog pre-filled with the current name; confirm is disabled when the field is blank or unchanged
- `SimpleTopBar` - optional `actions` parameter added (default empty, no existing callers affected)
- `ListDetailViewModel` - stores the loaded `UserList` and exposes `renameList(newName)` which persists via `UserListRepository.save()`
- `ListDetailScreen` - edit icon in the top bar triggers the dialog. Title updates immediately on confirm

## 🖼️ Media

<img width="1016" height="1080" alt="image" src="https://github.com/user-attachments/assets/bf58ccb2-bb38-4094-a16d-658a53b6c435" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed