### PR TITLE
feat(nav): migrate from Navigation 2 to Navigation 3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,11 @@ composable<SpellRoute.List> {
 
 ### Navigation
 
-`App.kt` is the `NavDisplay` root. The back stack is a `SnapshotStateList<Any>` created with `rememberNavBackStack(savedStateConfig, startKey)`. Each feature registers its routes via an `EntryProviderBuilder<Any>` extension function (`handleSpellRoutes`, `handleCampaignRoutes`, etc.) inside the `entryProvider { }` block. Routes are `@Serializable` objects/data classes. A `SavedStateConfiguration` with polymorphic serializers for every route type is required for non-JVM targets (iOS). Complex objects are passed as serialized strings using `serialize()`/`deserialize()` helpers from the `Serializer.kt` utility in the `shared/core` module.
+`App.kt` is the `NavDisplay` root. The back stack is a `NavBackStack<NavKey>` created with `rememberNavBackStack(savedStateConfig, startKey)`. Each feature registers its routes via an `EntryProviderScope<NavKey>` extension function (`handleSpellRoutes`, `handleCampaignRoutes`, etc.) inside the `entryProvider { }` block. Routes are `@Serializable` data objects/classes implementing `NavKey`. A `SavedStateConfiguration` with polymorphic serializers for every route type is required for non-JVM targets (iOS) — each feature exposes a `register*Routes()` extension on `PolymorphicModuleBuilder<NavKey>` for this purpose. Complex objects are passed as serialized strings using `serialize()`/`deserialize()` helpers from the `Serializer.kt` utility in the `shared/core` module.
 
 ### Router pattern
 
-Each feature defines a `{Feature}Router` interface and a `{Feature}RouterImpl(backStack: MutableList<Any>)`. The interface is injected into ViewModels; the impl lives in the navigation layer. Navigation calls use `backStack.add(route)` to push and `backStack.removeLastOrNull()` to pop.
+Each feature defines a `{Feature}Router` interface and a `{Feature}RouterImpl(backStack: NavBackStack<NavKey>)`. The interface is injected into ViewModels; the impl lives in the navigation layer. Navigation calls use `backStack.add(route)` to push and `backStack.removeLastOrNull()` to pop. A `NavBackStack<NavKey>.navigateUp()` extension in `core/navigation/NavExt.kt` wraps `removeLastOrNull()` for convenience. `onNavigateUpClicked` callbacks are wired directly from the route entry (not from the ViewModel). When calling `viewModel()` for shared ViewModel types (`UserListsViewModel`, `ListDetailViewModel<T>`), always pass an explicit `key` to avoid ViewModel sharing across entries.
 
 ### State
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,11 @@ composable<SpellRoute.List> {
 
 ### Navigation
 
-`App.kt` is the `NavHost` root. Each feature registers its routes via a `NavGraphBuilder` extension function (`handleSpellRoutes`, `handleCampaignRoutes`, etc.). Routes are `@Serializable` objects/data classes. Complex objects are passed as serialized strings using `serialize()`/`deserialize()` helpers from the `Serializer.kt` utility in the `shared/core` module.
+`App.kt` is the `NavDisplay` root. The back stack is a `SnapshotStateList<Any>` created with `rememberNavBackStack(savedStateConfig, startKey)`. Each feature registers its routes via an `EntryProviderBuilder<Any>` extension function (`handleSpellRoutes`, `handleCampaignRoutes`, etc.) inside the `entryProvider { }` block. Routes are `@Serializable` objects/data classes. A `SavedStateConfiguration` with polymorphic serializers for every route type is required for non-JVM targets (iOS). Complex objects are passed as serialized strings using `serialize()`/`deserialize()` helpers from the `Serializer.kt` utility in the `shared/core` module.
 
 ### Router pattern
 
-Each feature defines a `{Feature}Router` interface and a `{Feature}RouterImpl(navController)`. The interface is injected into ViewModels; the impl lives in the navigation layer.
+Each feature defines a `{Feature}Router` interface and a `{Feature}RouterImpl(backStack: MutableList<Any>)`. The interface is injected into ViewModels; the impl lives in the navigation layer. Navigation calls use `backStack.add(route)` to push and `backStack.removeLastOrNull()` to pop.
 
 ### State
 

--- a/cmp-ttrpg-companion/composeApp/build.gradle.kts
+++ b/cmp-ttrpg-companion/composeApp/build.gradle.kts
@@ -55,7 +55,8 @@ kotlin {
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
 
-            implementation(libs.jetbrains.compose.navigation)
+            implementation(libs.jetbrains.navigation3.ui)
+            implementation(libs.jetbrains.lifecycle.viewmodelNavigation3)
             implementation(libs.jetbrains.lifecycle.runtime.compose)
             implementation(libs.jetbrains.lifecycle.viewmodel.compose)
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -26,17 +26,23 @@ import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
 import com.cyrillrx.rpg.core.navigation.navigateUp
 import com.cyrillrx.rpg.core.presentation.theme.AppTheme
 import com.cyrillrx.rpg.creature.data.JsonCreatureRepository
+import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRouterImpl
 import com.cyrillrx.rpg.creature.presentation.navigation.handleCreatureRoutes
 import com.cyrillrx.rpg.creature.presentation.navigation.registerCreatureRoutes
 import com.cyrillrx.rpg.home.presentation.HomeScreen
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouterImpl
 import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouterImpl
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.handleMagicalItemRoutes
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.registerMagicalItemRoutes
 import com.cyrillrx.rpg.spell.data.JsonSpellRepository
+import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouterImpl
 import com.cyrillrx.rpg.spell.presentation.navigation.handleSpellRoutes
 import com.cyrillrx.rpg.spell.presentation.navigation.registerSpellRoutes
 import com.cyrillrx.rpg.userlist.data.SQLDelightUserListRepository
+import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouterImpl
+import com.cyrillrx.rpg.userlist.presentation.navigation.handleUserListRoutes
+import com.cyrillrx.rpg.userlist.presentation.navigation.registerUserListRoutes
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -52,6 +58,8 @@ private val navSavedStateConfig = SavedStateConfiguration {
             registerSpellRoutes()
             registerMagicalItemRoutes()
             registerCreatureRoutes()
+
+            registerUserListRoutes()
         }
     }
 }
@@ -86,9 +94,23 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
                 handlePlayerCharacterRoutes(backStack, RamPlayerCharacterRepository())
 
-                handleSpellRoutes(backStack, JsonSpellRepository(fileReader), userListRepository)
-                handleMagicalItemRoutes(backStack, JsonMagicalItemRepository(fileReader), userListRepository)
-                handleCreatureRoutes(backStack, JsonCreatureRepository(fileReader), userListRepository)
+                handleSpellRoutes(
+                    router = SpellRouterImpl(backStack),
+                    spellRepository = JsonSpellRepository(fileReader),
+                    userListRepository = userListRepository,
+                )
+                handleMagicalItemRoutes(
+                    router = MagicalItemRouterImpl(backStack),
+                    repository = JsonMagicalItemRepository(fileReader),
+                    userListRepository = userListRepository,
+                )
+                handleCreatureRoutes(
+                    router = CreatureRouterImpl(backStack),
+                    repository = JsonCreatureRepository(fileReader),
+                    userListRepository = userListRepository,
+                )
+
+                handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
             },
         )
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -23,6 +23,7 @@ import com.cyrillrx.rpg.character.presentation.navigation.declareCharacterRoutes
 import com.cyrillrx.rpg.character.presentation.navigation.handlePlayerCharacterRoutes
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
+import com.cyrillrx.rpg.core.navigation.navigateUp
 import com.cyrillrx.rpg.core.presentation.theme.AppTheme
 import com.cyrillrx.rpg.creature.data.JsonCreatureRepository
 import com.cyrillrx.rpg.creature.presentation.navigation.declareCreatureRoutes
@@ -69,7 +70,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
-            onBack = { if (backStack.size > 1) backStack.removeAt(backStack.size - 1) },
+            onBack = backStack::navigateUp,
             transitionSpec = {
                 slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
                     slideOutHorizontally(targetOffsetX = { -it }) + fadeOut()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -16,26 +16,26 @@ import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import androidx.savedstate.serialization.SavedStateConfiguration
 import com.cyrillrx.rpg.campaign.data.SQLDelightCampaignRepository
-import com.cyrillrx.rpg.campaign.navigation.declareCampaignRoutes
 import com.cyrillrx.rpg.campaign.navigation.handleCampaignRoutes
+import com.cyrillrx.rpg.campaign.navigation.registerCampaignRoutes
 import com.cyrillrx.rpg.character.data.RamPlayerCharacterRepository
-import com.cyrillrx.rpg.character.presentation.navigation.declareCharacterRoutes
 import com.cyrillrx.rpg.character.presentation.navigation.handlePlayerCharacterRoutes
+import com.cyrillrx.rpg.character.presentation.navigation.registerCharacterRoutes
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
 import com.cyrillrx.rpg.core.navigation.navigateUp
 import com.cyrillrx.rpg.core.presentation.theme.AppTheme
 import com.cyrillrx.rpg.creature.data.JsonCreatureRepository
-import com.cyrillrx.rpg.creature.presentation.navigation.declareCreatureRoutes
 import com.cyrillrx.rpg.creature.presentation.navigation.handleCreatureRoutes
+import com.cyrillrx.rpg.creature.presentation.navigation.registerCreatureRoutes
 import com.cyrillrx.rpg.home.presentation.HomeScreen
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouterImpl
 import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
-import com.cyrillrx.rpg.magicalitem.presentation.navigation.declareMagicalItemRoutes
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.handleMagicalItemRoutes
+import com.cyrillrx.rpg.magicalitem.presentation.navigation.registerMagicalItemRoutes
 import com.cyrillrx.rpg.spell.data.JsonSpellRepository
-import com.cyrillrx.rpg.spell.presentation.navigation.declareSpellRoutes
 import com.cyrillrx.rpg.spell.presentation.navigation.handleSpellRoutes
+import com.cyrillrx.rpg.spell.presentation.navigation.registerSpellRoutes
 import com.cyrillrx.rpg.userlist.data.SQLDelightUserListRepository
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
@@ -46,12 +46,12 @@ private val navSavedStateConfig = SavedStateConfiguration {
         polymorphic(NavKey::class) {
             subclass(MainRoute.Home::class, MainRoute.Home.serializer())
 
-            declareCampaignRoutes()
-            declareCharacterRoutes()
+            registerCampaignRoutes()
+            registerCharacterRoutes()
 
-            declareSpellRoutes()
-            declareMagicalItemRoutes()
-            declareCreatureRoutes()
+            registerSpellRoutes()
+            registerMagicalItemRoutes()
+            registerCreatureRoutes()
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -4,61 +4,91 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import androidx.savedstate.serialization.SavedStateConfiguration
 import com.cyrillrx.rpg.campaign.data.SQLDelightCampaignRepository
+import com.cyrillrx.rpg.campaign.navigation.declareCampaignRoutes
 import com.cyrillrx.rpg.campaign.navigation.handleCampaignRoutes
 import com.cyrillrx.rpg.character.data.RamPlayerCharacterRepository
+import com.cyrillrx.rpg.character.presentation.navigation.declareCharacterRoutes
 import com.cyrillrx.rpg.character.presentation.navigation.handlePlayerCharacterRoutes
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
 import com.cyrillrx.rpg.core.presentation.theme.AppTheme
 import com.cyrillrx.rpg.creature.data.JsonCreatureRepository
+import com.cyrillrx.rpg.creature.presentation.navigation.declareCreatureRoutes
 import com.cyrillrx.rpg.creature.presentation.navigation.handleCreatureRoutes
 import com.cyrillrx.rpg.home.presentation.HomeScreen
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouterImpl
 import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.presentation.navigation.declareMagicalItemRoutes
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.handleMagicalItemRoutes
 import com.cyrillrx.rpg.spell.data.JsonSpellRepository
+import com.cyrillrx.rpg.spell.presentation.navigation.declareSpellRoutes
 import com.cyrillrx.rpg.spell.presentation.navigation.handleSpellRoutes
 import com.cyrillrx.rpg.userlist.data.SQLDelightUserListRepository
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
 import org.jetbrains.compose.ui.tooling.preview.Preview
+
+private val navSavedStateConfig = SavedStateConfiguration {
+    serializersModule = SerializersModule {
+        polymorphic(NavKey::class) {
+            subclass(MainRoute.Home::class, MainRoute.Home.serializer())
+
+            declareCampaignRoutes()
+            declareCharacterRoutes()
+
+            declareSpellRoutes()
+            declareMagicalItemRoutes()
+            declareCreatureRoutes()
+        }
+    }
+}
 
 @Composable
 @Preview
 fun App(dbDriverFactory: DatabaseDriverFactory) {
     AppTheme {
-        val navController = rememberNavController()
+        val backStack = rememberNavBackStack(navSavedStateConfig, MainRoute.Home)
 
         val fileReader = ComposeFileReader()
         val userListRepository = SQLDelightUserListRepository(dbDriverFactory)
 
-        NavHost(
-            navController = navController,
-            startDestination = MainRoute.Home,
-            Modifier
+        NavDisplay(
+            backStack = backStack,
+            modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
-            enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
-            exitTransition = { slideOutHorizontally(targetOffsetX = { -it }) + fadeOut() },
-            popEnterTransition = { slideInHorizontally(initialOffsetX = { -it }) + fadeIn() },
-            popExitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() },
-        ) {
-            val homeRouter = HomeRouterImpl(navController)
-            composable<MainRoute.Home> { HomeScreen(homeRouter) }
+            onBack = { if (backStack.size > 1) backStack.removeAt(backStack.size - 1) },
+            transitionSpec = {
+                slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
+                    slideOutHorizontally(targetOffsetX = { -it }) + fadeOut()
+            },
+            popTransitionSpec = {
+                slideInHorizontally(initialOffsetX = { -it }) + fadeIn() togetherWith
+                    slideOutHorizontally(targetOffsetX = { it }) + fadeOut()
+            },
+            entryProvider = entryProvider {
+                val homeRouter = HomeRouterImpl(backStack)
+                entry<MainRoute.Home> { HomeScreen(homeRouter) }
 
-            handleCampaignRoutes(navController, SQLDelightCampaignRepository(dbDriverFactory))
-            handlePlayerCharacterRoutes(navController, RamPlayerCharacterRepository())
+                handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
+                handlePlayerCharacterRoutes(backStack, RamPlayerCharacterRepository())
 
-            handleSpellRoutes(navController, JsonSpellRepository(fileReader), userListRepository)
-            handleMagicalItemRoutes(navController, JsonMagicalItemRepository(fileReader), userListRepository)
-            handleCreatureRoutes(navController, JsonCreatureRepository(fileReader), userListRepository)
-        }
+                handleSpellRoutes(backStack, JsonSpellRepository(fileReader), userListRepository)
+                handleMagicalItemRoutes(backStack, JsonMagicalItemRepository(fileReader), userListRepository)
+                handleCreatureRoutes(backStack, JsonCreatureRepository(fileReader), userListRepository)
+            },
+        )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/MainRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/MainRoute.kt
@@ -1,8 +1,9 @@
 package com.cyrillrx.rpg.app
 
+import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 interface MainRoute {
     @Serializable
-    data object Home
+    data object Home : NavKey
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/CreateCampaignScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/CreateCampaignScreen.kt
@@ -33,6 +33,7 @@ import com.cyrillrx.rpg.campaign.common.getMessage
 import com.cyrillrx.rpg.campaign.common.getName
 import com.cyrillrx.rpg.campaign.create.viewmodel.CreateCampaignViewModel
 import com.cyrillrx.rpg.campaign.domain.RuleSet
+import com.cyrillrx.rpg.campaign.navigation.CampaignRouter
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
@@ -48,11 +49,11 @@ import rpg_companion.composeapp.generated.resources.ruleset_other
 import rpg_companion.composeapp.generated.resources.title_create_campaign
 
 @Composable
-fun CreateCampaignScreen(viewModel: CreateCampaignViewModel) {
+fun CreateCampaignScreen(viewModel: CreateCampaignViewModel, router: CampaignRouter) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     CreateCampaignScreen(
         state = state,
-        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onCampaignNameChanged = viewModel::onCampaignNameChanged,
         onRuleSetSelected = viewModel::onRuleSetSelected,
         onCreateButtonClicked = viewModel::onCreateCampaignClicked,
@@ -83,7 +84,7 @@ fun CreateCampaignScreen(
         topBar = {
             SimpleTopBar(
                 titleResource = Res.string.title_create_campaign,
-                navigateUp = onNavigateUpClicked,
+                onNavigateUpClicked = onNavigateUpClicked,
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
@@ -20,10 +20,6 @@ class CreateCampaignViewModel(
     val state: StateFlow<CreateCampaignState>
         field = MutableStateFlow(CreateCampaignState(campaignName = "", selectedRuleSet = RuleSet.UNDEFINED, error = null))
 
-    fun onNavigateUpClicked() {
-        router.navigateUp()
-    }
-
     fun onCampaignNameChanged(name: String) {
         state.update { it.copy(campaignName = name) }
     }
@@ -61,7 +57,7 @@ class CreateCampaignViewModel(
             }
 
             repository.save(newCampaign)
-            onNavigateUpClicked()
+            router.navigateUp()
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.campaign.domain.Campaign
 import com.cyrillrx.rpg.campaign.domain.RuleSet
 import com.cyrillrx.rpg.campaign.list.viewmodel.CampaignListViewModel
+import com.cyrillrx.rpg.campaign.navigation.CampaignRouter
 import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -39,11 +40,11 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_campaign
 
 @Composable
-fun CampaignListScreen(viewModel: CampaignListViewModel) {
+fun CampaignListScreen(viewModel: CampaignListViewModel, router: CampaignRouter) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     CampaignListScreen(
         state = state,
-        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onCampaignClicked = viewModel::onCampaignClicked,
         onCreateCampaignClicked = viewModel::onCreateCampaignClicked,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -25,10 +25,6 @@ class CampaignListViewModel(
     val state: StateFlow<CampaignListState>
         field = MutableStateFlow(CampaignListState(searchQuery = "", body = CampaignListState.Body.Empty))
 
-    fun onNavigateUpClicked() {
-        router.navigateUp()
-    }
-
     fun onSearchQueryChanged(query: String) {
         updateJob?.cancel()
         updateJob = viewModelScope.launch { updateData(query) }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
@@ -27,7 +27,7 @@ sealed interface CampaignRoute {
     data object Create : NavKey
 }
 
-fun PolymorphicModuleBuilder<NavKey>.declareCampaignRoutes() {
+fun PolymorphicModuleBuilder<NavKey>.registerCampaignRoutes() {
     subclass(CampaignRoute.List::class, CampaignRoute.List.serializer())
     subclass(CampaignRoute.Detail::class, CampaignRoute.Detail.serializer())
     subclass(CampaignRoute.Create::class, CampaignRoute.Create.serializer())

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
@@ -39,7 +39,7 @@ fun EntryProviderScope<NavKey>.handleCampaignRoutes(backStack: NavBackStack<NavK
     entry<CampaignRoute.List> {
         val viewModelFactory = CampaignListViewModelFactory(router, repository)
         val viewModel = viewModel<CampaignListViewModel>(factory = viewModelFactory)
-        CampaignListScreen(viewModel)
+        CampaignListScreen(viewModel, router)
     }
 
     entry<CampaignRoute.Detail> { route ->
@@ -52,6 +52,6 @@ fun EntryProviderScope<NavKey>.handleCampaignRoutes(backStack: NavBackStack<NavK
     entry<CampaignRoute.Create> {
         val viewModelFactory = CreateCampaignViewModelFactory(router, repository)
         val viewModel = viewModel<CreateCampaignViewModel>(factory = viewModelFactory)
-        CreateCampaignScreen(viewModel)
+        CreateCampaignScreen(viewModel, router)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRoute.kt
@@ -1,50 +1,55 @@
 package com.cyrillrx.rpg.campaign.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.campaign.create.CreateCampaignScreen
 import com.cyrillrx.rpg.campaign.create.viewmodel.CreateCampaignViewModel
 import com.cyrillrx.rpg.campaign.create.viewmodel.CreateCampaignViewModelFactory
-import com.cyrillrx.rpg.campaign.domain.CampaignRepository
 import com.cyrillrx.rpg.campaign.detail.CampaignDetailScreen
+import com.cyrillrx.rpg.campaign.domain.CampaignRepository
 import com.cyrillrx.rpg.campaign.list.CampaignListScreen
 import com.cyrillrx.rpg.campaign.list.viewmodel.CampaignListViewModel
 import com.cyrillrx.rpg.campaign.list.viewmodel.CampaignListViewModelFactory
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
 
-interface CampaignRoute {
+sealed interface CampaignRoute {
     @Serializable
-    data object List
-
-    @Serializable
-    data class Detail(val serializedCampaign: String)
+    data object List : NavKey
 
     @Serializable
-    data object Create
+    data class Detail(val serializedCampaign: String) : NavKey
+
+    @Serializable
+    data object Create : NavKey
 }
 
-fun NavGraphBuilder.handleCampaignRoutes(navController: NavController, repository: CampaignRepository) {
-    val router = CampaignRouterImpl(navController)
+fun PolymorphicModuleBuilder<NavKey>.declareCampaignRoutes() {
+    subclass(CampaignRoute.List::class, CampaignRoute.List.serializer())
+    subclass(CampaignRoute.Detail::class, CampaignRoute.Detail.serializer())
+    subclass(CampaignRoute.Create::class, CampaignRoute.Create.serializer())
+}
 
-    composable<CampaignRoute.List> {
+fun EntryProviderScope<NavKey>.handleCampaignRoutes(backStack: NavBackStack<NavKey>, repository: CampaignRepository) {
+    val router = CampaignRouterImpl(backStack)
+
+    entry<CampaignRoute.List> {
         val viewModelFactory = CampaignListViewModelFactory(router, repository)
         val viewModel = viewModel<CampaignListViewModel>(factory = viewModelFactory)
         CampaignListScreen(viewModel)
     }
 
-    composable<CampaignRoute.Detail> { entry ->
-        val args = entry.toRoute<CampaignRoute.Detail>()
+    entry<CampaignRoute.Detail> { route ->
         CampaignDetailScreen(
-            campaign = args.serializedCampaign.deserialize(),
+            campaign = route.serializedCampaign.deserialize(),
             onNavigateUpClicked = router::navigateUp,
         )
     }
 
-    composable<CampaignRoute.Create> {
+    entry<CampaignRoute.Create> {
         val viewModelFactory = CreateCampaignViewModelFactory(router, repository)
         val viewModel = viewModel<CreateCampaignViewModel>(factory = viewModelFactory)
         CreateCampaignScreen(viewModel)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRouter.kt
@@ -4,6 +4,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.campaign.domain.Campaign
+import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface CampaignRouter {
     fun navigateUp()
@@ -13,7 +14,7 @@ interface CampaignRouter {
 
 class CampaignRouterImpl(private val backStack: NavBackStack<NavKey>) : CampaignRouter {
     override fun navigateUp() {
-        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
+        backStack.navigateUp()
     }
 
     override fun openCreateCampaign() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/navigation/CampaignRouter.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.campaign.navigation
 
-import androidx.navigation.NavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.campaign.domain.Campaign
 
@@ -10,16 +11,16 @@ interface CampaignRouter {
     fun openCreateCampaign()
 }
 
-class CampaignRouterImpl(private val navController: NavController) : CampaignRouter {
+class CampaignRouterImpl(private val backStack: NavBackStack<NavKey>) : CampaignRouter {
     override fun navigateUp() {
-        navController.navigateUp()
+        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
     }
 
     override fun openCreateCampaign() {
-        navController.navigate(CampaignRoute.Create)
+        backStack.add(CampaignRoute.Create)
     }
 
     override fun openCampaignDetail(campaign: Campaign) {
-        navController.navigate(CampaignRoute.Detail(campaign.serialize()))
+        backStack.add(CampaignRoute.Detail(campaign.serialize()))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CreatePlayerCharacterScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CreatePlayerCharacterScreen.kt
@@ -9,9 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-fun CreatePlayerCharacterScreen(
-    onNavigateUpClicked: () -> Unit,
-) {
+fun CreatePlayerCharacterScreen(onNavigateUpClicked: () -> Unit) {
     Scaffold { paddingValues ->
         Text(
             text = "Create Player Character Screen",

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/PlayerCharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/PlayerCharacterDetailScreen.kt
@@ -12,12 +12,12 @@ import com.cyrillrx.rpg.character.domain.PlayerCharacter
 @Composable
 fun PlayerCharacterDetailScreen(
     character: PlayerCharacter,
-    onNavigateUpClicked: () -> Boolean,
+    onNavigateUpClicked: () -> Unit,
 ) {
     Scaffold { paddingValues ->
         Text(
             text = character.name,
-            Modifier.clickable { onNavigateUpClicked() }
+            Modifier.clickable(onClick = onNavigateUpClicked)
                 .padding(paddingValues)
                 .fillMaxSize(),
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/PlayerCharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/PlayerCharacterListScreen.kt
@@ -7,14 +7,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.character.presentation.navigation.PlayerCharacterRouter
 import com.cyrillrx.rpg.character.presentation.viewmodel.PlayerCharacterListViewModel
 
 @Composable
-fun PlayerCharacterListScreen(viewModel: PlayerCharacterListViewModel) {
+fun PlayerCharacterListScreen(viewModel: PlayerCharacterListViewModel, router: PlayerCharacterRouter) {
     Scaffold { paddingValues ->
         Text(
             text = "Player Character List Screen",
-            Modifier.clickable { viewModel.onNavigateUpClicked() }
+            Modifier.clickable(onClick = router::navigateUp)
                 .padding(paddingValues)
                 .fillMaxSize(),
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
@@ -26,7 +26,7 @@ interface PlayerCharacterRoute {
     data object Create : NavKey
 }
 
-fun PolymorphicModuleBuilder<NavKey>.declareCharacterRoutes() {
+fun PolymorphicModuleBuilder<NavKey>.registerCharacterRoutes() {
     subclass(PlayerCharacterRoute.List::class, PlayerCharacterRoute.List.serializer())
     subclass(PlayerCharacterRoute.Detail::class, PlayerCharacterRoute.Detail.serializer())
     subclass(PlayerCharacterRoute.Create::class, PlayerCharacterRoute.Create.serializer())

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
@@ -1,10 +1,9 @@
 package com.cyrillrx.rpg.character.presentation.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.character.domain.PlayerCharacterRepository
 import com.cyrillrx.rpg.character.presentation.component.CreatePlayerCharacterScreen
@@ -13,37 +12,60 @@ import com.cyrillrx.rpg.character.presentation.component.PlayerCharacterListScre
 import com.cyrillrx.rpg.character.presentation.viewmodel.PlayerCharacterListViewModel
 import com.cyrillrx.rpg.character.presentation.viewmodel.PlayerCharacterListViewModelFactory
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
 
 interface PlayerCharacterRoute {
     @Serializable
-    data object List
+    data object List : NavKey
 
     @Serializable
-    data class Detail(val serializedPlayerCharacter: String)
+    data class Detail(val serializedPlayerCharacter: String) : NavKey
 
     @Serializable
-    data object Create
+    data object Create : NavKey
 }
 
-fun NavGraphBuilder.handlePlayerCharacterRoutes(navController: NavController, repository: PlayerCharacterRepository) {
-    composable<PlayerCharacterRoute.List> {
-        val router = PlayerCharacterRouterImpl(navController)
+fun PolymorphicModuleBuilder<NavKey>.declareCharacterRoutes() {
+    subclass(PlayerCharacterRoute.List::class, PlayerCharacterRoute.List.serializer())
+    subclass(PlayerCharacterRoute.Detail::class, PlayerCharacterRoute.Detail.serializer())
+    subclass(PlayerCharacterRoute.Create::class, PlayerCharacterRoute.Create.serializer())
+}
+
+fun EntryProviderScope<NavKey>.handlePlayerCharacterRoutes(
+    backStack: NavBackStack<NavKey>,
+    repository: PlayerCharacterRepository,
+) {
+    entry<PlayerCharacterRoute.List> {
+        val router = PlayerCharacterRouterImpl(backStack)
         val viewModelFactory = PlayerCharacterListViewModelFactory(router, repository)
         val viewModel = viewModel<PlayerCharacterListViewModel>(factory = viewModelFactory)
         PlayerCharacterListScreen(viewModel)
     }
 
-    composable<PlayerCharacterRoute.Detail> { entry ->
-        val args = entry.toRoute<PlayerCharacterRoute.Detail>()
+    entry<PlayerCharacterRoute.Detail> { route ->
         PlayerCharacterDetailScreen(
-            character = args.serializedPlayerCharacter.deserialize(),
-            onNavigateUpClicked = { navController.navigateUp() },
+            character = route.serializedPlayerCharacter.deserialize(),
+            onNavigateUpClicked = {
+                if (backStack.size > 1) {
+                    backStack.removeAt(backStack.size - 1)
+                    true
+                } else {
+                    false
+                }
+            },
         )
     }
 
-    composable<PlayerCharacterRoute.Create> {
+    entry<PlayerCharacterRoute.Create> {
         CreatePlayerCharacterScreen(
-            onNavigateUpClicked = { navController.navigateUp() },
+            onNavigateUpClicked = {
+                if (backStack.size > 1) {
+                    backStack.removeAt(backStack.size - 1)
+                    true
+                } else {
+                    false
+                }
+            },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRoute.kt
@@ -11,6 +11,7 @@ import com.cyrillrx.rpg.character.presentation.component.PlayerCharacterDetailSc
 import com.cyrillrx.rpg.character.presentation.component.PlayerCharacterListScreen
 import com.cyrillrx.rpg.character.presentation.viewmodel.PlayerCharacterListViewModel
 import com.cyrillrx.rpg.character.presentation.viewmodel.PlayerCharacterListViewModelFactory
+import com.cyrillrx.rpg.core.navigation.navigateUp
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 
@@ -39,33 +40,19 @@ fun EntryProviderScope<NavKey>.handlePlayerCharacterRoutes(
         val router = PlayerCharacterRouterImpl(backStack)
         val viewModelFactory = PlayerCharacterListViewModelFactory(router, repository)
         val viewModel = viewModel<PlayerCharacterListViewModel>(factory = viewModelFactory)
-        PlayerCharacterListScreen(viewModel)
+        PlayerCharacterListScreen(viewModel, router)
     }
 
     entry<PlayerCharacterRoute.Detail> { route ->
         PlayerCharacterDetailScreen(
             character = route.serializedPlayerCharacter.deserialize(),
-            onNavigateUpClicked = {
-                if (backStack.size > 1) {
-                    backStack.removeAt(backStack.size - 1)
-                    true
-                } else {
-                    false
-                }
-            },
+            onNavigateUpClicked = backStack::navigateUp,
         )
     }
 
     entry<PlayerCharacterRoute.Create> {
         CreatePlayerCharacterScreen(
-            onNavigateUpClicked = {
-                if (backStack.size > 1) {
-                    backStack.removeAt(backStack.size - 1)
-                    true
-                } else {
-                    false
-                }
-            },
+            onNavigateUpClicked = backStack::navigateUp,
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRouter.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.character.presentation.navigation
 
-import androidx.navigation.NavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
 
@@ -10,16 +11,16 @@ interface PlayerCharacterRouter {
     fun openCreatePlayerCharacter()
 }
 
-class PlayerCharacterRouterImpl(private val navController: NavController) : PlayerCharacterRouter {
+class PlayerCharacterRouterImpl(private val backStack: NavBackStack<NavKey>) : PlayerCharacterRouter {
     override fun navigateUp() {
-        navController.navigateUp()
+        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
     }
 
     override fun openCreatePlayerCharacter() {
-        navController.navigate(PlayerCharacterRoute.Create)
+        backStack.add(PlayerCharacterRoute.Create)
     }
 
     override fun openPlayerCharacterDetail(character: PlayerCharacter) {
-        navController.navigate(PlayerCharacterRoute.Detail(character.serialize()))
+        backStack.add(PlayerCharacterRoute.Detail(character.serialize()))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/PlayerCharacterRouter.kt
@@ -4,6 +4,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
+import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface PlayerCharacterRouter {
     fun navigateUp()
@@ -13,7 +14,7 @@ interface PlayerCharacterRouter {
 
 class PlayerCharacterRouterImpl(private val backStack: NavBackStack<NavKey>) : PlayerCharacterRouter {
     override fun navigateUp() {
-        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
+        backStack.navigateUp()
     }
 
     override fun openCreatePlayerCharacter() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/PlayerCharacterListViewModel.kt
@@ -29,10 +29,6 @@ class PlayerCharacterListViewModel(
         onSearchQueryChanged(query = "")
     }
 
-    fun onNavigateUpClicked() {
-        router.navigateUp()
-    }
-
     fun onSearchQueryChanged(query: String) {
         updateJob?.cancel()
         updateJob = viewModelScope.launch { updateData(query) }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/navigation/NavExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/navigation/NavExt.kt
@@ -1,0 +1,8 @@
+package com.cyrillrx.rpg.core.navigation
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+
+fun NavBackStack<NavKey>.navigateUp() {
+    if (size > 1) removeAt(index = size - 1)
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/navigation/NavExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/navigation/NavExt.kt
@@ -4,5 +4,5 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 
 fun NavBackStack<NavKey>.navigateUp() {
-    if (size > 1) removeAt(index = size - 1)
+    removeLastOrNull()
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SimpleTopBar.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SimpleTopBar.kt
@@ -19,23 +19,23 @@ import rpg_companion.composeapp.generated.resources.btn_back
 @Composable
 fun SimpleTopBar(
     titleResource: StringResource,
-    navigateUp: () -> Unit,
+    onNavigateUpClicked: () -> Unit,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
-    SimpleTopBar(stringResource(titleResource), navigateUp, actions)
+    SimpleTopBar(stringResource(titleResource), onNavigateUpClicked, actions)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SimpleTopBar(
     title: String,
-    navigateUp: () -> Unit,
+    onNavigateUpClicked: () -> Unit,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     TopAppBar(
         title = { Text(title) },
         navigationIcon = {
-            IconButton(onClick = { navigateUp() }) {
+            IconButton(onClick = onNavigateUpClicked) {
                 Icon(
                     Icons.AutoMirrored.Rounded.ArrowBack,
                     contentDescription = stringResource(Res.string.btn_back),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/CreatureEntityRepository.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/CreatureEntityRepository.kt
@@ -5,7 +5,7 @@ import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
 
 class CreatureEntityRepository(
-    private val delegate: CreatureRepository,
+    private val creatureRepository: CreatureRepository,
 ) : EntityRepository<Creature> {
-    override suspend fun getById(id: String): Creature? = delegate.getById(id)
+    override suspend fun getById(id: String): Creature? = creatureRepository.getById(id)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureAddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureAddToListProvider.kt
@@ -29,9 +29,10 @@ class CreatureAddToListProvider(
     repository: CreatureRepository,
     userListRepository: UserListRepository,
 ) : AddToListProvider<Creature> {
+    override val listType: UserList.Type = UserList.Type.CREATURE
 
     override val viewModelFactory = AddToListViewModelFactory(
-        listType = UserList.Type.CREATURE,
+        listType = listType,
         userListRepository = userListRepository,
         entityRepository = CreatureEntityRepository(repository),
         errorMessage = Res.string.error_while_loading_creatures,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/AbilitiesRow.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/AbilitiesRow.kt
@@ -34,6 +34,7 @@ fun AbilitiesLayout(
             Text(
                 text = stringResource(Res.string.ability_label_str),
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
@@ -41,6 +42,7 @@ fun AbilitiesLayout(
             Text(
                 text = stringResource(Res.string.ability_label_dex),
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
@@ -48,6 +50,7 @@ fun AbilitiesLayout(
             Text(
                 text = stringResource(Res.string.ability_label_con),
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
@@ -55,6 +58,7 @@ fun AbilitiesLayout(
             Text(
                 text = stringResource(Res.string.ability_label_int),
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
@@ -62,6 +66,7 @@ fun AbilitiesLayout(
             Text(
                 text = stringResource(Res.string.ability_label_wis),
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
@@ -69,6 +74,7 @@ fun AbilitiesLayout(
             Text(
                 text = stringResource(Res.string.ability_label_cha),
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
@@ -78,36 +84,42 @@ fun AbilitiesLayout(
             Text(
                 text = str,
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
             )
             Text(
                 text = dex,
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
             )
             Text(
                 text = con,
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
             )
             Text(
                 text = int,
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
             )
             Text(
                 text = wis,
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
             )
             Text(
                 text = cha,
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
             )
@@ -117,15 +129,28 @@ fun AbilitiesLayout(
 
 @Preview
 @Composable
-private fun PreviewAbilitiesLayout() {
+private fun PreviewAbilitiesLayoutLight() {
     AppThemePreview(darkTheme = false) {
-        AbilitiesLayout(
-            str = "10 (+0)",
-            dex = "16 (+3)",
-            con = "12 (+1)",
-            int = "10 (+0)",
-            wis = "18 (+4)",
-            cha = "10 (+0)",
-        )
+        AbilitiesLayoutPreview()
     }
+}
+
+@Preview
+@Composable
+private fun PreviewAbilitiesLayoutDark() {
+    AppThemePreview(darkTheme = true) {
+        AbilitiesLayoutPreview()
+    }
+}
+
+@Composable
+private fun AbilitiesLayoutPreview() {
+    AbilitiesLayout(
+        str = "10 (+0)",
+        dex = "16 (+3)",
+        con = "12 (+1)",
+        int = "10 (+0)",
+        wis = "18 (+4)",
+        cha = "10 (+0)",
+    )
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
@@ -23,21 +23,29 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
+import com.cyrillrx.rpg.core.presentation.component.SwipeToAdd
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.presentation.CreatureAddToListProvider
 import com.cyrillrx.rpg.creature.presentation.CreatureListState
 import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRouter
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
+import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
+import com.cyrillrx.rpg.userlist.presentation.AddToListProvider
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_creature
 
 @Composable
-fun CreatureCompactListScreen(viewModel: CreatureListViewModel, router: CreatureRouter) {
+fun CreatureCompactListScreen(
+    viewModel: CreatureListViewModel,
+    router: CreatureRouter,
+    addToListProvider: AddToListProvider<Creature>,
+) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     CreatureCompactListScreen(
@@ -48,6 +56,7 @@ fun CreatureCompactListScreen(viewModel: CreatureListViewModel, router: Creature
         onTypeToggled = viewModel::onTypeToggled,
         onChallengeRatingToggled = viewModel::onChallengeRatingToggled,
         onResetFilters = viewModel::onResetFilters,
+        addToListProvider = addToListProvider,
     )
 }
 
@@ -60,8 +69,10 @@ fun CreatureCompactListScreen(
     onTypeToggled: (Creature.Type) -> Unit,
     onChallengeRatingToggled: (Float) -> Unit,
     onResetFilters: () -> Unit,
+    addToListProvider: AddToListProvider<Creature>,
 ) {
     var showFilterSheet by remember { mutableStateOf(false) }
+    var creatureToAdd by remember { mutableStateOf<Creature?>(null) }
 
     Scaffold(
         topBar = {
@@ -85,7 +96,11 @@ fun CreatureCompactListScreen(
                 is CreatureListState.Body.Loading -> Loader()
                 is CreatureListState.Body.Empty -> EmptySearch(state.filter.query)
                 is CreatureListState.Body.Error -> ErrorLayout(body.errorMessage)
-                is CreatureListState.Body.WithData -> CreatureCompactList(body.searchResults, onCreatureClicked)
+                is CreatureListState.Body.WithData -> CreatureCompactList(
+                    creatures = body.searchResults,
+                    onCreatureClicked = onCreatureClicked,
+                    showAddToList = { creature -> creatureToAdd = creature },
+                )
             }
         }
     }
@@ -99,12 +114,20 @@ fun CreatureCompactListScreen(
             onDismiss = { showFilterSheet = false },
         )
     }
+
+    creatureToAdd?.let { creature ->
+        addToListProvider.BottomSheet(
+            entityId = creature.id,
+            onDismiss = { creatureToAdd = null },
+        )
+    }
 }
 
 @Composable
 private fun CreatureCompactList(
     creatures: List<Creature>,
     onCreatureClicked: (Creature) -> Unit,
+    showAddToList: (Creature) -> Unit,
 ) {
     val listState = rememberLazyListState()
     LaunchedEffect(creatures) {
@@ -117,25 +140,26 @@ private fun CreatureCompactList(
         contentPadding = PaddingValues(spacingMedium),
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
-        items(creatures) { creature ->
-            CreatureCompactListItem(
-                creature = creature,
-                onClick = { onCreatureClicked(creature) },
+        items(creatures, key = { it.id }) { creature ->
+            SwipeToAdd(
+                onSwiped = { showAddToList(creature) },
                 modifier = Modifier.fillMaxWidth(),
-            )
+            ) {
+                CreatureCompactListItem(
+                    creature = creature,
+                    onClick = { onCreatureClicked(creature) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 }
-
-private val stateWithSampleData = CreatureListState(
-    body = CreatureListState.Body.WithData(SampleCreatureRepository.getAll()),
-)
 
 @Preview
 @Composable
 private fun PreviewCreatureCompactListScreenLight() {
     AppThemePreview(darkTheme = false) {
-        CreatureCompactListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
+        CreatureCompactListScreenPreview()
     }
 }
 
@@ -143,6 +167,15 @@ private fun PreviewCreatureCompactListScreenLight() {
 @Composable
 private fun PreviewCreatureCompactListScreenDark() {
     AppThemePreview(darkTheme = true) {
-        CreatureCompactListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {})
+        CreatureCompactListScreenPreview()
     }
+}
+
+@Composable
+private fun CreatureCompactListScreenPreview() {
+    val stateWithSampleData = CreatureListState(
+        body = CreatureListState.Body.WithData(SampleCreatureRepository.getAll()),
+    )
+    val addToListProvider = CreatureAddToListProvider(SampleCreatureRepository(), SampleUserListRepository())
+    CreatureCompactListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, addToListProvider)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureCompactListScreen.kt
@@ -29,6 +29,7 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.presentation.CreatureListState
+import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRouter
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -36,12 +37,12 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_creature
 
 @Composable
-fun CreatureCompactListScreen(viewModel: CreatureListViewModel) {
+fun CreatureCompactListScreen(viewModel: CreatureListViewModel, router: CreatureRouter) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     CreatureCompactListScreen(
         state = state,
-        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onCreatureClicked = viewModel::onCreatureClicked,
         onTypeToggled = viewModel::onTypeToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureDetailScreen.kt
@@ -63,7 +63,7 @@ private fun CreatureDetailContent(
         topBar = {
             SimpleTopBar(
                 title = creature.name,
-                navigateUp = onNavigateUpClicked,
+                onNavigateUpClicked = onNavigateUpClicked,
             )
         },
         bottomBar = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureItem.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.creature.presentation.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -9,22 +10,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun CreatureItem(
     creature: Creature,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .padding(spacingCommon),
-    ) {
+    Column(modifier = modifier
+        .background(MaterialTheme.colorScheme.background)
+        .padding(spacingCommon)) {
         Text(
             text = creature.name,
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
         )
 
         MainStatLayout(
@@ -43,5 +47,21 @@ fun CreatureItem(
         )
 
         HtmlText(text = creature.description)
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureItemLight() {
+    AppThemePreview(darkTheme = false) {
+        CreatureItem(creature = SampleCreatureRepository.getFirst())
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreatureItemDark() {
+    AppThemePreview(darkTheme = true) {
+        CreatureItem(creature = SampleCreatureRepository.getFirst())
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.creature.presentation.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -126,17 +128,16 @@ private fun CreatureList(
             ) {
                 CreatureItem(
                     creature = creature,
-                    modifier = Modifier.fillMaxWidth().clickable { onCreatureClicked(creature) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onCreatureClicked(creature) }
+                        .background(MaterialTheme.colorScheme.background),
                 )
             }
             HorizontalDivider()
         }
     }
 }
-
-private val stateWithSampleData = CreatureListState(
-    body = CreatureListState.Body.WithData(SampleCreatureRepository.getAll()),
-)
 
 @Preview
 @Composable
@@ -152,6 +153,9 @@ private fun PreviewCreatureListScreenDark() {
 
 @Composable
 private fun CreatureListScreenPreview() {
+    val stateWithSampleData = CreatureListState(
+        body = CreatureListState.Body.WithData(SampleCreatureRepository.getAll()),
+    )
     val addToListProvider = CreatureAddToListProvider(SampleCreatureRepository(), SampleUserListRepository())
     CreatureListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, addToListProvider)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/CreatureListScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -27,6 +26,7 @@ import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.presentation.CreatureAddToListProvider
 import com.cyrillrx.rpg.creature.presentation.CreatureListState
+import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRouter
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListProvider
@@ -38,12 +38,13 @@ import rpg_companion.composeapp.generated.resources.hint_search_creature
 @Composable
 fun CreatureListScreen(
     viewModel: CreatureListViewModel,
+    router: CreatureRouter,
     addToListProvider: AddToListProvider<Creature>,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     CreatureListScreen(
         state = state,
-        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onCreatureClicked = viewModel::onCreatureClicked,
         onTypeToggled = viewModel::onTypeToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MainStatLayout.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MainStatLayout.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.creature.presentation.component
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -10,8 +11,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.core.presentation.component.dnd.getSubtitle
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.creature.data.SampleCreatureRepository
 import com.cyrillrx.rpg.creature.domain.Creature
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.creature_ac
 import rpg_companion.composeapp.generated.resources.creature_hp
@@ -34,6 +38,7 @@ fun MainStatLayout(
                     append(creature.getSubtitle())
                 }
             },
+            color = MaterialTheme.colorScheme.onBackground,
         )
         Text(
             buildAnnotatedString {
@@ -43,6 +48,7 @@ fun MainStatLayout(
                 }
                 append(creature.armorClass.toString())
             },
+            color = MaterialTheme.colorScheme.onBackground,
         )
         Text(
             buildAnnotatedString {
@@ -52,6 +58,7 @@ fun MainStatLayout(
                 }
                 append(creature.maxHitPoints.toString())
             },
+            color = MaterialTheme.colorScheme.onBackground,
         )
         Text(
             buildAnnotatedString {
@@ -65,6 +72,23 @@ fun MainStatLayout(
                 }
                 append(creature.speed)
             },
+            color = MaterialTheme.colorScheme.onBackground,
         )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMainStatLayoutLight() {
+    AppThemePreview(darkTheme = false) {
+        MainStatLayout(creature = SampleCreatureRepository.getFirst())
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMainStatLayoutDark() {
+    AppThemePreview(darkTheme = true) {
+        MainStatLayout(creature = SampleCreatureRepository.getFirst())
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -2,7 +2,6 @@ package com.cyrillrx.rpg.creature.presentation.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.EntryProviderScope
-import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.creature.data.CreatureEntityRepository
 import com.cyrillrx.rpg.creature.domain.Creature
@@ -11,105 +10,67 @@ import com.cyrillrx.rpg.creature.presentation.CreatureAddToListProvider
 import com.cyrillrx.rpg.creature.presentation.CreatureItemProvider
 import com.cyrillrx.rpg.creature.presentation.component.CreatureCompactListScreen
 import com.cyrillrx.rpg.creature.presentation.component.CreatureDetailScreen
-import com.cyrillrx.rpg.creature.presentation.component.CreatureListScreen
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureDetailViewModelFactory
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModel
 import com.cyrillrx.rpg.creature.presentation.viewmodel.CreatureListViewModelFactory
-import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.component.ListDetailScreen
-import com.cyrillrx.rpg.userlist.presentation.component.UserListsScreen
-import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouterImpl
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModelFactory
-import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
-import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
-import org.jetbrains.compose.resources.stringResource
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.title_my_bestiary_lists
 
 interface CreatureRoute {
-    @Serializable
-    data object CompactList : NavKey
 
     @Serializable
-    data object List : NavKey
+    data object Compendium : NavKey
 
     @Serializable
     data class Detail(val creatureId: String) : NavKey
-
-    @Serializable
-    data object UserLists : NavKey
 
     @Serializable
     data class UserListDetail(val listId: String) : NavKey
 }
 
 fun PolymorphicModuleBuilder<NavKey>.registerCreatureRoutes() {
-    subclass(CreatureRoute.CompactList::class, CreatureRoute.CompactList.serializer())
-    subclass(CreatureRoute.List::class, CreatureRoute.List.serializer())
+    subclass(CreatureRoute.Compendium::class, CreatureRoute.Compendium.serializer())
     subclass(CreatureRoute.Detail::class, CreatureRoute.Detail.serializer())
-    subclass(CreatureRoute.UserLists::class, CreatureRoute.UserLists.serializer())
     subclass(CreatureRoute.UserListDetail::class, CreatureRoute.UserListDetail.serializer())
 }
 
 fun EntryProviderScope<NavKey>.handleCreatureRoutes(
-    backStack: NavBackStack<NavKey>,
+    router: CreatureRouter,
     repository: CreatureRepository,
     userListRepository: UserListRepository,
 ) {
-    entry<CreatureRoute.CompactList> {
-        val router = CreatureRouterImpl(backStack)
-        val viewModelFactory = CreatureListViewModelFactory(router, repository)
-        val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
-        CreatureCompactListScreen(viewModel, router)
-    }
-
-    entry<CreatureRoute.List> {
-        val router = CreatureRouterImpl(backStack)
+    entry<CreatureRoute.Compendium> {
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
         val addToListProvider = CreatureAddToListProvider(repository, userListRepository)
-        CreatureListScreen(viewModel, router, addToListProvider)
+        // CreatureListScreen(viewModel, router, addToListProvider)
+        CreatureCompactListScreen(viewModel, router, addToListProvider)
     }
 
     entry<CreatureRoute.Detail> { route ->
-        val router = CreatureRouterImpl(backStack)
-        val viewModelFactory = CreatureDetailViewModelFactory(route.creatureId, repository)
-        val viewModel = viewModel<CreatureDetailViewModel>(factory = viewModelFactory)
+        val creatureId = route.creatureId
+        val viewModelFactory = CreatureDetailViewModelFactory(creatureId, repository)
+        val viewModel = viewModel<CreatureDetailViewModel>(key = creatureId, factory = viewModelFactory)
         val addToListProvider = CreatureAddToListProvider(repository, userListRepository)
         CreatureDetailScreen(viewModel, router, addToListProvider)
     }
 
-    entry<CreatureRoute.UserLists> {
-        val listType = UserList.Type.CREATURE
-        val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
-        val viewModel = viewModel<UserListsViewModel>(
-            key = listType.name,
-            factory = viewModelFactory,
-        )
-        val title = stringResource(Res.string.title_my_bestiary_lists)
-        UserListsScreen(viewModel, router, title)
-    }
-
     entry<CreatureRoute.UserListDetail> { route ->
+        val listId = route.listId
         val viewModelFactory = ListDetailViewModelFactory(
-            listId = route.listId,
+            listId = listId,
             userListRepository = userListRepository,
             repository = CreatureEntityRepository(repository),
         )
-        val viewModel = viewModel<ListDetailViewModel<Creature>>(
-            key = "Creature_${route.listId}",
-            factory = viewModelFactory,
-        )
-        val router = CreatureRouterImpl(backStack)
+        val viewModel = viewModel<ListDetailViewModel<Creature>>(key = listId, factory = viewModelFactory)
         val itemProvider = CreatureItemProvider(
             onItemClicked = router::openDetail,
-            onEmptyLayoutBtnClicked = router::openList,
+            onEmptyLayoutBtnClicked = router::openCompendium,
         )
         ListDetailScreen(
             viewModel = viewModel,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -48,7 +48,7 @@ interface CreatureRoute {
     data class UserListDetail(val listId: String) : NavKey
 }
 
-fun PolymorphicModuleBuilder<NavKey>.declareCreatureRoutes() {
+fun PolymorphicModuleBuilder<NavKey>.registerCreatureRoutes() {
     subclass(CreatureRoute.CompactList::class, CreatureRoute.CompactList.serializer())
     subclass(CreatureRoute.List::class, CreatureRoute.List.serializer())
     subclass(CreatureRoute.Detail::class, CreatureRoute.Detail.serializer())

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -1,10 +1,9 @@
 package com.cyrillrx.rpg.creature.presentation.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.creature.data.CreatureEntityRepository
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.CreatureRepository
@@ -27,81 +26,92 @@ import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModelFacto
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.title_my_bestiary_lists
 
 interface CreatureRoute {
     @Serializable
-    data object CompactList
+    data object CompactList : NavKey
 
     @Serializable
-    data object List
+    data object List : NavKey
 
     @Serializable
-    data class Detail(val creatureId: String)
+    data class Detail(val creatureId: String) : NavKey
 
     @Serializable
-    data object UserLists
+    data object UserLists : NavKey
 
     @Serializable
-    data class UserListDetail(val listId: String)
+    data class UserListDetail(val listId: String) : NavKey
 }
 
-fun NavGraphBuilder.handleCreatureRoutes(
-    navController: NavController,
+fun PolymorphicModuleBuilder<NavKey>.declareCreatureRoutes() {
+    subclass(CreatureRoute.CompactList::class, CreatureRoute.CompactList.serializer())
+    subclass(CreatureRoute.List::class, CreatureRoute.List.serializer())
+    subclass(CreatureRoute.Detail::class, CreatureRoute.Detail.serializer())
+    subclass(CreatureRoute.UserLists::class, CreatureRoute.UserLists.serializer())
+    subclass(CreatureRoute.UserListDetail::class, CreatureRoute.UserListDetail.serializer())
+}
+
+fun EntryProviderScope<NavKey>.handleCreatureRoutes(
+    backStack: NavBackStack<NavKey>,
     repository: CreatureRepository,
     userListRepository: UserListRepository,
 ) {
-    composable<CreatureRoute.CompactList> {
-        val router = CreatureRouterImpl(navController)
+    entry<CreatureRoute.CompactList> {
+        val router = CreatureRouterImpl(backStack)
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
         CreatureCompactListScreen(viewModel)
     }
 
-    composable<CreatureRoute.List> {
-        val router = CreatureRouterImpl(navController)
+    entry<CreatureRoute.List> {
+        val router = CreatureRouterImpl(backStack)
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
         val addToListProvider = CreatureAddToListProvider(repository, userListRepository)
         CreatureListScreen(viewModel, addToListProvider)
     }
 
-    composable<CreatureRoute.Detail> { entry ->
-        val router = CreatureRouterImpl(navController)
-        val creatureId = entry.toRoute<CreatureRoute.Detail>().creatureId
-        val viewModel = viewModel<CreatureDetailViewModel>(
-            factory = CreatureDetailViewModelFactory(creatureId, repository),
-        )
+    entry<CreatureRoute.Detail> { route ->
+        val router = CreatureRouterImpl(backStack)
+        val viewModelFactory = CreatureDetailViewModelFactory(route.creatureId, repository)
+        val viewModel = viewModel<CreatureDetailViewModel>(factory = viewModelFactory)
         val addToListProvider = CreatureAddToListProvider(repository, userListRepository)
-        CreatureDetailScreen(viewModel = viewModel, router = router, addToListProvider = addToListProvider)
+        CreatureDetailScreen(viewModel, router, addToListProvider)
     }
 
-    composable<CreatureRoute.UserLists> {
-        val router = UserListRouterImpl(navController)
-        val viewModel = viewModel<UserListsViewModel>(
-            factory = UserListsViewModelFactory(UserList.Type.CREATURE, router, userListRepository),
+    entry<CreatureRoute.UserLists> {
+        val router = UserListRouterImpl(backStack)
+        val viewModelFactory = UserListsViewModelFactory(
+            listType = UserList.Type.CREATURE,
+            router = router,
+            userListRepository = userListRepository,
         )
-        UserListsScreen(
-            viewModel = viewModel,
-            title = stringResource(Res.string.title_my_bestiary_lists),
-        )
+        val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
+        val screenTitle = stringResource(Res.string.title_my_bestiary_lists)
+        UserListsScreen(viewModel = viewModel, title = screenTitle)
     }
 
-    composable<CreatureRoute.UserListDetail> { entry ->
-        val listId = entry.toRoute<CreatureRoute.UserListDetail>().listId
-        val viewModel = viewModel<ListDetailViewModel<Creature>>(
-            factory = ListDetailViewModelFactory(listId, userListRepository, CreatureEntityRepository(repository)),
+    entry<CreatureRoute.UserListDetail> { route ->
+        val viewModelFactory = ListDetailViewModelFactory(
+            listId = route.listId,
+            userListRepository = userListRepository,
+            repository = CreatureEntityRepository(repository),
         )
-        val router = CreatureRouterImpl(navController)
+        val viewModel = viewModel<ListDetailViewModel<Creature>>(factory = viewModelFactory)
+        val router = CreatureRouterImpl(backStack)
+        val itemProvider = CreatureItemProvider(
+            onItemClicked = router::openDetail,
+            onEmptyLayoutBtnClicked = router::openList,
+        )
         ListDetailScreen(
             viewModel = viewModel,
-            itemProvider = CreatureItemProvider(
-                onItemClicked = router::openDetail,
-                onEmptyLayoutBtnClicked = { navController.navigate(CreatureRoute.List) },
-            ),
-            onNavigateUp = { navController.navigateUp() },
+            itemProvider = itemProvider,
+            onNavigateUp = router::navigateUp,
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -65,7 +65,7 @@ fun EntryProviderScope<NavKey>.handleCreatureRoutes(
         val router = CreatureRouterImpl(backStack)
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
-        CreatureCompactListScreen(viewModel)
+        CreatureCompactListScreen(viewModel, router)
     }
 
     entry<CreatureRoute.List> {
@@ -73,7 +73,7 @@ fun EntryProviderScope<NavKey>.handleCreatureRoutes(
         val viewModelFactory = CreatureListViewModelFactory(router, repository)
         val viewModel = viewModel<CreatureListViewModel>(factory = viewModelFactory)
         val addToListProvider = CreatureAddToListProvider(repository, userListRepository)
-        CreatureListScreen(viewModel, addToListProvider)
+        CreatureListScreen(viewModel, router, addToListProvider)
     }
 
     entry<CreatureRoute.Detail> { route ->
@@ -92,8 +92,8 @@ fun EntryProviderScope<NavKey>.handleCreatureRoutes(
             userListRepository = userListRepository,
         )
         val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
-        val screenTitle = stringResource(Res.string.title_my_bestiary_lists)
-        UserListsScreen(viewModel = viewModel, title = screenTitle)
+        val title = stringResource(Res.string.title_my_bestiary_lists)
+        UserListsScreen(viewModel, router, title)
     }
 
     entry<CreatureRoute.UserListDetail> { route ->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRoute.kt
@@ -85,13 +85,13 @@ fun EntryProviderScope<NavKey>.handleCreatureRoutes(
     }
 
     entry<CreatureRoute.UserLists> {
+        val listType = UserList.Type.CREATURE
         val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(
-            listType = UserList.Type.CREATURE,
-            router = router,
-            userListRepository = userListRepository,
+        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(
+            key = listType.name,
+            factory = viewModelFactory,
         )
-        val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
         val title = stringResource(Res.string.title_my_bestiary_lists)
         UserListsScreen(viewModel, router, title)
     }
@@ -102,7 +102,10 @@ fun EntryProviderScope<NavKey>.handleCreatureRoutes(
             userListRepository = userListRepository,
             repository = CreatureEntityRepository(repository),
         )
-        val viewModel = viewModel<ListDetailViewModel<Creature>>(factory = viewModelFactory)
+        val viewModel = viewModel<ListDetailViewModel<Creature>>(
+            key = "Creature_${route.listId}",
+            factory = viewModelFactory,
+        )
         val router = CreatureRouterImpl(backStack)
         val itemProvider = CreatureItemProvider(
             onItemClicked = router::openDetail,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.creature.presentation.navigation
 
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface CreatureRouter {
     fun navigateUp()
@@ -11,7 +12,7 @@ interface CreatureRouter {
 
 class CreatureRouterImpl(private val backStack: NavBackStack<NavKey>) : CreatureRouter {
     override fun navigateUp() {
-        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
+        backStack.navigateUp()
     }
 
     override fun openList() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -6,7 +6,7 @@ import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface CreatureRouter {
     fun navigateUp()
-    fun openList()
+    fun openCompendium()
     fun openDetail(creatureId: String)
 }
 
@@ -15,8 +15,8 @@ class CreatureRouterImpl(private val backStack: NavBackStack<NavKey>) : Creature
         backStack.navigateUp()
     }
 
-    override fun openList() {
-        backStack.add(CreatureRoute.List)
+    override fun openCompendium() {
+        backStack.add(CreatureRoute.Compendium)
     }
 
     override fun openDetail(creatureId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/navigation/CreatureRouter.kt
@@ -1,18 +1,24 @@
 package com.cyrillrx.rpg.creature.presentation.navigation
 
-import androidx.navigation.NavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 
 interface CreatureRouter {
     fun navigateUp()
+    fun openList()
     fun openDetail(creatureId: String)
 }
 
-class CreatureRouterImpl(private val navController: NavController) : CreatureRouter {
+class CreatureRouterImpl(private val backStack: NavBackStack<NavKey>) : CreatureRouter {
     override fun navigateUp() {
-        navController.navigateUp()
+        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
+    }
+
+    override fun openList() {
+        backStack.add(CreatureRoute.List)
     }
 
     override fun openDetail(creatureId: String) {
-        navController.navigate(CreatureRoute.Detail(creatureId))
+        backStack.add(CreatureRoute.Detail(creatureId))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModel.kt
@@ -30,10 +30,6 @@ class CreatureListViewModel(
         refreshData()
     }
 
-    fun onNavigateUpClicked() {
-        router.navigateUp()
-    }
-
     fun onSearchQueryChanged(query: String) {
         updateFilter { it.copy(query = query) }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -68,19 +68,19 @@ fun HomeScreen(router: HomeRouter) {
                 IconLabelButton(
                     label = stringResource(Res.string.btn_spell_book),
                     icon = Icons.Filled.AutoAwesome,
-                    onClick = router::openSpellList,
+                    onClick = router::openSpellCompendium,
                     modifier = Modifier.weight(1f),
                 )
                 IconLabelButton(
                     label = stringResource(Res.string.btn_inventory),
                     icon = Icons.Filled.Diamond,
-                    onClick = router::openMagicalItemList,
+                    onClick = router::openMagicalItemCompendium,
                     modifier = Modifier.weight(1f),
                 )
                 IconLabelButton(
                     label = stringResource(Res.string.btn_bestiary),
                     icon = Icons.Filled.Pets,
-                    onClick = router::openCreatureCompactList,
+                    onClick = router::openCreatureCompendium,
                     modifier = Modifier.weight(1f),
                 )
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -7,16 +7,14 @@ import com.cyrillrx.rpg.character.presentation.navigation.PlayerCharacterRoute
 import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRoute
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRoute
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRoute
+import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRoute
 
 interface HomeRouter {
     fun openCampaignList() {}
     fun openCharacterSheetList() {}
-    fun openSpellList() {}
-    fun openSpellCardCarousel() {}
-    fun openMagicalItemList() {}
-    fun openMagicalItemCardCarousel() {}
-    fun openCreatureCompactList() {}
-    fun openCreatureList() {}
+    fun openSpellCompendium() {}
+    fun openMagicalItemCompendium() {}
+    fun openCreatureCompendium() {}
     fun openMySpellLists() {}
     fun openMyMagicalItemLists() {}
     fun openMyCreatureLists() {}
@@ -31,39 +29,27 @@ class HomeRouterImpl(private val backStack: NavBackStack<NavKey>) : HomeRouter {
         backStack.add(PlayerCharacterRoute.List)
     }
 
-    override fun openSpellList() {
-        backStack.add(SpellRoute.List)
+    override fun openSpellCompendium() {
+        backStack.add(SpellRoute.Compendium)
     }
 
-    override fun openSpellCardCarousel() {
-        backStack.add(SpellRoute.CardCarousel)
+    override fun openMagicalItemCompendium() {
+        backStack.add(MagicalItemRoute.Compendium)
     }
 
-    override fun openMagicalItemList() {
-        backStack.add(MagicalItemRoute.List)
-    }
-
-    override fun openMagicalItemCardCarousel() {
-        backStack.add(MagicalItemRoute.CardCarousel)
-    }
-
-    override fun openCreatureCompactList() {
-        backStack.add(CreatureRoute.CompactList)
-    }
-
-    override fun openCreatureList() {
-        backStack.add(CreatureRoute.List)
+    override fun openCreatureCompendium() {
+        backStack.add(CreatureRoute.Compendium)
     }
 
     override fun openMySpellLists() {
-        backStack.add(SpellRoute.UserLists)
+        backStack.add(UserListRoute.Spell)
     }
 
     override fun openMyMagicalItemLists() {
-        backStack.add(MagicalItemRoute.UserLists)
+        backStack.add(UserListRoute.MagicalItem)
     }
 
     override fun openMyCreatureLists() {
-        backStack.add(CreatureRoute.UserLists)
+        backStack.add(UserListRoute.Creature)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.home.presentation.navigation
 
-import androidx.navigation.NavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.campaign.navigation.CampaignRoute
 import com.cyrillrx.rpg.character.presentation.navigation.PlayerCharacterRoute
 import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRoute
@@ -21,48 +22,48 @@ interface HomeRouter {
     fun openMyCreatureLists() {}
 }
 
-class HomeRouterImpl(private val navController: NavController) : HomeRouter {
+class HomeRouterImpl(private val backStack: NavBackStack<NavKey>) : HomeRouter {
     override fun openCampaignList() {
-        navController.navigate(CampaignRoute.List)
+        backStack.add(CampaignRoute.List)
     }
 
     override fun openCharacterSheetList() {
-        navController.navigate(PlayerCharacterRoute.List)
+        backStack.add(PlayerCharacterRoute.List)
     }
 
     override fun openSpellList() {
-        navController.navigate(SpellRoute.List)
+        backStack.add(SpellRoute.List)
     }
 
     override fun openSpellCardCarousel() {
-        navController.navigate(SpellRoute.CardCarousel)
+        backStack.add(SpellRoute.CardCarousel)
     }
 
     override fun openMagicalItemList() {
-        navController.navigate(MagicalItemRoute.List)
+        backStack.add(MagicalItemRoute.List)
     }
 
     override fun openMagicalItemCardCarousel() {
-        navController.navigate(MagicalItemRoute.CardCarousel)
+        backStack.add(MagicalItemRoute.CardCarousel)
     }
 
     override fun openCreatureCompactList() {
-        navController.navigate(CreatureRoute.CompactList)
+        backStack.add(CreatureRoute.CompactList)
     }
 
     override fun openCreatureList() {
-        navController.navigate(CreatureRoute.List)
+        backStack.add(CreatureRoute.List)
     }
 
     override fun openMySpellLists() {
-        navController.navigate(SpellRoute.UserLists)
+        backStack.add(SpellRoute.UserLists)
     }
 
     override fun openMyMagicalItemLists() {
-        navController.navigate(MagicalItemRoute.UserLists)
+        backStack.add(MagicalItemRoute.UserLists)
     }
 
     override fun openMyCreatureLists() {
-        navController.navigate(CreatureRoute.UserLists)
+        backStack.add(CreatureRoute.UserLists)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/MagicalItemEntityRepository.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/MagicalItemEntityRepository.kt
@@ -5,7 +5,7 @@ import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 
 class MagicalItemEntityRepository(
-    private val delegate: MagicalItemRepository,
+    private val magicalItemRepository: MagicalItemRepository,
 ) : EntityRepository<MagicalItem> {
-    override suspend fun getById(id: String): MagicalItem? = delegate.getById(id)
+    override suspend fun getById(id: String): MagicalItem? = magicalItemRepository.getById(id)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemAddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemAddToListProvider.kt
@@ -29,9 +29,10 @@ class MagicalItemAddToListProvider(
     repository: MagicalItemRepository,
     userListRepository: UserListRepository,
 ) : AddToListProvider<MagicalItem> {
+    override val listType: UserList.Type = UserList.Type.MAGICAL_ITEM
 
     override val viewModelFactory = AddToListViewModelFactory(
-        listType = UserList.Type.MAGICAL_ITEM,
+        listType = listType,
         userListRepository = userListRepository,
         entityRepository = MagicalItemEntityRepository(repository),
         errorMessage = Res.string.error_while_loading_magical_items,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
@@ -25,6 +25,7 @@ import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
+import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouter
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -32,11 +33,11 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.hint_search_magical_item
 
 @Composable
-fun MagicalItemCardCarouselScreen(viewModel: MagicalItemListViewModel) {
+fun MagicalItemCardCarouselScreen(viewModel: MagicalItemListViewModel, router: MagicalItemRouter) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     MagicalItemCardCarouselScreen(
         state = state,
-        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onMagicalItemClicked = viewModel::onItemClicked,
         onTypeToggled = viewModel::onTypeToggled,
@@ -74,7 +75,10 @@ fun MagicalItemCardCarouselScreen(
                 is MagicalItemListState.Body.Loading -> Loader()
                 is MagicalItemListState.Body.Empty -> EmptySearch(state.filter.query)
                 is MagicalItemListState.Body.Error -> ErrorLayout(body.errorMessage)
-                is MagicalItemListState.Body.WithData -> MagicalItemCardCarousel(body.searchResults, onMagicalItemClicked)
+                is MagicalItemListState.Body.WithData -> MagicalItemCardCarousel(
+                    body.searchResults,
+                    onMagicalItemClicked,
+                )
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -32,6 +32,7 @@ import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemAddToListProvider
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
+import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouter
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListProvider
@@ -43,13 +44,14 @@ import rpg_companion.composeapp.generated.resources.hint_search_magical_item
 @Composable
 fun MagicalItemListScreen(
     viewModel: MagicalItemListViewModel,
+    router: MagicalItemRouter,
     addToListProvider: AddToListProvider<MagicalItem>,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     MagicalItemListScreen(
         state = state,
-        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::onSearchQueryChanged,
         onMagicalItemClicked = viewModel::onItemClicked,
         onTypeToggled = viewModel::onTypeToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -2,114 +2,74 @@ package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.EntryProviderScope
-import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.magicalitem.data.MagicalItemEntityRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemAddToListProvider
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemItemProvider
-import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardCarouselScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListScreen
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModel
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModelFactory
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModel
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemListViewModelFactory
-import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.component.ListDetailScreen
-import com.cyrillrx.rpg.userlist.presentation.component.UserListsScreen
-import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouterImpl
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModelFactory
-import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
-import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
-import org.jetbrains.compose.resources.stringResource
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.title_my_item_lists
 
 interface MagicalItemRoute {
     @Serializable
-    data object List : NavKey
-
-    @Serializable
-    data object CardCarousel : NavKey
+    data object Compendium : NavKey
 
     @Serializable
     data class Detail(val magicalItemId: String) : NavKey
-
-    @Serializable
-    data object UserLists : NavKey
 
     @Serializable
     data class UserListDetail(val listId: String) : NavKey
 }
 
 fun PolymorphicModuleBuilder<NavKey>.registerMagicalItemRoutes() {
-    subclass(MagicalItemRoute.CardCarousel::class, MagicalItemRoute.CardCarousel.serializer())
-    subclass(MagicalItemRoute.List::class, MagicalItemRoute.List.serializer())
+    subclass(MagicalItemRoute.Compendium::class, MagicalItemRoute.Compendium.serializer())
     subclass(MagicalItemRoute.Detail::class, MagicalItemRoute.Detail.serializer())
-    subclass(MagicalItemRoute.UserLists::class, MagicalItemRoute.UserLists.serializer())
     subclass(MagicalItemRoute.UserListDetail::class, MagicalItemRoute.UserListDetail.serializer())
 }
 
 fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
-    backStack: NavBackStack<NavKey>,
+    router: MagicalItemRouter,
     repository: MagicalItemRepository,
     userListRepository: UserListRepository,
 ) {
-    entry<MagicalItemRoute.List> {
-        val router = MagicalItemRouterImpl(backStack)
+    entry<MagicalItemRoute.Compendium> {
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
         val addToListProvider = MagicalItemAddToListProvider(repository, userListRepository)
         MagicalItemListScreen(viewModel, router, addToListProvider)
-    }
-
-    entry<MagicalItemRoute.CardCarousel> {
-        val router = MagicalItemRouterImpl(backStack)
-        val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
-        val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
-        MagicalItemCardCarouselScreen(viewModel, router)
+        // MagicalItemCardCarouselScreen(viewModel, router)
     }
 
     entry<MagicalItemRoute.Detail> { route ->
-        val router = MagicalItemRouterImpl(backStack)
-        val viewModelFactory = MagicalItemDetailViewModelFactory(route.magicalItemId, repository)
-        val viewModel = viewModel<MagicalItemDetailViewModel>(factory = viewModelFactory)
+        val magicalItemId = route.magicalItemId
+        val viewModelFactory = MagicalItemDetailViewModelFactory(magicalItemId, repository)
+        val viewModel = viewModel<MagicalItemDetailViewModel>(key = magicalItemId, factory = viewModelFactory)
         val addToListProvider = MagicalItemAddToListProvider(repository, userListRepository)
         MagicalItemCardScreen(viewModel, router, addToListProvider)
     }
 
-    entry<MagicalItemRoute.UserLists> {
-        val listType = UserList.Type.MAGICAL_ITEM
-        val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
-        val viewModel = viewModel<UserListsViewModel>(
-            key = listType.name,
-            factory = viewModelFactory,
-        )
-        val title = stringResource(Res.string.title_my_item_lists)
-        UserListsScreen(viewModel, router, title)
-    }
-
     entry<MagicalItemRoute.UserListDetail> { route ->
+        val listId = route.listId
         val viewModelFactory = ListDetailViewModelFactory(
-            listId = route.listId,
+            listId = listId,
             userListRepository = userListRepository,
             repository = MagicalItemEntityRepository(repository),
         )
-        val viewModel = viewModel<ListDetailViewModel<MagicalItem>>(
-            key = "MagicalItem_${route.listId}",
-            factory = viewModelFactory,
-        )
-        val router = MagicalItemRouterImpl(backStack)
+        val viewModel = viewModel<ListDetailViewModel<MagicalItem>>(key = listId, factory = viewModelFactory)
         val itemProvider = MagicalItemItemProvider(
             onItemClicked = router::openDetail,
-            onEmptyLayoutBtnClicked = router::openList,
+            onEmptyLayoutBtnClicked = router::openCompendium,
         )
         ListDetailScreen(
             viewModel = viewModel,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -1,10 +1,9 @@
 package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.magicalitem.data.MagicalItemEntityRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
@@ -27,81 +26,88 @@ import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModelFacto
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.title_my_item_lists
 
 interface MagicalItemRoute {
     @Serializable
-    data object List
+    data object List : NavKey
 
     @Serializable
-    data object CardCarousel
+    data object CardCarousel : NavKey
 
     @Serializable
-    data class Detail(val magicalItemId: String)
+    data class Detail(val magicalItemId: String) : NavKey
 
     @Serializable
-    data object UserLists
+    data object UserLists : NavKey
 
     @Serializable
-    data class UserListDetail(val listId: String)
+    data class UserListDetail(val listId: String) : NavKey
 }
 
-fun NavGraphBuilder.handleMagicalItemRoutes(
-    navController: NavController,
+fun PolymorphicModuleBuilder<NavKey>.declareMagicalItemRoutes() {
+    subclass(MagicalItemRoute.CardCarousel::class, MagicalItemRoute.CardCarousel.serializer())
+    subclass(MagicalItemRoute.List::class, MagicalItemRoute.List.serializer())
+    subclass(MagicalItemRoute.Detail::class, MagicalItemRoute.Detail.serializer())
+    subclass(MagicalItemRoute.UserLists::class, MagicalItemRoute.UserLists.serializer())
+    subclass(MagicalItemRoute.UserListDetail::class, MagicalItemRoute.UserListDetail.serializer())
+}
+
+fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
+    backStack: NavBackStack<NavKey>,
     repository: MagicalItemRepository,
     userListRepository: UserListRepository,
 ) {
-    composable<MagicalItemRoute.List> {
-        val router = MagicalItemRouterImpl(navController)
+    entry<MagicalItemRoute.List> {
+        val router = MagicalItemRouterImpl(backStack)
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
         val addToListProvider = MagicalItemAddToListProvider(repository, userListRepository)
         MagicalItemListScreen(viewModel, addToListProvider)
     }
 
-    composable<MagicalItemRoute.CardCarousel> {
-        val router = MagicalItemRouterImpl(navController)
+    entry<MagicalItemRoute.CardCarousel> {
+        val router = MagicalItemRouterImpl(backStack)
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
         MagicalItemCardCarouselScreen(viewModel)
     }
 
-    composable<MagicalItemRoute.Detail> { entry ->
-        val router = MagicalItemRouterImpl(navController)
-        val id = entry.toRoute<MagicalItemRoute.Detail>().magicalItemId
-        val viewModel = viewModel<MagicalItemDetailViewModel>(
-            factory = MagicalItemDetailViewModelFactory(id, repository),
-        )
+    entry<MagicalItemRoute.Detail> { route ->
+        val router = MagicalItemRouterImpl(backStack)
+        val viewModelFactory = MagicalItemDetailViewModelFactory(route.magicalItemId, repository)
+        val viewModel = viewModel<MagicalItemDetailViewModel>(factory = viewModelFactory)
         val addToListProvider = MagicalItemAddToListProvider(repository, userListRepository)
-        MagicalItemCardScreen(viewModel = viewModel, router = router, addToListProvider = addToListProvider)
+        MagicalItemCardScreen(viewModel, router, addToListProvider)
     }
 
-    composable<MagicalItemRoute.UserLists> {
-        val router = UserListRouterImpl(navController)
-        val viewModel = viewModel<UserListsViewModel>(
-            factory = UserListsViewModelFactory(UserList.Type.MAGICAL_ITEM, router, userListRepository),
-        )
-        UserListsScreen(
-            viewModel = viewModel,
-            title = stringResource(Res.string.title_my_item_lists),
-        )
+    entry<MagicalItemRoute.UserLists> {
+        val router = UserListRouterImpl(backStack)
+        val viewModelFactory = UserListsViewModelFactory(UserList.Type.MAGICAL_ITEM, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
+        val screenTitle = stringResource(Res.string.title_my_item_lists)
+        UserListsScreen(viewModel = viewModel, title = screenTitle)
     }
 
-    composable<MagicalItemRoute.UserListDetail> { entry ->
-        val listId = entry.toRoute<MagicalItemRoute.UserListDetail>().listId
-        val viewModel = viewModel<ListDetailViewModel<MagicalItem>>(
-            factory = ListDetailViewModelFactory(listId, userListRepository, MagicalItemEntityRepository(repository)),
+    entry<MagicalItemRoute.UserListDetail> { route ->
+        val viewModelFactory = ListDetailViewModelFactory(
+            listId = route.listId,
+            userListRepository = userListRepository,
+            repository = MagicalItemEntityRepository(repository),
         )
-        val router = MagicalItemRouterImpl(navController)
+        val viewModel = viewModel<ListDetailViewModel<MagicalItem>>(factory = viewModelFactory)
+        val router = MagicalItemRouterImpl(backStack)
+        val itemProvider = MagicalItemItemProvider(
+            onItemClicked = router::openDetail,
+            onEmptyLayoutBtnClicked = { backStack.add(MagicalItemRoute.List) },
+        )
         ListDetailScreen(
             viewModel = viewModel,
-            itemProvider = MagicalItemItemProvider(
-                onItemClicked = router::openDetail,
-                onEmptyLayoutBtnClicked = { navController.navigate(MagicalItemRoute.List) },
-            ),
-            onNavigateUp = { navController.navigateUp() },
+            itemProvider = itemProvider,
+            onNavigateUp = router::navigateUp,
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -66,14 +66,14 @@ fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
         val addToListProvider = MagicalItemAddToListProvider(repository, userListRepository)
-        MagicalItemListScreen(viewModel, addToListProvider)
+        MagicalItemListScreen(viewModel, router, addToListProvider)
     }
 
     entry<MagicalItemRoute.CardCarousel> {
         val router = MagicalItemRouterImpl(backStack)
         val viewModelFactory = MagicalItemListViewModelFactory(router, repository)
         val viewModel = viewModel<MagicalItemListViewModel>(factory = viewModelFactory)
-        MagicalItemCardCarouselScreen(viewModel)
+        MagicalItemCardCarouselScreen(viewModel, router)
     }
 
     entry<MagicalItemRoute.Detail> { route ->
@@ -86,10 +86,14 @@ fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
 
     entry<MagicalItemRoute.UserLists> {
         val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(UserList.Type.MAGICAL_ITEM, router, userListRepository)
+        val viewModelFactory = UserListsViewModelFactory(
+            listType = UserList.Type.MAGICAL_ITEM,
+            router = router,
+            userListRepository = userListRepository,
+        )
         val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
-        val screenTitle = stringResource(Res.string.title_my_item_lists)
-        UserListsScreen(viewModel = viewModel, title = screenTitle)
+        val title = stringResource(Res.string.title_my_item_lists)
+        UserListsScreen(viewModel, router, title)
     }
 
     entry<MagicalItemRoute.UserListDetail> { route ->
@@ -102,7 +106,7 @@ fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
         val router = MagicalItemRouterImpl(backStack)
         val itemProvider = MagicalItemItemProvider(
             onItemClicked = router::openDetail,
-            onEmptyLayoutBtnClicked = { backStack.add(MagicalItemRoute.List) },
+            onEmptyLayoutBtnClicked = router::openList,
         )
         ListDetailScreen(
             viewModel = viewModel,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -85,13 +85,13 @@ fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
     }
 
     entry<MagicalItemRoute.UserLists> {
+        val listType = UserList.Type.MAGICAL_ITEM
         val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(
-            listType = UserList.Type.MAGICAL_ITEM,
-            router = router,
-            userListRepository = userListRepository,
+        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(
+            key = listType.name,
+            factory = viewModelFactory,
         )
-        val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
         val title = stringResource(Res.string.title_my_item_lists)
         UserListsScreen(viewModel, router, title)
     }
@@ -102,7 +102,10 @@ fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
             userListRepository = userListRepository,
             repository = MagicalItemEntityRepository(repository),
         )
-        val viewModel = viewModel<ListDetailViewModel<MagicalItem>>(factory = viewModelFactory)
+        val viewModel = viewModel<ListDetailViewModel<MagicalItem>>(
+            key = "MagicalItem_${route.listId}",
+            factory = viewModelFactory,
+        )
         val router = MagicalItemRouterImpl(backStack)
         val itemProvider = MagicalItemItemProvider(
             onItemClicked = router::openDetail,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -48,7 +48,7 @@ interface MagicalItemRoute {
     data class UserListDetail(val listId: String) : NavKey
 }
 
-fun PolymorphicModuleBuilder<NavKey>.declareMagicalItemRoutes() {
+fun PolymorphicModuleBuilder<NavKey>.registerMagicalItemRoutes() {
     subclass(MagicalItemRoute.CardCarousel::class, MagicalItemRoute.CardCarousel.serializer())
     subclass(MagicalItemRoute.List::class, MagicalItemRoute.List.serializer())
     subclass(MagicalItemRoute.Detail::class, MagicalItemRoute.Detail.serializer())

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
@@ -2,15 +2,21 @@ package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface MagicalItemRouter {
     fun navigateUp()
+    fun openList()
     fun openDetail(magicalItemId: String)
 }
 
 class MagicalItemRouterImpl(private val backStack: NavBackStack<NavKey>) : MagicalItemRouter {
     override fun navigateUp() {
-        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
+        backStack.navigateUp()
+    }
+
+    override fun openList() {
+        backStack.add(MagicalItemRoute.List)
     }
 
     override fun openDetail(magicalItemId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
@@ -6,7 +6,7 @@ import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface MagicalItemRouter {
     fun navigateUp()
-    fun openList()
+    fun openCompendium()
     fun openDetail(magicalItemId: String)
 }
 
@@ -15,8 +15,8 @@ class MagicalItemRouterImpl(private val backStack: NavBackStack<NavKey>) : Magic
         backStack.navigateUp()
     }
 
-    override fun openList() {
-        backStack.add(MagicalItemRoute.List)
+    override fun openCompendium() {
+        backStack.add(MagicalItemRoute.Compendium)
     }
 
     override fun openDetail(magicalItemId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRouter.kt
@@ -1,18 +1,19 @@
 package com.cyrillrx.rpg.magicalitem.presentation.navigation
 
-import androidx.navigation.NavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 
 interface MagicalItemRouter {
     fun navigateUp()
     fun openDetail(magicalItemId: String)
 }
 
-class MagicalItemRouterImpl(private val navController: NavController) : MagicalItemRouter {
+class MagicalItemRouterImpl(private val backStack: NavBackStack<NavKey>) : MagicalItemRouter {
     override fun navigateUp() {
-        navController.navigateUp()
+        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
     }
 
     override fun openDetail(magicalItemId: String) {
-        navController.navigate(MagicalItemRoute.Detail(magicalItemId))
+        backStack.add(MagicalItemRoute.Detail(magicalItemId))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -30,10 +30,6 @@ class MagicalItemListViewModel(
         refreshData()
     }
 
-    fun onNavigateUpClicked() {
-        router.navigateUp()
-    }
-
     fun onSearchQueryChanged(query: String) {
         updateFilter { it.copy(query = query) }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SpellEntityRepository.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SpellEntityRepository.kt
@@ -5,7 +5,7 @@ import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellRepository
 
 class SpellEntityRepository(
-    private val delegate: SpellRepository,
+    private val spellRepository: SpellRepository,
 ) : EntityRepository<Spell> {
-    override suspend fun getById(id: String): Spell? = delegate.getById(id)
+    override suspend fun getById(id: String): Spell? = spellRepository.getById(id)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellAddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellAddToListProvider.kt
@@ -34,9 +34,10 @@ class SpellAddToListProvider(
     spellRepository: SpellRepository,
     userListRepository: UserListRepository,
 ) : AddToListProvider<Spell> {
+    override val listType: UserList.Type = UserList.Type.SPELL
 
     override val viewModelFactory = AddToListViewModelFactory(
-        listType = UserList.Type.SPELL,
+        listType = listType,
         userListRepository = userListRepository,
         entityRepository = SpellEntityRepository(spellRepository),
         errorMessage = Res.string.error_while_loading_spells,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -1,10 +1,9 @@
 package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.spell.data.SpellEntityRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellRepository
@@ -27,91 +26,101 @@ import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModelFacto
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.title_my_spell_lists
 
 interface SpellRoute {
     @Serializable
-    data object List
+    data object List : NavKey
 
     @Serializable
-    data object CardCarousel
+    data object CardCarousel : NavKey
 
     @Serializable
-    data class Detail(val spellId: String)
+    data class Detail(val spellId: String) : NavKey
 
     @Serializable
-    data object UserLists
+    data object UserLists : NavKey
 
     @Serializable
-    data class UserListDetail(val listId: String)
+    data class UserListDetail(val listId: String) : NavKey
 }
 
-fun NavGraphBuilder.handleSpellRoutes(
-    navController: NavController,
+fun PolymorphicModuleBuilder<NavKey>.declareSpellRoutes() {
+    subclass(SpellRoute.CardCarousel::class, SpellRoute.CardCarousel.serializer())
+    subclass(SpellRoute.List::class, SpellRoute.List.serializer())
+    subclass(SpellRoute.Detail::class, SpellRoute.Detail.serializer())
+    subclass(SpellRoute.UserLists::class, SpellRoute.UserLists.serializer())
+    subclass(SpellRoute.UserListDetail::class, SpellRoute.UserListDetail.serializer())
+}
+
+fun EntryProviderScope<NavKey>.handleSpellRoutes(
+    backStack: NavBackStack<NavKey>,
     spellRepository: SpellRepository,
     userListRepository: UserListRepository,
 ) {
-    composable<SpellRoute.List> {
-        val router = SpellRouterImpl(navController)
+    entry<SpellRoute.List> {
+        val router = SpellRouterImpl(backStack)
         val viewModelFactory = SpellListViewModelFactory(router, spellRepository)
         val viewModel = viewModel<SpellListViewModel>(factory = viewModelFactory)
-
         val bottomSheetProvider = SpellAddToListProvider(
             spellRepository = spellRepository,
             userListRepository = userListRepository,
         )
-
         SpellListScreen(viewModel, router, bottomSheetProvider)
     }
 
-    composable<SpellRoute.CardCarousel> {
-        val router = SpellRouterImpl(navController)
+    entry<SpellRoute.CardCarousel> {
+        val router = SpellRouterImpl(backStack)
         val viewModelFactory = SpellListViewModelFactory(router, spellRepository)
         val viewModel = viewModel<SpellListViewModel>(factory = viewModelFactory)
         SpellCardCarouselScreen(viewModel, router)
     }
 
-    composable<SpellRoute.Detail> { entry ->
-        val router = SpellRouterImpl(navController)
-        val spellId = entry.toRoute<SpellRoute.Detail>().spellId
-        val viewModel = viewModel<SpellDetailViewModel>(
-            factory = SpellDetailViewModelFactory(spellId, spellRepository),
-        )
-
+    entry<SpellRoute.Detail> { route ->
+        val router = SpellRouterImpl(backStack)
+        val viewModelFactory = SpellDetailViewModelFactory(route.spellId, spellRepository)
+        val viewModel = viewModel<SpellDetailViewModel>(factory = viewModelFactory)
         val bottomSheetProvider = SpellAddToListProvider(
             spellRepository = spellRepository,
             userListRepository = userListRepository,
         )
-
-        SpellCardScreen(viewModel = viewModel, router = router, bottomSheetProvider = bottomSheetProvider)
+        SpellCardScreen(viewModel, router, bottomSheetProvider)
     }
 
-    composable<SpellRoute.UserLists> {
-        val router = UserListRouterImpl(navController)
-        val viewModel = viewModel<UserListsViewModel>(
-            factory = UserListsViewModelFactory(UserList.Type.SPELL, router, userListRepository),
-        )
-        UserListsScreen(
-            viewModel = viewModel,
-            title = stringResource(Res.string.title_my_spell_lists),
-        )
+    entry<SpellRoute.UserLists> {
+        val router = UserListRouterImpl(backStack)
+        val viewModelFactory = UserListsViewModelFactory(UserList.Type.SPELL, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
+        val screenTitle = stringResource(Res.string.title_my_spell_lists)
+        UserListsScreen(viewModel = viewModel, title = screenTitle)
     }
 
-    composable<SpellRoute.UserListDetail> { entry ->
-        val listId = entry.toRoute<SpellRoute.UserListDetail>().listId
-        val viewModel = viewModel<ListDetailViewModel<Spell>>(
-            factory = ListDetailViewModelFactory(listId, userListRepository, SpellEntityRepository(spellRepository)),
+    entry<SpellRoute.UserListDetail> { route ->
+        val viewModelFactory = ListDetailViewModelFactory(
+            listId = route.listId,
+            userListRepository = userListRepository,
+            repository = SpellEntityRepository(spellRepository),
         )
-        val router = SpellRouterImpl(navController)
+        val viewModel = viewModel<ListDetailViewModel<Spell>>(factory = viewModelFactory)
+        val router = SpellRouterImpl(backStack)
+        val itemProvider = SpellItemProvider(
+            onItemClicked = router::openDetail,
+            onEmptyLayoutBtnClicked = { backStack.add(SpellRoute.List) },
+        )
         ListDetailScreen(
             viewModel = viewModel,
-            itemProvider = SpellItemProvider(
-                onItemClicked = router::openDetail,
-                onEmptyLayoutBtnClicked = { navController.navigate(SpellRoute.List) },
-            ),
-            onNavigateUp = { navController.navigateUp() },
+            itemProvider = itemProvider,
+            onNavigateUp = {
+                if (backStack.size > 1) {
+                    backStack.removeAt(backStack.size - 1)
+                    true
+                } else {
+                    false
+                }
+            },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -49,7 +49,7 @@ interface SpellRoute {
     data class UserListDetail(val listId: String) : NavKey
 }
 
-fun PolymorphicModuleBuilder<NavKey>.declareSpellRoutes() {
+fun PolymorphicModuleBuilder<NavKey>.registerSpellRoutes() {
     subclass(SpellRoute.CardCarousel::class, SpellRoute.CardCarousel.serializer())
     subclass(SpellRoute.List::class, SpellRoute.List.serializer())
     subclass(SpellRoute.Detail::class, SpellRoute.Detail.serializer())

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.core.navigation.navigateUp
 import com.cyrillrx.rpg.spell.data.SpellEntityRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellRepository
@@ -92,10 +93,14 @@ fun EntryProviderScope<NavKey>.handleSpellRoutes(
 
     entry<SpellRoute.UserLists> {
         val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(UserList.Type.SPELL, router, userListRepository)
+        val viewModelFactory = UserListsViewModelFactory(
+            listType = UserList.Type.SPELL,
+            router = router,
+            userListRepository = userListRepository,
+        )
         val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
-        val screenTitle = stringResource(Res.string.title_my_spell_lists)
-        UserListsScreen(viewModel = viewModel, title = screenTitle)
+        val title = stringResource(Res.string.title_my_spell_lists)
+        UserListsScreen(viewModel, router, title)
     }
 
     entry<SpellRoute.UserListDetail> { route ->
@@ -108,19 +113,12 @@ fun EntryProviderScope<NavKey>.handleSpellRoutes(
         val router = SpellRouterImpl(backStack)
         val itemProvider = SpellItemProvider(
             onItemClicked = router::openDetail,
-            onEmptyLayoutBtnClicked = { backStack.add(SpellRoute.List) },
+            onEmptyLayoutBtnClicked = router::openList,
         )
         ListDetailScreen(
             viewModel = viewModel,
             itemProvider = itemProvider,
-            onNavigateUp = {
-                if (backStack.size > 1) {
-                    backStack.removeAt(backStack.size - 1)
-                    true
-                } else {
-                    false
-                }
-            },
+            onNavigateUp = backStack::navigateUp,
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -2,68 +2,48 @@ package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.EntryProviderScope
-import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
-import com.cyrillrx.rpg.core.navigation.navigateUp
 import com.cyrillrx.rpg.spell.data.SpellEntityRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.presentation.SpellAddToListProvider
 import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
-import com.cyrillrx.rpg.spell.presentation.component.SpellCardCarouselScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellCardScreen
 import com.cyrillrx.rpg.spell.presentation.component.SpellListScreen
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModelFactory
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellListViewModel
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellListViewModelFactory
-import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.component.ListDetailScreen
-import com.cyrillrx.rpg.userlist.presentation.component.UserListsScreen
-import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouterImpl
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModelFactory
-import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
-import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
-import org.jetbrains.compose.resources.stringResource
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.title_my_spell_lists
 
 interface SpellRoute {
     @Serializable
-    data object List : NavKey
-
-    @Serializable
-    data object CardCarousel : NavKey
+    data object Compendium : NavKey
 
     @Serializable
     data class Detail(val spellId: String) : NavKey
-
-    @Serializable
-    data object UserLists : NavKey
 
     @Serializable
     data class UserListDetail(val listId: String) : NavKey
 }
 
 fun PolymorphicModuleBuilder<NavKey>.registerSpellRoutes() {
-    subclass(SpellRoute.CardCarousel::class, SpellRoute.CardCarousel.serializer())
-    subclass(SpellRoute.List::class, SpellRoute.List.serializer())
-    subclass(SpellRoute.Detail::class, SpellRoute.Detail.serializer())
-    subclass(SpellRoute.UserLists::class, SpellRoute.UserLists.serializer())
+    subclass(SpellRoute.Compendium::class, SpellRoute.Compendium.serializer())
     subclass(SpellRoute.UserListDetail::class, SpellRoute.UserListDetail.serializer())
+    subclass(SpellRoute.Detail::class, SpellRoute.Detail.serializer())
 }
 
 fun EntryProviderScope<NavKey>.handleSpellRoutes(
-    backStack: NavBackStack<NavKey>,
+    router: SpellRouter,
     spellRepository: SpellRepository,
     userListRepository: UserListRepository,
 ) {
-    entry<SpellRoute.List> {
-        val router = SpellRouterImpl(backStack)
+    entry<SpellRoute.Compendium> {
         val viewModelFactory = SpellListViewModelFactory(router, spellRepository)
         val viewModel = viewModel<SpellListViewModel>(factory = viewModelFactory)
         val bottomSheetProvider = SpellAddToListProvider(
@@ -71,19 +51,13 @@ fun EntryProviderScope<NavKey>.handleSpellRoutes(
             userListRepository = userListRepository,
         )
         SpellListScreen(viewModel, router, bottomSheetProvider)
-    }
-
-    entry<SpellRoute.CardCarousel> {
-        val router = SpellRouterImpl(backStack)
-        val viewModelFactory = SpellListViewModelFactory(router, spellRepository)
-        val viewModel = viewModel<SpellListViewModel>(factory = viewModelFactory)
-        SpellCardCarouselScreen(viewModel, router)
+        // SpellCardCarouselScreen(viewModel, router)
     }
 
     entry<SpellRoute.Detail> { route ->
-        val router = SpellRouterImpl(backStack)
-        val viewModelFactory = SpellDetailViewModelFactory(route.spellId, spellRepository)
-        val viewModel = viewModel<SpellDetailViewModel>(factory = viewModelFactory)
+        val spellId = route.spellId
+        val viewModelFactory = SpellDetailViewModelFactory(spellId, spellRepository)
+        val viewModel = viewModel<SpellDetailViewModel>(key = spellId, factory = viewModelFactory)
         val bottomSheetProvider = SpellAddToListProvider(
             spellRepository = spellRepository,
             userListRepository = userListRepository,
@@ -91,37 +65,22 @@ fun EntryProviderScope<NavKey>.handleSpellRoutes(
         SpellCardScreen(viewModel, router, bottomSheetProvider)
     }
 
-    entry<SpellRoute.UserLists> {
-        val listType = UserList.Type.SPELL
-        val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
-        val viewModel = viewModel<UserListsViewModel>(
-            key = listType.name,
-            factory = viewModelFactory,
-        )
-        val title = stringResource(Res.string.title_my_spell_lists)
-        UserListsScreen(viewModel, router, title)
-    }
-
     entry<SpellRoute.UserListDetail> { route ->
+        val listId = route.listId
         val viewModelFactory = ListDetailViewModelFactory(
-            listId = route.listId,
+            listId = listId,
             userListRepository = userListRepository,
             repository = SpellEntityRepository(spellRepository),
         )
-        val viewModel = viewModel<ListDetailViewModel<Spell>>(
-            key = "Spell_${route.listId}",
-            factory = viewModelFactory,
-        )
-        val router = SpellRouterImpl(backStack)
+        val viewModel = viewModel<ListDetailViewModel<Spell>>(key = listId, factory = viewModelFactory)
         val itemProvider = SpellItemProvider(
             onItemClicked = router::openDetail,
-            onEmptyLayoutBtnClicked = router::openList,
+            onEmptyLayoutBtnClicked = router::openCompendium,
         )
         ListDetailScreen(
             viewModel = viewModel,
             itemProvider = itemProvider,
-            onNavigateUp = backStack::navigateUp,
+            onNavigateUp = router::navigateUp,
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRoute.kt
@@ -92,13 +92,13 @@ fun EntryProviderScope<NavKey>.handleSpellRoutes(
     }
 
     entry<SpellRoute.UserLists> {
+        val listType = UserList.Type.SPELL
         val router = UserListRouterImpl(backStack)
-        val viewModelFactory = UserListsViewModelFactory(
-            listType = UserList.Type.SPELL,
-            router = router,
-            userListRepository = userListRepository,
+        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(
+            key = listType.name,
+            factory = viewModelFactory,
         )
-        val viewModel = viewModel<UserListsViewModel>(factory = viewModelFactory)
         val title = stringResource(Res.string.title_my_spell_lists)
         UserListsScreen(viewModel, router, title)
     }
@@ -109,7 +109,10 @@ fun EntryProviderScope<NavKey>.handleSpellRoutes(
             userListRepository = userListRepository,
             repository = SpellEntityRepository(spellRepository),
         )
-        val viewModel = viewModel<ListDetailViewModel<Spell>>(factory = viewModelFactory)
+        val viewModel = viewModel<ListDetailViewModel<Spell>>(
+            key = "Spell_${route.listId}",
+            factory = viewModelFactory,
+        )
         val router = SpellRouterImpl(backStack)
         val itemProvider = SpellItemProvider(
             onItemClicked = router::openDetail,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
@@ -1,18 +1,19 @@
 package com.cyrillrx.rpg.spell.presentation.navigation
 
-import androidx.navigation.NavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 
 interface SpellRouter {
     fun navigateUp()
     fun openDetail(spellId: String)
 }
 
-class SpellRouterImpl(private val navController: NavController) : SpellRouter {
+class SpellRouterImpl(private val backStack: NavBackStack<NavKey>) : SpellRouter {
     override fun navigateUp() {
-        navController.navigateUp()
+        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
     }
 
     override fun openDetail(spellId: String) {
-        navController.navigate(SpellRoute.Detail(spellId))
+        backStack.add(SpellRoute.Detail(spellId))
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
@@ -2,15 +2,21 @@ package com.cyrillrx.rpg.spell.presentation.navigation
 
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface SpellRouter {
     fun navigateUp()
+    fun openList()
     fun openDetail(spellId: String)
 }
 
 class SpellRouterImpl(private val backStack: NavBackStack<NavKey>) : SpellRouter {
     override fun navigateUp() {
-        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
+        backStack.navigateUp()
+    }
+
+    override fun openList() {
+        backStack.add(SpellRoute.List)
     }
 
     override fun openDetail(spellId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/navigation/SpellRouter.kt
@@ -6,7 +6,7 @@ import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface SpellRouter {
     fun navigateUp()
-    fun openList()
+    fun openCompendium()
     fun openDetail(spellId: String)
 }
 
@@ -15,8 +15,8 @@ class SpellRouterImpl(private val backStack: NavBackStack<NavKey>) : SpellRouter
         backStack.navigateUp()
     }
 
-    override fun openList() {
-        backStack.add(SpellRoute.List)
+    override fun openCompendium() {
+        backStack.add(SpellRoute.Compendium)
     }
 
     override fun openDetail(spellId: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -31,10 +31,6 @@ class SpellListViewModel(
         refreshData()
     }
 
-    fun onNavigateUpClicked() {
-        router.navigateUp()
-    }
-
     fun onSearchQueryChanged(query: String) {
         updateFilter { it.copy(query = query) }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/AddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/AddToListProvider.kt
@@ -3,12 +3,13 @@ package com.cyrillrx.rpg.userlist.presentation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.presentation.component.AddToListBottomSheet
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.AddToListViewModel
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.AddToListViewModelFactory
 
 interface AddToListProvider<T> {
-
+    val listType: UserList.Type
     val viewModelFactory: AddToListViewModelFactory<T>
 
     @Composable
@@ -19,7 +20,7 @@ interface AddToListProvider<T> {
         entityId: String,
         onDismiss: () -> Unit,
     ) {
-        val viewModel = viewModel<AddToListViewModel<T>>(factory = viewModelFactory)
+        val viewModel = viewModel<AddToListViewModel<T>>(key = listType.name, factory = viewModelFactory)
         LaunchedEffect(entityId) { viewModel.loadEntity(entityId) }
         AddToListBottomSheet(viewModel, ::Header, onDismiss = onDismiss)
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -59,6 +61,11 @@ fun <T> ListDetailScreen(
     onNavigateUp: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.silentRefresh()
+    }
+
     ListDetailScreen(
         state = state,
         events = viewModel.events,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -135,7 +135,7 @@ fun <T> ListDetailScreen(
         topBar = {
             SimpleTopBar(
                 title = state.listName,
-                navigateUp = onNavigateUpClicked,
+                onNavigateUpClicked = onNavigateUpClicked,
                 actions = {
                     IconButton(onClick = { showRenameDialog = true }) {
                         Icon(Icons.Default.Edit, contentDescription = stringResource(Res.string.btn_rename_list))

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -27,8 +27,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
@@ -40,6 +40,7 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.presentation.UserListsState
+import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouter
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -55,7 +56,7 @@ import rpg_companion.composeapp.generated.resources.snackbar_error_deleting_list
 import rpg_companion.composeapp.generated.resources.snackbar_list_deleted
 
 @Composable
-fun UserListsScreen(viewModel: UserListsViewModel, title: String) {
+fun UserListsScreen(viewModel: UserListsViewModel, router: UserListRouter, title: String) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
@@ -66,7 +67,7 @@ fun UserListsScreen(viewModel: UserListsViewModel, title: String) {
         state = state,
         title = title,
         events = viewModel.events,
-        onNavigateUpClicked = viewModel::onNavigateUpClicked,
+        onNavigateUpClicked = router::navigateUp,
         onAddBtnClicked = viewModel::createList,
         onDeleteListOptimistically = viewModel::deleteListOptimistically,
         onUndoDeletion = viewModel::undoDeletion,
@@ -127,7 +128,7 @@ fun UserListsScreen(
         topBar = {
             SimpleTopBar(
                 title = title,
-                navigateUp = onNavigateUpClicked,
+                onNavigateUpClicked = onNavigateUpClicked,
             )
         },
         floatingActionButton = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRoute.kt
@@ -1,0 +1,72 @@
+package com.cyrillrx.rpg.userlist.presentation.navigation
+
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.userlist.domain.UserList
+import com.cyrillrx.rpg.userlist.domain.UserListRepository
+import com.cyrillrx.rpg.userlist.presentation.component.UserListsScreen
+import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
+import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModelFactory
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.title_my_bestiary_lists
+import rpg_companion.composeapp.generated.resources.title_my_item_lists
+import rpg_companion.composeapp.generated.resources.title_my_spell_lists
+
+interface UserListRoute {
+    @Serializable
+    data object Spell : NavKey
+
+    @Serializable
+    data object MagicalItem : NavKey
+
+    @Serializable
+    data object Creature : NavKey
+}
+
+fun PolymorphicModuleBuilder<NavKey>.registerUserListRoutes() {
+    subclass(UserListRoute.Spell::class, UserListRoute.Spell.serializer())
+    subclass(UserListRoute.MagicalItem::class, UserListRoute.MagicalItem.serializer())
+    subclass(UserListRoute.Creature::class, UserListRoute.Creature.serializer())
+}
+
+fun EntryProviderScope<NavKey>.handleUserListRoutes(
+    router: UserListRouter,
+    userListRepository: UserListRepository,
+) {
+    entry<UserListRoute.Spell> {
+        val listType = UserList.Type.SPELL
+        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(
+            key = listType.name,
+            factory = viewModelFactory,
+        )
+        val title = stringResource(Res.string.title_my_spell_lists)
+        UserListsScreen(viewModel, router, title)
+    }
+
+    entry<UserListRoute.MagicalItem> {
+        val listType = UserList.Type.MAGICAL_ITEM
+        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(
+            key = listType.name,
+            factory = viewModelFactory,
+        )
+        val title = stringResource(Res.string.title_my_item_lists)
+        UserListsScreen(viewModel, router, title)
+    }
+
+    entry<UserListRoute.Creature> {
+        val listType = UserList.Type.CREATURE
+        val viewModelFactory = UserListsViewModelFactory(listType, router, userListRepository)
+        val viewModel = viewModel<UserListsViewModel>(
+            key = listType.name,
+            factory = viewModelFactory,
+        )
+        val title = stringResource(Res.string.title_my_bestiary_lists)
+        UserListsScreen(viewModel, router, title)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.userlist.presentation.navigation
 
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.core.navigation.navigateUp
 import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRoute
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRoute
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRoute
@@ -14,7 +15,7 @@ interface UserListRouter {
 
 class UserListRouterImpl(private val backStack: NavBackStack<NavKey>) : UserListRouter {
     override fun navigateUp() {
-        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
+        backStack.navigateUp()
     }
 
     override fun openUserList(list: UserList) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/navigation/UserListRouter.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.userlist.presentation.navigation
 
-import androidx.navigation.NavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.creature.presentation.navigation.CreatureRoute
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRoute
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRoute
@@ -11,16 +12,16 @@ interface UserListRouter {
     fun openUserList(list: UserList)
 }
 
-class UserListRouterImpl(private val navController: NavController) : UserListRouter {
+class UserListRouterImpl(private val backStack: NavBackStack<NavKey>) : UserListRouter {
     override fun navigateUp() {
-        navController.navigateUp()
+        if (backStack.size > 1) backStack.removeAt(backStack.size - 1)
     }
 
     override fun openUserList(list: UserList) {
         when (list.type) {
-            UserList.Type.SPELL -> navController.navigate(SpellRoute.UserListDetail(list.id))
-            UserList.Type.MAGICAL_ITEM -> navController.navigate(MagicalItemRoute.UserListDetail(list.id))
-            UserList.Type.CREATURE -> navController.navigate(CreatureRoute.UserListDetail(list.id))
+            UserList.Type.SPELL -> backStack.add(SpellRoute.UserListDetail(list.id))
+            UserList.Type.MAGICAL_ITEM -> backStack.add(MagicalItemRoute.UserListDetail(list.id))
+            UserList.Type.CREATURE -> backStack.add(CreatureRoute.UserListDetail(list.id))
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -123,27 +123,45 @@ class ListDetailViewModel<T>(
         }
     }
 
+    fun silentRefresh() {
+        if (state.value.body is ListDetailState.Body.Loading) return
+
+        viewModelScope.launch {
+            try {
+                fetchDetail()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Silently ignore — don't overwrite existing content with an error
+            }
+        }
+    }
+
     private fun loadDetail() {
         viewModelScope.launch {
             state.update { it.copy(body = ListDetailState.Body.Loading) }
 
             try {
-                val list = userListRepository.get(listId) ?: error("Could not find list $listId")
-                currentList = list
-                state.update { it.copy(listName = list.name) }
-
-                val items = repository.getByIds(list.itemIds)
-                val body = if (items.isEmpty()) {
-                    ListDetailState.Body.EmptyList
-                } else {
-                    ListDetailState.Body.WithData(items)
-                }
-                state.update { it.copy(body = body) }
+                fetchDetail()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 state.update { it.copy(body = ListDetailState.Body.Error(Res.string.error_while_loading_user_list)) }
             }
         }
+    }
+
+    private suspend fun fetchDetail() {
+        val list = userListRepository.get(listId) ?: error("Could not find list $listId")
+        currentList = list
+        state.update { it.copy(listName = list.name) }
+
+        val items = repository.getByIds(list.itemIds)
+        val body = if (items.isEmpty()) {
+            ListDetailState.Body.EmptyList
+        } else {
+            ListDetailState.Body.WithData(items)
+        }
+        state.update { it.copy(body = body) }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -54,10 +54,6 @@ class UserListsViewModel(
         commitAllPendingDeletions()
     }
 
-    fun onNavigateUpClicked() {
-        router.navigateUp()
-    }
-
     @OptIn(ExperimentalUuidApi::class)
     fun createList(name: String) {
         viewModelScope.launch {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModelTest.kt
@@ -177,7 +177,7 @@ class CreatureListViewModelTest {
 
 private class NoOpCreatureRouter : CreatureRouter {
     override fun navigateUp() = Unit
-    override fun openList() = Unit
+    override fun openCompendium() = Unit
     override fun openDetail(creatureId: String) = Unit
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/CreatureListViewModelTest.kt
@@ -177,6 +177,7 @@ class CreatureListViewModelTest {
 
 private class NoOpCreatureRouter : CreatureRouter {
     override fun navigateUp() = Unit
+    override fun openList() = Unit
     override fun openDetail(creatureId: String) = Unit
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -176,6 +176,7 @@ class MagicalItemListViewModelTest {
 
 private class NoOpMagicalItemRouter : MagicalItemRouter {
     override fun navigateUp() = Unit
+    override fun openList() = Unit
     override fun openDetail(magicalItemId: String) = Unit
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -176,7 +176,7 @@ class MagicalItemListViewModelTest {
 
 private class NoOpMagicalItemRouter : MagicalItemRouter {
     override fun navigateUp() = Unit
-    override fun openList() = Unit
+    override fun openCompendium() = Unit
     override fun openDetail(magicalItemId: String) = Unit
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
@@ -195,6 +195,7 @@ class SpellListViewModelTest {
 
 private class NoOpSpellRouter : SpellRouter {
     override fun navigateUp() = Unit
+    override fun openList() = Unit
     override fun openDetail(spellId: String) = Unit
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
@@ -195,7 +195,7 @@ class SpellListViewModelTest {
 
 private class NoOpSpellRouter : SpellRouter {
     override fun navigateUp() = Unit
-    override fun openList() = Unit
+    override fun openCompendium() = Unit
     override fun openDetail(spellId: String) = Unit
 }
 

--- a/cmp-ttrpg-companion/gradle/libs.versions.toml
+++ b/cmp-ttrpg-companion/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.3.10"
-ktlint = "14.0.1"
+kotlin = "2.3.20"
+ktlint = "14.2.0"
 agp = "9.0.1"
 compose-plugin = "1.10.1"
 kotlinx-coroutines-core = "1.10.2"
@@ -16,12 +16,14 @@ androidx-appcompat = "1.7.1"
 androidx-coreKtx = "1.17.0"
 androidx-activity-compose = "1.12.4"
 androidx-lifecycle = "2.9.6"
-navigationCompose = "2.9.2"
+navigation3 = "1.0.0-alpha06"
+lifecycle-viewmodel-navigation3 = "2.10.0"
 
 legacy-materialVersion = "1.13.0"
 
 [libraries]
-jetbrains-compose-navigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+jetbrains-lifecycle-viewmodelNavigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycle-viewmodel-navigation3" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines-core" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines-core" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-core" }


### PR DESCRIPTION
## 📝 Description

Migrate the CMP app from Navigation 2 (`navigation-compose:2.9.2`) to Navigation 3 (`navigation3-ui:1.0.0-alpha06`).

Nav3 introduces a fundamentally different model: the developer owns the back stack as a `NavBackStack<NavKey>` (a `SnapshotStateList`), replacing the library-managed `NavController`.

Important note: add explicit `viewModel()` keys to prevent ViewModel sharing, which can lead to bugs (Nav3 alpha bug - `LocalViewModelStoreOwner` not scoped per entry).

Also, update the navigation section in AGENTS.md to reflect Nav3 patterns.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed