### PR TITLE
test(e2e): add Maestro happy path flows and E2E test case doc

### DIFF
--- a/cmp-ttrpg-companion/.maestro/flows/UL-01_create-spell-list.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-01_create-spell-list.yaml
@@ -1,0 +1,21 @@
+appId: com.cyrillrx.rpg
+---
+- launchApp:
+    clearState: true
+
+# Navigate to My Spell Lists
+- tapOn:
+    text: "Spellbooks"
+
+# Open the create-list dialog
+- tapOn:
+    accessibilityText: "Create"
+- tapOn:
+    id: "input_list_name"
+- typeText: "My Test Spellbook"
+- tapOn:
+    text: "Create"
+
+# Verify the list appears in the Spellbooks screen
+- assertVisible:
+    text: "My Test Spellbook"

--- a/cmp-ttrpg-companion/.maestro/flows/UL-01_create-spell-list.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-01_create-spell-list.yaml
@@ -9,10 +9,10 @@ appId: com.cyrillrx.rpg
 
 # Open the create-list dialog
 - tapOn:
-    accessibilityText: "Create"
+    text: "Create"
 - tapOn:
     id: "input_list_name"
-- typeText: "My Test Spellbook"
+- inputText: "My Test Spellbook"
 - tapOn:
     text: "Create"
 

--- a/cmp-ttrpg-companion/.maestro/flows/UL-02_rename-spell-list.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-02_rename-spell-list.yaml
@@ -7,10 +7,10 @@ appId: com.cyrillrx.rpg
 - tapOn:
     text: "Spellbooks"
 - tapOn:
-    accessibilityText: "Create"
+    text: "Create"
 - tapOn:
     id: "input_list_name"
-- typeText: "My Test Spellbook"
+- inputText: "My Test Spellbook"
 - tapOn:
     text: "Create"
 
@@ -20,11 +20,11 @@ appId: com.cyrillrx.rpg
 
 # Rename the list
 - tapOn:
-    accessibilityText: "Rename"
+    text: "Rename"
 - tapOn:
     id: "input_list_name"
-- clearText
-- typeText: "Renamed Spellbook"
+- eraseText
+- inputText: "Renamed Spellbook"
 - tapOn:
     text: "Confirm"
 

--- a/cmp-ttrpg-companion/.maestro/flows/UL-02_rename-spell-list.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-02_rename-spell-list.yaml
@@ -1,0 +1,33 @@
+appId: com.cyrillrx.rpg
+---
+- launchApp:
+    clearState: true
+
+# Setup: create a list to rename
+- tapOn:
+    text: "Spellbooks"
+- tapOn:
+    accessibilityText: "Create"
+- tapOn:
+    id: "input_list_name"
+- typeText: "My Test Spellbook"
+- tapOn:
+    text: "Create"
+
+# Open the list detail
+- tapOn:
+    text: "My Test Spellbook"
+
+# Rename the list
+- tapOn:
+    accessibilityText: "Rename"
+- tapOn:
+    id: "input_list_name"
+- clearText
+- typeText: "Renamed Spellbook"
+- tapOn:
+    text: "Confirm"
+
+# Verify the updated name is shown in the top bar
+- assertVisible:
+    text: "Renamed Spellbook"

--- a/cmp-ttrpg-companion/.maestro/flows/UL-03_swipe-to-delete-with-undo.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-03_swipe-to-delete-with-undo.yaml
@@ -1,0 +1,35 @@
+appId: com.cyrillrx.rpg
+---
+- launchApp:
+    clearState: true
+
+# Navigate to My Spell Lists and create a list to delete
+- tapOn:
+    text: "Spellbooks"
+- tapOn:
+    accessibilityText: "Create"
+- tapOn:
+    id: "input_list_name"
+- typeText: "List to Delete"
+- tapOn:
+    text: "Create"
+- assertVisible:
+    text: "List to Delete"
+
+# Swipe LEFT (EndToStart) to trigger the optimistic delete
+- swipe:
+    direction: LEFT
+    from:
+      text: "List to Delete"
+
+# Snackbar with Undo should appear
+- assertVisible:
+    text: "Undo"
+
+# Tap Undo to restore the list
+- tapOn:
+    text: "Undo"
+
+# Verify the list is still visible
+- assertVisible:
+    text: "List to Delete"

--- a/cmp-ttrpg-companion/.maestro/flows/UL-03_swipe-to-delete-with-undo.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-03_swipe-to-delete-with-undo.yaml
@@ -7,10 +7,10 @@ appId: com.cyrillrx.rpg
 - tapOn:
     text: "Spellbooks"
 - tapOn:
-    accessibilityText: "Create"
+    text: "Create"
 - tapOn:
     id: "input_list_name"
-- typeText: "List to Delete"
+- inputText: "List to Delete"
 - tapOn:
     text: "Create"
 - assertVisible:
@@ -19,6 +19,7 @@ appId: com.cyrillrx.rpg
 # Swipe LEFT (EndToStart) to trigger the optimistic delete
 - swipe:
     direction: LEFT
+    duration: 100
     from:
       text: "List to Delete"
 

--- a/cmp-ttrpg-companion/.maestro/flows/UL-04_add-spell-to-list-and-verify.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-04_add-spell-to-list-and-verify.yaml
@@ -1,0 +1,46 @@
+appId: com.cyrillrx.rpg
+---
+- launchApp:
+    clearState: true
+
+# Step 1 – create a spell list from the home screen
+- tapOn:
+    text: "Spellbooks"
+- tapOn:
+    accessibilityText: "Create"
+- tapOn:
+    id: "input_list_name"
+- typeText: "My Spells"
+- tapOn:
+    text: "Create"
+- assertVisible:
+    text: "My Spells"
+- tapOn:
+    accessibilityText: "Back"
+
+# Step 2 – navigate to the Spellbook compendium
+- tapOn:
+    text: "Spellbook"
+
+# Step 3 – swipe RIGHT (StartToEnd) on the first spell to open the Add-to-List sheet
+# "Aspersion acide" is the first entry in grimoire.json (file order preserved, no sort)
+- swipe:
+    direction: RIGHT
+    from:
+      text: "Aspersion acide"
+
+# Step 4 – select the list and confirm
+- tapOn:
+    text: "My Spells"
+- tapOn:
+    text: "Confirm"
+
+# Step 5 – navigate back to home then into the list to verify the spell is there
+- tapOn:
+    accessibilityText: "Back"
+- tapOn:
+    text: "Spellbooks"
+- tapOn:
+    text: "My Spells"
+- assertVisible:
+    text: "Aspersion acide"

--- a/cmp-ttrpg-companion/.maestro/flows/UL-04_add-spell-to-list-and-verify.yaml
+++ b/cmp-ttrpg-companion/.maestro/flows/UL-04_add-spell-to-list-and-verify.yaml
@@ -7,16 +7,16 @@ appId: com.cyrillrx.rpg
 - tapOn:
     text: "Spellbooks"
 - tapOn:
-    accessibilityText: "Create"
+    text: "Create"
 - tapOn:
     id: "input_list_name"
-- typeText: "My Spells"
+- inputText: "My Spells"
 - tapOn:
     text: "Create"
 - assertVisible:
     text: "My Spells"
 - tapOn:
-    accessibilityText: "Back"
+    text: "Back"
 
 # Step 2 – navigate to the Spellbook compendium
 - tapOn:
@@ -26,6 +26,7 @@ appId: com.cyrillrx.rpg
 # "Aspersion acide" is the first entry in grimoire.json (file order preserved, no sort)
 - swipe:
     direction: RIGHT
+    duration: 100
     from:
       text: "Aspersion acide"
 
@@ -37,7 +38,7 @@ appId: com.cyrillrx.rpg
 
 # Step 5 – navigate back to home then into the list to verify the spell is there
 - tapOn:
-    accessibilityText: "Back"
+    text: "Back"
 - tapOn:
     text: "Spellbooks"
 - tapOn:

--- a/cmp-ttrpg-companion/androidApp/build.gradle.kts
+++ b/cmp-ttrpg-companion/androidApp/build.gradle.kts
@@ -44,3 +44,35 @@ dependencies {
     implementation(projects.composeApp)
     debugImplementation(libs.androidx.ui.tooling)
 }
+
+// Workaround: com.android.kotlin.multiplatform.library does not bundle Compose Resources into
+// the AAR, so androidApp copies them from composeApp's prepared resources output.
+// The CMP task copyAndroidMainComposeResourcesToAndroidAssets has no outputDirectory configured
+// for this plugin variant. See: https://youtrack.jetbrains.com/issue/CMP-7877
+//
+// Source: composeApp/build/generated/compose/resourceGenerator/preparedResources/commonMain/composeResources/
+// Destination: androidApp/build/generated/cmpResources/assets/composeResources/rpg_companion.composeapp.generated.resources/
+
+// Register the assets source dir at configuration time (static path required by the old SourceSet API).
+@Suppress("DEPRECATION")
+android.sourceSets.getByName("main").assets.srcDir(
+    projectDir.resolve("build/generated/cmpResources/assets"),
+)
+
+// Register the copy task and task dependencies after both projects are evaluated.
+afterEvaluate {
+    val cmpResourcesSrc = project(":composeApp").projectDir
+        .resolve("build/generated/compose/resourceGenerator/preparedResources/commonMain/composeResources")
+
+    val cmpResourcesDest = projectDir
+        .resolve("build/generated/cmpResources/assets/composeResources/rpg_companion.composeapp.generated.resources")
+
+    val copyCmpResourcesToAssets = tasks.register("copyCmpResourcesToAssets", Copy::class.java) {
+        dependsOn(":composeApp:prepareComposeResourcesTaskForCommonMain")
+        from(cmpResourcesSrc)
+        into(cmpResourcesDest)
+    }
+
+    tasks.named("mergeDebugAssets") { dependsOn(copyCmpResourcesToAssets) }
+    tasks.named("mergeReleaseAssets") { dependsOn(copyCmpResourcesToAssets) }
+}

--- a/cmp-ttrpg-companion/androidApp/build.gradle.kts
+++ b/cmp-ttrpg-companion/androidApp/build.gradle.kts
@@ -12,6 +12,7 @@ android {
     defaultConfig {
         applicationId = "com.cyrillrx.rpg"
         minSdk = Version.MIN_SDK
+        targetSdk = Version.COMPILE_SDK
         versionCode = 1
         versionName = "1.0"
     }

--- a/cmp-ttrpg-companion/androidApp/build.gradle.kts
+++ b/cmp-ttrpg-companion/androidApp/build.gradle.kts
@@ -60,19 +60,13 @@ android.sourceSets.getByName("main").assets.srcDir(
 )
 
 // Register the copy task and task dependencies after both projects are evaluated.
+val copyCmpResourcesToAssets = tasks.register("copyCmpResourcesToAssets", Copy::class.java) {
+    dependsOn(":composeApp:prepareComposeResourcesTaskForCommonMain")
+    from(project(":composeApp").layout.buildDirectory.dir("generated/compose/resourceGenerator/preparedResources/commonMain/composeResources"))
+    into(layout.buildDirectory.dir("generated/cmpResources/assets/composeResources/rpg_companion.composeapp.generated.resources"))
+}
+
 afterEvaluate {
-    val cmpResourcesSrc = project(":composeApp").projectDir
-        .resolve("build/generated/compose/resourceGenerator/preparedResources/commonMain/composeResources")
-
-    val cmpResourcesDest = projectDir
-        .resolve("build/generated/cmpResources/assets/composeResources/rpg_companion.composeapp.generated.resources")
-
-    val copyCmpResourcesToAssets = tasks.register("copyCmpResourcesToAssets", Copy::class.java) {
-        dependsOn(":composeApp:prepareComposeResourcesTaskForCommonMain")
-        from(cmpResourcesSrc)
-        into(cmpResourcesDest)
-    }
-
     tasks.named("mergeDebugAssets") { dependsOn(copyCmpResourcesToAssets) }
     tasks.named("mergeReleaseAssets") { dependsOn(copyCmpResourcesToAssets) }
 }

--- a/cmp-ttrpg-companion/composeApp/src/androidMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/androidMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
@@ -1,0 +1,11 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
+
+actual fun Modifier.accessibilityId(id: String): Modifier = semantics {
+    testTag = id
+    testTagsAsResourceId = true
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_custom_lists.xml
@@ -10,7 +10,8 @@
     <string name="title_my_bestiary_lists">Bestiaires</string>
     <string name="btn_my_bestiary_lists">Bestiaires</string>
 
-    <string name="btn_create_list">Nouvelle liste</string>
+    <string name="title_create_list">Nouvelle liste</string>
+    <string name="btn_create_list">Créer</string>
     <string name="btn_add_to_list">Ajouter à une liste</string>
     <string name="title_save_to_list">Sauvegarder dans...</string>
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_custom_lists.xml
@@ -10,7 +10,8 @@
     <string name="title_my_bestiary_lists">Bestiaries</string>
     <string name="btn_my_bestiary_lists">Bestiaries</string>
 
-    <string name="btn_create_list">New List</string>
+    <string name="title_create_list">New List</string>
+    <string name="btn_create_list">Create</string>
     <string name="btn_add_to_list">Add to a list</string>
     <string name="title_save_to_list">Save to...</string>
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
@@ -1,21 +1,15 @@
 package com.cyrillrx.rpg.core.presentation.component
 
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
-import androidx.compose.ui.semantics.testTagsAsResourceId
 
 /**
  * Sets an accessibility ID that Maestro (and other UI testing tools) can target with `id: "<id>"`.
  *
- * [Modifier.testTag] only exposes the tag to the Compose semantics testing framework.
- * Setting [testTagsAsResourceId] = true makes it visible in the Android accessibility tree as a resource ID,
- * which is what Maestro's `id:` selector queries.
+ * On Android, this exposes the tag as a resource ID in the accessibility tree via
+ * [testTagsAsResourceId]. On other platforms, it falls back to a plain testTag.
  *
- * Note: [androidx.compose.material3.AlertDialog] renders in a separate Android window, so this must be applied inside the dialog.
- * root-level semantics do not propagate across dialog boundaries.
+ * Note: [androidx.compose.material3.AlertDialog] renders in a separate Android window, so this
+ * must be applied inside the dialog - root-level semantics do not propagate across dialog
+ * boundaries.
  */
-fun Modifier.accessibilityId(id: String): Modifier = semantics {
-    testTag = id
-    testTagsAsResourceId = true
-}
+expect fun Modifier.accessibilityId(id: String): Modifier

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
@@ -1,0 +1,21 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
+
+/**
+ * Sets an accessibility ID that Maestro (and other UI testing tools) can target with `id: "<id>"`.
+ *
+ * [Modifier.testTag] only exposes the tag to the Compose semantics testing framework.
+ * Setting [testTagsAsResourceId] = true makes it visible in the Android accessibility tree as a resource ID,
+ * which is what Maestro's `id:` selector queries.
+ *
+ * Note: [androidx.compose.material3.AlertDialog] renders in a separate Android window, so this must be applied inside the dialog.
+ * root-level semantics do not propagate across dialog boundaries.
+ */
+fun Modifier.accessibilityId(id: String): Modifier = semantics {
+    testTag = id
+    testTagsAsResourceId = true
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
+import com.cyrillrx.rpg.core.presentation.component.accessibilityId
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_cancel
@@ -34,7 +34,7 @@ fun CreateListDialog(
                 onValueChange = { name = it },
                 placeholder = { Text(stringResource(Res.string.hint_list_name)) },
                 singleLine = true,
-                modifier = Modifier.testTag("input_list_name"),
+                modifier = Modifier.accessibilityId("input_list_name"),
             )
         },
         confirmButton = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
@@ -14,6 +14,7 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_cancel
 import rpg_companion.composeapp.generated.resources.btn_create_list
 import rpg_companion.composeapp.generated.resources.hint_list_name
+import rpg_companion.composeapp.generated.resources.title_create_list
 
 @Composable
 fun CreateListDialog(
@@ -24,7 +25,7 @@ fun CreateListDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.btn_create_list)) },
+        title = { Text(stringResource(Res.string.title_create_list)) },
         text = {
             TextField(
                 value = name,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_cancel
@@ -32,6 +34,7 @@ fun CreateListDialog(
                 onValueChange = { name = it },
                 placeholder = { Text(stringResource(Res.string.hint_list_name)) },
                 singleLine = true,
+                modifier = Modifier.testTag("input_list_name"),
             )
         },
         confirmButton = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_cancel
@@ -33,6 +35,7 @@ fun RenameListDialog(
                 onValueChange = { name = it },
                 placeholder = { Text(stringResource(Res.string.hint_list_name)) },
                 singleLine = true,
+                modifier = Modifier.testTag("input_list_name"),
             )
         },
         confirmButton = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
+import com.cyrillrx.rpg.core.presentation.component.accessibilityId
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_cancel
@@ -35,7 +35,7 @@ fun RenameListDialog(
                 onValueChange = { name = it },
                 placeholder = { Text(stringResource(Res.string.hint_list_name)) },
                 singleLine = true,
-                modifier = Modifier.testTag("input_list_name"),
+                modifier = Modifier.accessibilityId("input_list_name"),
             )
         },
         confirmButton = {

--- a/cmp-ttrpg-companion/composeApp/src/iosMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/iosMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
@@ -1,0 +1,6 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+actual fun Modifier.accessibilityId(id: String): Modifier = testTag(id)

--- a/cmp-ttrpg-companion/composeApp/src/jvmMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/jvmMain/kotlin/com/cyrillrx/rpg/core/presentation/component/ModifierExt.kt
@@ -1,0 +1,6 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+actual fun Modifier.accessibilityId(id: String): Modifier = testTag(id)

--- a/docs/conventions/KMP_CONVENTIONS.md
+++ b/docs/conventions/KMP_CONVENTIONS.md
@@ -86,12 +86,18 @@ For ViewModels with mutations (delete, rename, add): test optimistic mutation, u
 - Every bulk filter operation → `{Feature}ApplyFilterTest`
 - Every pure extension function → dedicated unit test
 
-### E2E tests (Maestro — to be set up)
+### E2E tests (Maestro)
 
-Happy paths and navigation flows live in `.maestro/flows/`. Priority flows:
-- Add item to list, navigate back, verify item appears
-- Swipe-to-delete with undo
-- Create list and rename it
+Test scenarios per feature are documented in [`docs/testing/E2E_TEST_CASES.md`](../../docs/testing/E2E_TEST_CASES.md).
+Automated flows live in `.maestro/flows/`.
+
+Run all flows (requires a connected Android device or emulator):
+
+```bash
+cd cmp-ttrpg-companion
+./gradlew installDebug
+maestro test .maestro/flows/
+```
 
 ### What does NOT need tests
 

--- a/docs/testing/E2E_TEST_CASES.md
+++ b/docs/testing/E2E_TEST_CASES.md
@@ -1,0 +1,49 @@
+# E2E Test Cases
+
+Functional test scenarios per feature, independent of tooling.
+Automated flows are implemented with Maestro in `cmp-ttrpg-companion/.maestro/flows/`.
+
+## User Lists
+
+| ID    | Scenario                                     | Success criterion                                 | Automated                                          |
+|-------|----------------------------------------------|---------------------------------------------------|----------------------------------------------------|
+| UL-01 | Create a spell list                          | The list appears in the Spellbooks screen         | ✅ `UL-01_create-spell-list.yaml`                 |
+| UL-02 | Rename a list from its detail screen         | The updated name is shown in the top bar          | ✅ `UL-02_rename-spell-list.yaml`                 |
+| UL-03 | Swipe to delete a list, then undo            | The list is restored after tapping Undo           | ✅ `UL-03_swipe-to-delete-with-undo.yaml`         |
+| UL-04 | Add a spell to a list, navigate back, verify | The spell appears in the list detail              | ✅ `UL-04_add-spell-to-list-and-verify.yaml`      |
+
+## Spellbook Compendium
+
+| ID    | Scenario             | Success criterion                              | Automated |
+|-------|----------------------|------------------------------------------------|-----------|
+| SP-01 | Browse spells        | Spell list is displayed                        | ❌        |
+| SP-02 | Search for a spell   | Results filtered to matching spells            | ❌        |
+| SP-03 | Open a spell detail  | Spell card shows name, school, description     | ❌        |
+
+## Bestiary Compendium
+
+| ID    | Scenario               | Success criterion                              | Automated |
+|-------|------------------------|------------------------------------------------|-----------|
+| BE-01 | Browse creatures       | Creature list is displayed                     | ❌        |
+| BE-02 | Open a creature detail | Creature card shows name and stats             | ❌        |
+
+## Magical Items Compendium
+
+| ID    | Scenario                   | Success criterion                              | Automated |
+|-------|----------------------------|------------------------------------------------|-----------|
+| MI-01 | Browse magical items       | Item list is displayed                         | ❌        |
+| MI-02 | Open a magical item detail | Item card shows name, rarity, description      | ❌        |
+
+## Campaigns
+
+| ID    | Scenario               | Success criterion                              | Automated |
+|-------|------------------------|------------------------------------------------|-----------|
+| CA-01 | Create a campaign      | Campaign appears in the list                   | ❌        |
+| CA-02 | Open a campaign detail | Campaign details are shown                     | ❌        |
+
+## Character Sheets
+
+| ID    | Scenario                | Success criterion                              | Automated |
+|-------|-------------------------|------------------------------------------------|-----------|
+| CS-01 | Create a character      | Character appears in the list                  | ❌        |
+| CS-02 | Open a character detail | Character details are shown                    | ❌        |


### PR DESCRIPTION
## 📝 Description

Sets up Maestro E2E testing for the CMP app with 4 flows covering the User Lists feature (create, rename, delete with undo, add spell).

Also introduces `docs/testing/E2E_TEST_CASES.md`, a tech-agnostic test case reference organized by feature, independent of the testing tool.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed