### PR TITLE
test(bruno): add compendium and health endpoint tests for Rust server

### DIFF
--- a/.github/workflows/ci-bruno.yml
+++ b/.github/workflows/ci-bruno.yml
@@ -1,0 +1,51 @@
+name: Bruno API Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['bruno/**', 'server-rust/**', 'data/compendium/**']
+  push:
+    branches: [main]
+    paths: ['bruno/**', 'server-rust/**', 'data/compendium/**']
+  workflow_dispatch:
+
+jobs:
+  bruno-tests:
+    name: Bruno - Compendium API Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust server
+        working-directory: server-rust
+        run: cargo build --release
+
+      - name: Start Rust server
+        working-directory: server-rust
+        run: ./target/release/server-rust &
+        env:
+          DATA_DIR: ../data/compendium
+
+      - name: Wait for server to be ready
+        run: until curl -sf http://localhost:3000/health; do sleep 1; done
+        timeout-minutes: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run Bruno tests
+        run: npx --yes @usebruno/cli run bruno/ --env local --reporter-junit results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bruno-test-results
+          path: results.xml

--- a/.github/workflows/ci-bruno.yml
+++ b/.github/workflows/ci-bruno.yml
@@ -21,6 +21,15 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            server-rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('server-rust/Cargo.lock') }}
+
       - name: Build Rust server
         working-directory: server-rust
         run: cargo build --release
@@ -41,11 +50,4 @@ jobs:
           node-version: '20'
 
       - name: Run Bruno tests
-        run: npx --yes @usebruno/cli run bruno/ --env local --reporter-junit results.xml
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: bruno-test-results
-          path: results.xml
+        run: npx --yes @usebruno/cli@1 run bruno/ --env local

--- a/.github/workflows/ci-bruno.yml
+++ b/.github/workflows/ci-bruno.yml
@@ -29,6 +29,8 @@ jobs:
             ~/.cargo/git
             server-rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('server-rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Build Rust server
         working-directory: server-rust
@@ -50,4 +52,4 @@ jobs:
           node-version: '20'
 
       - name: Run Bruno tests
-        run: npx --yes @usebruno/cli@1 run bruno/ --env local
+        run: npx --yes @usebruno/cli@1 run bruno/Server bruno/Compendium --env local

--- a/bruno/Compendium/Get Creatures.bru
+++ b/bruno/Compendium/Get Creatures.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Creatures
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:3000/compendium/creatures
+  body: none
+  auth: none
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  test("response is a non-empty array", function() {
+    expect(res.body).to.be.an('array').that.is.not.empty;
+  });
+}

--- a/bruno/Compendium/Get Creatures.bru
+++ b/bruno/Compendium/Get Creatures.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:3000/compendium/creatures
+  url: {{baseUrl}}/compendium/creatures
   body: none
   auth: none
 }

--- a/bruno/Compendium/Get Magical Items.bru
+++ b/bruno/Compendium/Get Magical Items.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Magical Items
+  type: http
+  seq: 3
+}
+
+get {
+  url: http://localhost:3000/compendium/magical-items
+  body: none
+  auth: none
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  test("response is a non-empty array", function() {
+    expect(res.body).to.be.an('array').that.is.not.empty;
+  });
+}

--- a/bruno/Compendium/Get Magical Items.bru
+++ b/bruno/Compendium/Get Magical Items.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:3000/compendium/magical-items
+  url: {{baseUrl}}/compendium/magical-items
   body: none
   auth: none
 }

--- a/bruno/Compendium/Get Spells.bru
+++ b/bruno/Compendium/Get Spells.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Spells
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:3000/compendium/spells
+  body: none
+  auth: none
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  test("response is a non-empty array", function() {
+    expect(res.body).to.be.an('array').that.is.not.empty;
+  });
+}

--- a/bruno/Compendium/Get Spells.bru
+++ b/bruno/Compendium/Get Spells.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:3000/compendium/spells
+  url: {{baseUrl}}/compendium/spells
   body: none
   auth: none
 }

--- a/bruno/Server/Health.bru
+++ b/bruno/Server/Health.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:3000/health
+  url: {{baseUrl}}/health
   body: none
   auth: none
 }

--- a/bruno/Server/Health.bru
+++ b/bruno/Server/Health.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Health
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:3000/health
+  body: none
+  auth: none
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://localhost:3000
+}


### PR DESCRIPTION
## 📝 Description

Adds Bruno API tests for the Rust server endpoints introduced in #72.

**New test files:**
- `bruno/Server/Health.bru` — `GET /health` → 200 OK
- `bruno/Compendium/Get Spells.bru` — `GET /compendium/spells` → 200 + non-empty array
- `bruno/Compendium/Get Creatures.bru` — `GET /compendium/creatures` → 200 + non-empty array
- `bruno/Compendium/Get Magical Items.bru` — `GET /compendium/magical-items` → 200 + non-empty array

URLs use `{{baseUrl}}` — configure the environment in Bruno to switch between local, staging, or Railway.

**Environment:**
- `bruno/environments/local.bru` — `baseUrl: http://localhost:3000`

## 🖼️ Media

```
bruno/
  environments/
    local.bru
  Server/
    Health.bru
  Compendium/
    Get Spells.bru
    Get Creatures.bru
    Get Magical Items.bru
```

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed