### PR TITLE
refactor(core): extract SwipeToDelete and rename SwipeToAddBox to SwipeToAdd

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAdd.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAdd.kt
@@ -26,7 +26,7 @@ import com.cyrillrx.rpg.core.presentation.theme.Green500
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 
 @Composable
-fun SwipeToAddBox(
+fun SwipeToAdd(
     onSwiped: () -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToDelete.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToDelete.kt
@@ -1,0 +1,58 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+
+@Composable
+fun SwipeToDelete(
+    onSwiped: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onSwiped()
+            }
+            false
+        },
+    )
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = modifier,
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = true,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(end = spacingMedium),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        },
+        content = content,
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.creature.presentation.component
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -20,7 +21,7 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
-import com.cyrillrx.rpg.core.presentation.component.SwipeToAddBox
+import com.cyrillrx.rpg.core.presentation.component.SwipeToAdd
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
@@ -118,7 +119,10 @@ private fun CreatureList(
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         items(creatures, key = { it.id }) { creature ->
-            SwipeToAddBox(onSwiped = { showAddToList(creature) }) {
+            SwipeToAdd(
+                onSwiped = { showAddToList(creature) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 CreatureItem(
                     creature = creature,
                     modifier = Modifier.clickable { onCreatureClicked(creature) },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -24,7 +24,7 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
-import com.cyrillrx.rpg.core.presentation.component.SwipeToAddBox
+import com.cyrillrx.rpg.core.presentation.component.SwipeToAdd
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -140,11 +140,13 @@ private fun MagicalItemList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(magicalItems, key = { it.id }) { item ->
-            SwipeToAddBox(onSwiped = { showAddToList(item) }) {
+            SwipeToAdd(
+                onSwiped = { showAddToList(item) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 MagicalItemListItem(
                     magicalItem = item,
                     onClick = { onMagicalItemClicked(item) },
-                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -25,7 +25,7 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
-import com.cyrillrx.rpg.core.presentation.component.SwipeToAddBox
+import com.cyrillrx.rpg.core.presentation.component.SwipeToAdd
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -146,11 +146,13 @@ private fun SpellList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(spells, key = { it.id }) { spell ->
-            SwipeToAddBox(onSwiped = { showAddToList(spell) }) {
+            SwipeToAdd(
+                onSwiped = { showAddToList(spell) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 SpellListItem(
                     spell = spell,
                     onClick = { onSpellClicked(spell) },
-                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -1,8 +1,6 @@
 package com.cyrillrx.rpg.userlist.presentation.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,19 +9,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -33,11 +26,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
 import com.cyrillrx.rpg.core.presentation.component.dialog.RenameListDialog
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
@@ -184,57 +177,16 @@ private fun <T> EntityDetailList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(items, key = { uiProvider.getId(it) }) { item ->
-            SwipeableListItem(
-                item = item,
-                uiProvider = uiProvider,
-                onRemoveItem = onRemoveItem,
+            SwipeToDelete(
+                onSwiped = { onRemoveItem(item) },
                 modifier = Modifier.animateItem(),
-            )
-        }
-    }
-}
-
-@Composable
-private fun <T> SwipeableListItem(
-    item: T,
-    uiProvider: ListItemProvider<T>,
-    onRemoveItem: (T) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val dismissState = rememberSwipeToDismissBoxState(
-        confirmValueChange = { value ->
-            if (value == SwipeToDismissBoxValue.EndToStart) {
-                onRemoveItem(item)
-            }
-            false
-        },
-    )
-    SwipeToDismissBox(
-        state = dismissState,
-        modifier = modifier,
-        enableDismissFromStartToEnd = false,
-        enableDismissFromEndToStart = true,
-        backgroundContent = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(MaterialTheme.colorScheme.errorContainer)
-                    .padding(end = spacingMedium),
-                contentAlignment = Alignment.CenterEnd,
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                uiProvider.ListItem(
+                    entity = item,
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
-        },
-    ) {
-        uiProvider.ListItem(
-            entity = item,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        }
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -179,12 +179,9 @@ private fun <T> EntityDetailList(
         items(items, key = { uiProvider.getId(it) }) { item ->
             SwipeToDelete(
                 onSwiped = { onRemoveItem(item) },
-                modifier = Modifier.animateItem(),
+                modifier = Modifier.fillMaxWidth().animateItem(),
             ) {
-                uiProvider.ListItem(
-                    entity = item,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                uiProvider.ListItem(entity = item, modifier = Modifier)
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -1,8 +1,6 @@
 package com.cyrillrx.rpg.userlist.presentation.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,18 +10,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -33,13 +26,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
 import com.cyrillrx.rpg.core.presentation.component.dialog.CreateListDialog
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
@@ -189,60 +182,19 @@ private fun UserLists(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(lists, key = { it.id }) { list ->
-            SwipeableUserListItem(
-                list = list,
-                onClick = { onListClicked(list) },
-                onDelete = { onDeleteList(list) },
+            SwipeToDelete(
+                onSwiped = { onDeleteList(list) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .animateItem(),
-            )
-        }
-    }
-}
-
-@Composable
-private fun SwipeableUserListItem(
-    list: UserList,
-    onClick: () -> Unit,
-    onDelete: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val dismissState = rememberSwipeToDismissBoxState(
-        confirmValueChange = { value ->
-            if (value == SwipeToDismissBoxValue.EndToStart) {
-                onDelete()
-            }
-            false
-        },
-    )
-    SwipeToDismissBox(
-        state = dismissState,
-        modifier = modifier,
-        enableDismissFromStartToEnd = false,
-        enableDismissFromEndToStart = true,
-        backgroundContent = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(MaterialTheme.colorScheme.errorContainer)
-                    .padding(end = spacingMedium),
-                contentAlignment = Alignment.CenterEnd,
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                UserListItem(
+                    list = list,
+                    onClick = { onListClicked(list) },
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
-        },
-    ) {
-        UserListItem(
-            list = list,
-            onClick = onClick,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        }
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -191,7 +191,6 @@ private fun UserLists(
                 UserListItem(
                     list = list,
                     onClick = { onListClicked(list) },
-                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }


### PR DESCRIPTION
## 📝 Description

Two refactoring steps to unify swipe components:

1. Extract `SwipeToDelete` as a reusable component

The swipe-to-delete logic was duplicated across `ListDetailScreen` and `UserListsScreen`. It is now extracted into `core/presentation/component/SwipeToDelete.kt`, significantly reducing both call sites.

2. Rename `SwipeToAddBox` → `SwipeToAdd` and enforce uniform modifier placement

- Renamed for consistency with `SwipeToDelete`
- `fillMaxWidth()` and `animateItem()` now always sit on the swipe component modifier (outermost element)
- Content lambdas no longer pass a redundant `fillMaxWidth()`

### Canonical pattern

```kotlin
// SwipeToDelete
SwipeToDelete(
    onSwiped = { ... },
    modifier = Modifier.fillMaxWidth().animateItem(),
) {
    SomeItem(entity = ...)
}

// SwipeToAdd
SwipeToAdd(
    onSwiped = { ... },
    modifier = Modifier.fillMaxWidth(),
) {
    SomeItem(entity = ...)
}
```

## 🖼️ Media

No visible change - internal refactoring only.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed