### PR TITLE
fix(userlist): add fillMaxWidth to items inside SwipeToDelete and SwipeToAdd

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -125,7 +125,7 @@ private fun CreatureList(
             ) {
                 CreatureItem(
                     creature = creature,
-                    modifier = Modifier.clickable { onCreatureClicked(creature) },
+                    modifier = Modifier.fillMaxWidth().clickable { onCreatureClicked(creature) },
                 )
             }
             HorizontalDivider()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -147,6 +147,7 @@ private fun MagicalItemList(
                 MagicalItemListItem(
                     magicalItem = item,
                     onClick = { onMagicalItemClicked(item) },
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -153,6 +153,7 @@ private fun SpellList(
                 SpellListItem(
                     spell = spell,
                     onClick = { onSpellClicked(spell) },
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -181,7 +181,7 @@ private fun <T> EntityDetailList(
                 onSwiped = { onRemoveItem(item) },
                 modifier = Modifier.fillMaxWidth().animateItem(),
             ) {
-                uiProvider.ListItem(entity = item, modifier = Modifier)
+                uiProvider.ListItem(entity = item, modifier = Modifier.fillMaxWidth())
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -191,6 +191,7 @@ private fun UserLists(
                 UserListItem(
                     list = list,
                     onClick = { onListClicked(list) },
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }


### PR DESCRIPTION
## 📝 Description

The `backgroundContent` of `SwipeToDismissBox` always renders at full row width (via `fillMaxSize()`). Item composables inside `SwipeToDelete` and `SwipeToAdd` were called without `Modifier.fillMaxWidth()`, so their Cards only wrapped their text content - leaving the coloured background (red/green) exposed at rest.

Fixed in all 5 call sites for consistency:
- `UserListsScreen` - `UserListItem` (reported bug)
- `ListDetailScreen` - `uiProvider.ListItem`
- `SpellListScreen` - `SpellListItem`
- `MagicalItemListScreen` - `MagicalItemListItem`
- `CreatureListScreen` - `CreatureItem`

## 🖼️ Media

Before fix
<img width="1066" height="532" alt="image" src="https://github.com/user-attachments/assets/04a05774-5b6f-4259-8359-934b24970356" />

After fix
<img width="1230" height="510" alt="image" src="https://github.com/user-attachments/assets/1e40f9c1-045d-4a1d-9214-111c0212631e" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed