### PR TITLE
build: sonar config, JVM target, wrapper and dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   kmp-tests:

--- a/cmp-ttrpg-companion/build.gradle.kts
+++ b/cmp-ttrpg-companion/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 sonar {
     properties {
-        property("sonar.projectKey", "cyrillrx_ttrpg-companion")
+        property("sonar.projectKey", "cyrillrx_ttrpg-companion_client-cmp")
         property("sonar.organization", "cyrillrx")
         property("sonar.host.url", "https://sonarcloud.io")
         property(

--- a/cmp-ttrpg-companion/buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/cmp-ttrpg-companion/buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/cmp-ttrpg-companion/composeApp/build.gradle.kts
+++ b/cmp-ttrpg-companion/composeApp/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
+            jvmTarget.set(JvmTarget.fromTarget(Version.java.majorVersion))
         }
     }
 

--- a/cmp-ttrpg-companion/gradle/libs.versions.toml
+++ b/cmp-ttrpg-companion/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
 kotlin = "2.3.20"
 ktlint = "14.2.0"
-agp = "9.0.1"
-compose-plugin = "1.10.1"
+agp = "9.1.0"
+compose-plugin = "1.10.3"
 kotlinx-coroutines-core = "1.10.2"
-kotlinx-serialization = "1.10.0"
+kotlinx-serialization = "1.11.0"
 kotlinx-datetime = "0.7.1"
 
-sqlDelight = "2.2.1"
+sqlDelight = "2.3.2"
 
-androidx-compose = "1.10.4"
+androidx-compose = "1.10.6"
 androidx-appcompat = "1.7.1"
-androidx-coreKtx = "1.17.0"
-androidx-activity-compose = "1.12.4"
-androidx-lifecycle = "2.9.6"
+androidx-coreKtx = "1.18.0"
+androidx-activity-compose = "1.13.0"
+androidx-lifecycle = "2.10.0"
 navigation3 = "1.0.0-alpha06"
 lifecycle-viewmodel-navigation3 = "2.10.0"
 

--- a/cmp-ttrpg-companion/gradle/libs.versions.toml
+++ b/cmp-ttrpg-companion/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.3.20"
 ktlint = "14.2.0"
-agp = "9.1.0"
+agp = "9.0.1"
 compose-plugin = "1.10.3"
 kotlinx-coroutines-core = "1.10.2"
 kotlinx-serialization = "1.11.0"

--- a/cmp-ttrpg-companion/gradle/libs.versions.toml
+++ b/cmp-ttrpg-companion/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ kotlinx-coroutines-core = "1.10.2"
 kotlinx-serialization = "1.10.0"
 kotlinx-datetime = "0.7.1"
 
-#ktor = "3.0.0"
 sqlDelight = "2.2.1"
 
 androidx-compose = "1.10.4"

--- a/cmp-ttrpg-companion/gradle/wrapper/gradle-wrapper.properties
+++ b/cmp-ttrpg-companion/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Thu Mar 03 23:45:44 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/cmp-ttrpg-companion/shared/core/build.gradle.kts
+++ b/cmp-ttrpg-companion/shared/core/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
         compileSdk = Version.COMPILE_SDK
         minSdk = Version.MIN_SDK
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
+            jvmTarget.set(JvmTarget.fromTarget(Version.java.majorVersion))
         }
     }
 

--- a/spring-server/build.gradle.kts
+++ b/spring-server/build.gradle.kts
@@ -54,7 +54,7 @@ kotlin {
 
 sonar {
     properties {
-        property("sonar.projectKey", "cyrillrx_ttrpg-companion")
+        property("sonar.projectKey", "cyrillrx_ttrpg-companion_server-spring")
         property("sonar.organization", "cyrillrx")
         property("sonar.host.url", "https://sonarcloud.io")
         property(


### PR DESCRIPTION
## 📝 Description

This PR groups several build configuration improvements:

- `build(sonar)`: disambiguate SonarCloud project keys (`_client-cmp` / `_server-spring`) to separate client and server metrics
- `ci`: add `workflow_dispatch` trigger to manually run Sonar analysis on `main`
- `build`: use `Version.java` for JVM target in `composeApp` and `shared/core` instead of hardcoding `JVM_17`
- `build`: align both Gradle wrappers (`gradle/` and `buildSrc/gradle/`) on the same version (9.4.1) and add `networkTimeout` and `validateDistributionUrl`
- `build(deps)`: Compose plugin, kotlinx-serialization, SQLDelight, androidx-compose, core-ktx, activity-compose, lifecycle
- ci: add workflow_dispatch trigger

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed