### PR TITLE
test(userlist): add missing ViewModel tests and concrete testing conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ For feature specifications and product decisions, refer to the [Product Requirem
 ### Collaboration and Communication
 
 - **Collaboration, Git & CI Conventions**: [`GIT_AND_COLLABORATION.md`](docs/conventions/GIT_AND_COLLABORATION.md)
+- **Documentation language**: All documentation, comments, commit messages, and PR descriptions must be written in English.
 - **AI Co-authorship**: Do not add AI co-author tags (e.g. `Co-Authored-By: Claude`) to commits or pull requests.
 - **AI/Agent rules**: All rules applying to AI agents must be written in this file (`AGENTS.md`). Agent-specific config files (e.g. `.claude/CLAUDE.md`) must only point to this file — never duplicate or extend rules there.
 - **AI/Agent naming convention**: Commits and PRs related to AI agent configuration or rules must use the `docs(agents)` conventional-commit prefix (e.g. `docs(agents): add co-authorship rule`).

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddToListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddToListViewModelTest.kt
@@ -237,6 +237,33 @@ class AddToListViewModelTest {
     }
 
     @Test
+    fun `loadEntity reflects fresh list data when called again after repository changes`() =
+        runTest(testDispatcher) {
+            val viewModel = buildViewModel()
+
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.state.collect {}
+            }
+
+            advanceUntilIdle()
+
+            val initialBody = assertIs<AddToListState.Body.WithData<Spell>>(viewModel.state.value.body)
+            assertTrue(initialBody.selectableLists.isEmpty())
+
+            // Simulate: spell was added to a new list externally (e.g. from another screen)
+            val newList = UserList("list1", "Grimoire", UserList.Type.SPELL, listOf(spell.id))
+            userListRepository.save(newList)
+
+            // Re-call loadEntity — simulates the bottom sheet being re-opened
+            viewModel.loadEntity(spell.id)
+            advanceUntilIdle()
+
+            val refreshedBody = assertIs<AddToListState.Body.WithData<Spell>>(viewModel.state.value.body)
+            assertEquals(expected = 1, actual = refreshedBody.selectableLists.size)
+            assertTrue(refreshedBody.selectableLists.first().alreadyAdded)
+        }
+
+    @Test
     fun `createAndAdd creates a new list with the itemId`() = runTest(testDispatcher) {
         val viewModel = buildViewModel()
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddToListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/AddToListViewModelTest.kt
@@ -25,6 +25,11 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+private const val TEST_LIST_ID = "list1"
+private const val TEST_LIST_ID_2 = "list2"
+private const val LIST_NAME = "Grimoire"
+private const val CREATED_LIST_NAME = "Nouveau grimoire"
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class AddToListViewModelTest {
 
@@ -95,7 +100,7 @@ class AddToListViewModelTest {
 
     @Test
     fun `initial state loads existing lists of given type`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Grimoire", UserList.Type.SPELL, emptyList())
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, emptyList())
         userListRepository.save(list)
 
         val viewModel = buildViewModel()
@@ -108,13 +113,13 @@ class AddToListViewModelTest {
 
         val body = assertIs<AddToListState.Body.WithData<Spell>>(viewModel.state.value.body)
         assertEquals(expected = 1, actual = body.selectableLists.size)
-        assertEquals(expected = "Grimoire", actual = body.selectableLists.first().list.name)
+        assertEquals(expected = LIST_NAME, actual = body.selectableLists.first().list.name)
     }
 
     @Test
     fun `initial state pre-selects lists where item is already added`() = runTest(testDispatcher) {
-        val list1 = UserList("list1", "Grimoire", UserList.Type.SPELL, listOf(spell.id))
-        val list2 = UserList("list2", "Other", UserList.Type.SPELL, emptyList())
+        val list1 = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
+        val list2 = UserList(TEST_LIST_ID_2, "Other", UserList.Type.SPELL, emptyList())
         userListRepository.save(list1)
         userListRepository.save(list2)
 
@@ -128,13 +133,13 @@ class AddToListViewModelTest {
 
         val body = assertIs<AddToListState.Body.WithData<Spell>>(viewModel.state.value.body)
         val selectableLists = body.selectableLists
-        assertTrue(selectableLists.first { it.list.id == "list1" }.isSelected)
-        assertFalse(selectableLists.first { it.list.id == "list2" }.isSelected)
+        assertTrue(selectableLists.first { it.list.id == TEST_LIST_ID }.isSelected)
+        assertFalse(selectableLists.first { it.list.id == TEST_LIST_ID_2 }.isSelected)
     }
 
     @Test
     fun `toggleSelection selects the list`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Grimoire", UserList.Type.SPELL, emptyList())
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, emptyList())
         userListRepository.save(list)
 
         val viewModel = buildViewModel()
@@ -145,15 +150,15 @@ class AddToListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.toggleSelection("list1")
+        viewModel.toggleSelection(TEST_LIST_ID)
 
         val body = assertIs<AddToListState.Body.WithData<Spell>>(viewModel.state.value.body)
-        assertTrue(body.selectableLists.first { it.list.id == "list1" }.isSelected)
+        assertTrue(body.selectableLists.first { it.list.id == TEST_LIST_ID }.isSelected)
     }
 
     @Test
     fun `toggleSelection deselects the list`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Grimoire", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
         val viewModel = buildViewModel()
@@ -164,15 +169,15 @@ class AddToListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.toggleSelection("list1")
+        viewModel.toggleSelection(TEST_LIST_ID)
 
         val body = assertIs<AddToListState.Body.WithData<Spell>>(viewModel.state.value.body)
-        assertFalse(body.selectableLists.first { it.list.id == "list1" }.isSelected)
+        assertFalse(body.selectableLists.first { it.list.id == TEST_LIST_ID }.isSelected)
     }
 
     @Test
     fun `confirmSelection adds item to newly selected lists`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Grimoire", UserList.Type.SPELL, emptyList())
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, emptyList())
         userListRepository.save(list)
 
         val viewModel = buildViewModel()
@@ -183,18 +188,18 @@ class AddToListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.toggleSelection("list1")
+        viewModel.toggleSelection(TEST_LIST_ID)
         viewModel.confirmSelection()
 
         advanceUntilIdle()
 
-        val savedList = userListRepository.get("list1")
+        val savedList = userListRepository.get(TEST_LIST_ID)
         assertTrue(savedList?.itemIds?.contains(spell.id) ?: false)
     }
 
     @Test
     fun `confirmSelection removes item from deselected lists`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Grimoire", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
         val viewModel = buildViewModel()
@@ -205,12 +210,12 @@ class AddToListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.toggleSelection("list1")
+        viewModel.toggleSelection(TEST_LIST_ID)
         viewModel.confirmSelection()
 
         advanceUntilIdle()
 
-        val savedList = userListRepository.get("list1")
+        val savedList = userListRepository.get(TEST_LIST_ID)
         assertFalse(savedList?.itemIds?.contains(spell.id) ?: true)
     }
 
@@ -251,7 +256,7 @@ class AddToListViewModelTest {
             assertTrue(initialBody.selectableLists.isEmpty())
 
             // Simulate: spell was added to a new list externally (e.g. from another screen)
-            val newList = UserList("list1", "Grimoire", UserList.Type.SPELL, listOf(spell.id))
+            val newList = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
             userListRepository.save(newList)
 
             // Re-call loadEntity — simulates the bottom sheet being re-opened
@@ -273,17 +278,17 @@ class AddToListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.createAndAdd("Nouveau grimoire")
+        viewModel.createAndAdd(CREATED_LIST_NAME)
 
         advanceUntilIdle()
 
         val lists = userListRepository.getAll(UserList.Type.SPELL)
         assertEquals(expected = 1, actual = lists.size)
-        assertEquals(expected = "Nouveau grimoire", actual = lists.first().name)
+        assertEquals(expected = CREATED_LIST_NAME, actual = lists.first().name)
         assertTrue(actual = lists.first().itemIds.contains(spell.id))
 
         val body = assertIs<AddToListState.Body.WithData<Spell>>(viewModel.state.value.body)
-        val newEntry = body.selectableLists.first { it.list.name == "Nouveau grimoire" }
+        val newEntry = body.selectableLists.first { it.list.name == CREATED_LIST_NAME }
         assertTrue(newEntry.alreadyAdded)
         assertTrue(newEntry.isSelected)
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -23,6 +23,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+private const val TEST_LIST_ID = "list1"
+private const val LIST_NAME = "Name of the list"
+private const val RENAMED_LIST_NAME = "New Name"
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class ListDetailViewModelTest {
 
@@ -47,14 +51,14 @@ class ListDetailViewModelTest {
 
     @Test
     fun `initial state is Loading before coroutines run`() = runTest(testDispatcher) {
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         assertIs<ListDetailState.Body.Loading>(viewModel.state.value.body)
     }
 
     @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
-        val viewModel = buildViewModel("list1", FailingUserListRepository())
+        val viewModel = buildViewModel(TEST_LIST_ID, FailingUserListRepository())
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -80,10 +84,10 @@ class ListDetailViewModelTest {
 
     @Test
     fun `state is Empty when list has no spells`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Gandalf's spells", UserList.Type.SPELL, emptyList())
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, emptyList())
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -92,15 +96,15 @@ class ListDetailViewModelTest {
         advanceUntilIdle()
 
         assertIs<ListDetailState.Body.EmptyList>(viewModel.state.value.body)
-        assertEquals(expected = "Gandalf's spells", actual = viewModel.state.value.listName)
+        assertEquals(expected = LIST_NAME, actual = viewModel.state.value.listName)
     }
 
     @Test
     fun `state is WithData when list has spells`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Fighting spells", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -116,10 +120,10 @@ class ListDetailViewModelTest {
     @Test
     fun `removeItemOptimistically then commit removes spell from list`() = runTest(testDispatcher) {
         val allSpells = SampleSpellRepository.getAll()
-        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, allSpells.map { it.id })
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, allSpells.map { it.id })
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -139,10 +143,10 @@ class ListDetailViewModelTest {
 
     @Test
     fun `undoRemoval restores the item`() = runTest(testDispatcher) {
-        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -160,10 +164,10 @@ class ListDetailViewModelTest {
     @Test
     fun `removeItemOptimistically then commit transitions to Empty when last spell removed`() =
         runTest(testDispatcher) {
-            val list = UserList("list1", "My spellbook", UserList.Type.SPELL, listOf(spell.id))
+            val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
             userListRepository.save(list)
 
-            val viewModel = buildViewModel("list1")
+            val viewModel = buildViewModel(TEST_LIST_ID)
 
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
                 viewModel.state.collect {}
@@ -181,10 +185,10 @@ class ListDetailViewModelTest {
 
     @Test
     fun `silentRefresh reflects new items added to repository`() = runTest(testDispatcher) {
-        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -207,10 +211,10 @@ class ListDetailViewModelTest {
 
     @Test
     fun `silentRefresh does not transition to Loading state`() = runTest(testDispatcher) {
-        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -229,10 +233,10 @@ class ListDetailViewModelTest {
 
     @Test
     fun `silentRefresh does nothing when state is already Loading`() = runTest(testDispatcher) {
-        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         assertIs<ListDetailState.Body.Loading>(viewModel.state.value.body)
 
@@ -243,10 +247,10 @@ class ListDetailViewModelTest {
 
     @Test
     fun `renameList updates list name in state`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Old Name", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -254,18 +258,18 @@ class ListDetailViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.renameList("New Name")
+        viewModel.renameList(RENAMED_LIST_NAME)
         advanceUntilIdle()
 
-        assertEquals(expected = "New Name", actual = viewModel.state.value.listName)
+        assertEquals(expected = RENAMED_LIST_NAME, actual = viewModel.state.value.listName)
     }
 
     @Test
     fun `renameList persists updated name to repository`() = runTest(testDispatcher) {
-        val list = UserList("list1", "Old Name", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -273,19 +277,19 @@ class ListDetailViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.renameList("New Name")
+        viewModel.renameList(RENAMED_LIST_NAME)
         advanceUntilIdle()
 
-        val savedList = userListRepository.get("list1")
-        assertEquals(expected = "New Name", actual = savedList?.name)
+        val savedList = userListRepository.get(TEST_LIST_ID)
+        assertEquals(expected = RENAMED_LIST_NAME, actual = savedList?.name)
     }
 
     @Test
     fun `onCleared commits pending removals that were never confirmed`() = runTest(testDispatcher) {
-        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
-        val viewModel = buildViewModel("list1")
+        val viewModel = buildViewModel(TEST_LIST_ID)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.state.collect {}
@@ -296,7 +300,7 @@ class ListDetailViewModelTest {
         viewModel.commitAllPendingRemovals() // simulate navigation away
         advanceUntilIdle()
 
-        val updatedList = userListRepository.get("list1")!!
+        val updatedList = userListRepository.get(TEST_LIST_ID)!!
         assertTrue(updatedList.itemIds.none { it == spell.id })
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -30,6 +30,7 @@ class ListDetailViewModelTest {
     private val spellRepository = SpellEntityRepository(SampleSpellRepository())
     private val userListRepository = RamUserListRepository()
     private val spell = SampleSpellRepository.getFirst()
+    private val secondSpell = SampleSpellRepository.getAll()[1]
 
     @BeforeTest
     fun setUp() {
@@ -177,6 +178,107 @@ class ListDetailViewModelTest {
 
             assertIs<ListDetailState.Body.EmptyList>(viewModel.state.value.body)
         }
+
+    @Test
+    fun `silentRefresh reflects new items added to repository`() = runTest(testDispatcher) {
+        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        userListRepository.save(list)
+
+        val viewModel = buildViewModel("list1")
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val initialBody = assertIs<ListDetailState.Body.WithData<Spell>>(viewModel.state.value.body)
+        assertEquals(expected = 1, actual = initialBody.items.size)
+
+        val updatedList = list.copy(itemIds = list.itemIds + secondSpell.id)
+        userListRepository.save(updatedList)
+
+        viewModel.silentRefresh()
+        advanceUntilIdle()
+
+        val refreshedBody = assertIs<ListDetailState.Body.WithData<Spell>>(viewModel.state.value.body)
+        assertEquals(expected = 2, actual = refreshedBody.items.size)
+    }
+
+    @Test
+    fun `silentRefresh does not transition to Loading state`() = runTest(testDispatcher) {
+        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        userListRepository.save(list)
+
+        val viewModel = buildViewModel("list1")
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.silentRefresh()
+
+        assertIs<ListDetailState.Body.WithData<Spell>>(viewModel.state.value.body)
+
+        advanceUntilIdle()
+
+        assertIs<ListDetailState.Body.WithData<Spell>>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `silentRefresh does nothing when state is already Loading`() = runTest(testDispatcher) {
+        val list = UserList("list1", "My Spellbook", UserList.Type.SPELL, listOf(spell.id))
+        userListRepository.save(list)
+
+        val viewModel = buildViewModel("list1")
+
+        assertIs<ListDetailState.Body.Loading>(viewModel.state.value.body)
+
+        viewModel.silentRefresh()
+
+        assertIs<ListDetailState.Body.Loading>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `renameList updates list name in state`() = runTest(testDispatcher) {
+        val list = UserList("list1", "Old Name", UserList.Type.SPELL, listOf(spell.id))
+        userListRepository.save(list)
+
+        val viewModel = buildViewModel("list1")
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.renameList("New Name")
+        advanceUntilIdle()
+
+        assertEquals(expected = "New Name", actual = viewModel.state.value.listName)
+    }
+
+    @Test
+    fun `renameList persists updated name to repository`() = runTest(testDispatcher) {
+        val list = UserList("list1", "Old Name", UserList.Type.SPELL, listOf(spell.id))
+        userListRepository.save(list)
+
+        val viewModel = buildViewModel("list1")
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.renameList("New Name")
+        advanceUntilIdle()
+
+        val savedList = userListRepository.get("list1")
+        assertEquals(expected = "New Name", actual = savedList?.name)
+    }
 
     @Test
     fun `onCleared commits pending removals that were never confirmed`() = runTest(testDispatcher) {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -222,13 +222,15 @@ class ListDetailViewModelTest {
 
         advanceUntilIdle()
 
+        val emittedBodies = mutableListOf<ListDetailState.Body<Spell>>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { emittedBodies.add(it.body) }
+        }
+
         viewModel.silentRefresh()
-
-        assertIs<ListDetailState.Body.WithData<Spell>>(viewModel.state.value.body)
-
         advanceUntilIdle()
 
-        assertIs<ListDetailState.Body.WithData<Spell>>(viewModel.state.value.body)
+        assertTrue(emittedBodies.none { it is ListDetailState.Body.Loading })
     }
 
     @Test

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -199,7 +199,7 @@ class UserListsViewModelTest {
     }
 
     @Test
-    fun `refresh updates state with fresh data without showing Loading`() = runTest(testDispatcher) {
+    fun `silentRefresh updates state with fresh data without showing Loading`() = runTest(testDispatcher) {
         val spellList = UserList("1", "Spellbook", UserList.Type.SPELL, emptyList())
         repository.save(spellList)
 
@@ -224,6 +224,17 @@ class UserListsViewModelTest {
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
         assertEquals(expected = 1, actual = body.lists.size)
         assertEquals(expected = "Updated Spellbook", actual = body.lists.first().name)
+    }
+
+    @Test
+    fun `silentRefresh does nothing when state is already Loading`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        assertIs<UserListsState.Body.Loading>(viewModel.state.value.body)
+
+        viewModel.silentRefresh()
+
+        assertIs<UserListsState.Body.Loading>(viewModel.state.value.body)
     }
 
     @Test

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -21,6 +21,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+private const val TEST_LIST_ID = "1"
+private const val LIST_NAME = "Name of the list"
+private const val UPDATED_LIST_NAME = "Updated name of the list"
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class UserListsViewModelTest {
 
@@ -83,12 +87,12 @@ class UserListsViewModelTest {
         }
 
         advanceUntilIdle()
-        viewModel.createList("Fighting spells")
+        viewModel.createList(LIST_NAME)
         advanceUntilIdle()
 
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
         assertEquals(expected = 1, actual = body.lists.size)
-        assertEquals(expected = "Fighting spells", actual = body.lists.first().name)
+        assertEquals(expected = LIST_NAME, actual = body.lists.first().name)
         assertEquals(expected = UserList.Type.SPELL, actual = body.lists.first().type)
     }
 
@@ -101,7 +105,7 @@ class UserListsViewModelTest {
         }
 
         advanceUntilIdle()
-        viewModel.createList("Fighting spells")
+        viewModel.createList(LIST_NAME)
         advanceUntilIdle()
 
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
@@ -121,7 +125,7 @@ class UserListsViewModelTest {
         }
 
         advanceUntilIdle()
-        viewModel.createList("Fighting spells")
+        viewModel.createList(LIST_NAME)
         advanceUntilIdle()
 
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
@@ -143,7 +147,7 @@ class UserListsViewModelTest {
         }
 
         advanceUntilIdle()
-        viewModel.createList("Fighting spells")
+        viewModel.createList(LIST_NAME)
         advanceUntilIdle()
 
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
@@ -165,7 +169,7 @@ class UserListsViewModelTest {
         }
 
         advanceUntilIdle()
-        viewModel.createList("Fighting spells")
+        viewModel.createList(LIST_NAME)
         advanceUntilIdle()
 
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
@@ -180,7 +184,7 @@ class UserListsViewModelTest {
 
     @Test
     fun `only lists matching the configured type are shown`() = runTest(testDispatcher) {
-        val spellList = UserList("1", "Spellbook", UserList.Type.SPELL, emptyList())
+        val spellList = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, emptyList())
         val itemList = UserList("2", "Artefacts", UserList.Type.MAGICAL_ITEM, emptyList())
         repository.save(spellList)
         repository.save(itemList)
@@ -200,7 +204,7 @@ class UserListsViewModelTest {
 
     @Test
     fun `silentRefresh updates state with fresh data without showing Loading`() = runTest(testDispatcher) {
-        val spellList = UserList("1", "Spellbook", UserList.Type.SPELL, emptyList())
+        val spellList = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, emptyList())
         repository.save(spellList)
 
         val viewModel = buildViewModel()
@@ -211,7 +215,7 @@ class UserListsViewModelTest {
 
         advanceUntilIdle()
 
-        val updatedList = spellList.copy(name = "Updated Spellbook")
+        val updatedList = spellList.copy(name = UPDATED_LIST_NAME)
         repository.save(updatedList)
 
         viewModel.silentRefresh()
@@ -223,7 +227,7 @@ class UserListsViewModelTest {
 
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
         assertEquals(expected = 1, actual = body.lists.size)
-        assertEquals(expected = "Updated Spellbook", actual = body.lists.first().name)
+        assertEquals(expected = UPDATED_LIST_NAME, actual = body.lists.first().name)
     }
 
     @Test
@@ -247,7 +251,7 @@ class UserListsViewModelTest {
         }
 
         advanceUntilIdle()
-        viewModel.createList("Spellbook")
+        viewModel.createList(LIST_NAME)
         advanceUntilIdle()
 
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -218,13 +218,15 @@ class UserListsViewModelTest {
         val updatedList = spellList.copy(name = UPDATED_LIST_NAME)
         repository.save(updatedList)
 
+        val emittedBodies = mutableListOf<UserListsState.Body>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { emittedBodies.add(it.body) }
+        }
+
         viewModel.silentRefresh()
-
-        // State must not be Loading during refresh
-        assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
-
         advanceUntilIdle()
 
+        assertTrue(emittedBodies.none { it is UserListsState.Body.Loading })
         val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
         assertEquals(expected = 1, actual = body.lists.size)
         assertEquals(expected = UPDATED_LIST_NAME, actual = body.lists.first().name)

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -69,14 +69,14 @@ The project enforces code formatting using **ktlint**.
 
 Use `StandardTestDispatcher` + `runTest`. Inject repositories via constructor; use in-memory fakes (`RamUserListRepository`, `SampleXxxRepository`).
 
-| Case | Description |
-|------|-------------|
-| Initial `Loading` state | Before coroutines have run |
-| `Error` state | When the repository throws |
-| Happy path `WithData` | Data loaded and displayed correctly |
-| `silentRefresh` reflects repo changes | After mutating the repo, `silentRefresh()` updates state |
-| `silentRefresh` does not show `Loading` | State does not regress to `Loading` during refresh |
-| `silentRefresh` no-op when `Loading` | Early call has no effect |
+| Case                                    | Description                                              |
+|-----------------------------------------|----------------------------------------------------------|
+| Initial `Loading` state                 | Before coroutines have run                               |
+| `Error` state                           | When the repository throws                               |
+| Happy path `WithData`                   | Data loaded and displayed correctly                      |
+| `silentRefresh` reflects repo changes   | After mutating the repo, `silentRefresh()` updates state |
+| `silentRefresh` does not show `Loading` | State does not regress to `Loading` during refresh       |
+| `silentRefresh` no-op when `Loading`    | Early call has no effect                                 |
 
 For ViewModels with mutations (delete, rename, add): test optimistic mutation, undo, commit, and repository persistence.
 

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -59,10 +59,44 @@ The project enforces code formatting using **ktlint**.
 
 ## 4. Testing
 
-- **Unit Tests**: Test pure business logic (Domain layer) and ViewModels in the `commonTest` source set.
-- **Coroutines Testing**: Use `runTest` and inject test dispatchers for predictable coroutine execution.
-- **UI Tests**: Test Compose UI components in isolation (if applicable via Android instrumented tests or Desktop UI tests).
-- Focus on behavior testing rather than implementation details.
+### Rules
+
+- Every ViewModel must have a test file in `composeApp/src/commonTest/`.
+- Every new public method on an existing ViewModel must be covered by at least one test.
+- Every bug fix must be accompanied by a regression test that fails before the fix and passes after.
+
+### ViewModel tests — required cases
+
+Use `StandardTestDispatcher` + `runTest`. Inject repositories via constructor; use in-memory fakes (`RamUserListRepository`, `SampleXxxRepository`).
+
+| Case | Description |
+|------|-------------|
+| Initial `Loading` state | Before coroutines have run |
+| `Error` state | When the repository throws |
+| Happy path `WithData` | Data loaded and displayed correctly |
+| `silentRefresh` reflects repo changes | After mutating the repo, `silentRefresh()` updates state |
+| `silentRefresh` does not show `Loading` | State does not regress to `Loading` during refresh |
+| `silentRefresh` no-op when `Loading` | Early call has no effect |
+
+For ViewModels with mutations (delete, rename, add): test optimistic mutation, undo, commit, and repository persistence.
+
+### Domain tests
+
+- Every filter predicate → `{Feature}FilterTest`, `{Feature}MatchesFilterTest`
+- Every bulk filter operation → `{Feature}ApplyFilterTest`
+- Every pure extension function → dedicated unit test
+
+### E2E tests (Maestro — to be set up)
+
+Happy paths and navigation flows live in `.maestro/flows/`. Priority flows:
+- Add item to list, navigate back, verify item appears
+- Swipe-to-delete with undo
+- Create list and rename it
+
+### What does NOT need tests
+
+- Pure layout composables — covered by Compose previews
+- `RouterImpl` — trivial delegation, covered indirectly by ViewModel tests
 
 ## 5. CI & Policies
 


### PR DESCRIPTION
## 📝 Description

Adds missing ViewModel test coverage and formalises the testing conventions so regressions like the untested `silentRefresh` cannot go unnoticed in future.

**Test additions (`test/viewmodel-silent-refresh` branch):**
- `UserListsViewModelTest`: rename existing refresh test to `silentRefresh`, add `silentRefresh does nothing when state is already Loading`
- `ListDetailViewModelTest`: add `silentRefresh reflects new items`, `silentRefresh does not transition to Loading`, `silentRefresh does nothing when Loading`, `renameList updates list name in state`, `renameList persists updated name to repository`
- `AddToListViewModelTest`: add `loadEntity reflects fresh list data when called again after repository changes`

**Documentation:**
- `AGENTS.md`: add explicit rule — all documentation, comments, commit messages, and PR descriptions must be written in English
- `KMP_CONVENTIONS.md §4`: replace vague bullet points with actionable rules (required ViewModel test cases table, domain test naming conventions, Maestro E2E guidance, explicit exclusions)

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed