### PR TITLE
docs(adr): add ADR-001, SRD translation map, and data ingestion guide

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,14 +25,19 @@ For detailed feature specifications, see the [PRDs](prd/).
 *Requires: Reference Data - Browsing & Filtering*
 
 - [x] Local spell lists - [PRD-001a](prd/PRD-001a-SPELLBOOK.md)
-- [ ] Local item lists - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
-- [ ] Local bestiary lists - [PRD-001c](prd/PRD-001c-BESTIARY.md)
+- [x] Local item lists - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
+- [x] Local bestiary lists - [PRD-001c](prd/PRD-001c-BESTIARY.md)
 
 ## Phase 4 - Backend setup and sync engine
 
 > Fetch public reference data from the server and sync user lists. - [PRD-001](prd/PRD-001-REFERENCE-DATA.md)
 
-- [ ] Setup backend service with a simple API
+- [x] Setup backend service with a simple API
+- [ ] Data quality & coherence — DB-ready models, i18n, source tracking
+  - [x] Architecture decisions & SRD translation map ([ADR-001](adr/ADR-001-data-model.md), [i18n](i18n/srd-fr-en.md))
+  - [ ] Spells: structured components, concentration/ritual flags, complete class list
+  - [ ] Magical items: typed fields normalized
+  - [ ] Creatures: full stat block (speed, senses, skills, saving throws, damage affinities); character model coherence
 - [ ] Fetch public reference data from backend (spells, items, creatures)
 - [ ] Develop the sync engine on which will rely all sync logic and conflict resolution
 - [ ] Sync user lists with backend

--- a/docs/adr/ADR-001-data-model.md
+++ b/docs/adr/ADR-001-data-model.md
@@ -1,0 +1,284 @@
+# ADR-001: Compendium Data Model Decisions
+
+**Status**: Accepted  
+**Date**: 2026-04-26  
+**Context**: Phase 4 intermediate step — data quality & coherence, before backend consumption by clients.
+
+---
+
+## 1. Entity + Translations Pattern
+
+### Decision
+All compendium entities separate mechanical data from locale-specific text using a `translations` map.
+
+```json
+{
+  "id": "acid-splash",
+  "source": "srd_5.1",
+  "level": 0,
+  "school": "conjuration",
+  "translations": {
+    "fr": {
+      "name": "Aspersion acide",
+      "description": "<p>...</p>"
+    }
+  }
+}
+```
+
+### Rationale
+- Mechanical fields (level, school, CR, ability scores) are locale-independent and must not be duplicated per language.
+- Text fields (name, description, castingTime, range, duration) vary by language and must be cleanly separated for contributors to add translations.
+- The app is open-source: a contributor adding English translations should only need to add an `"en"` block, not restructure the entire entry.
+- This pattern is DB-ready: maps cleanly to a `spell` table + `spell_translation` table.
+
+### Translation Resolution Order
+Applied consistently in all repository implementations (KMP, backend):
+
+1. Requested locale (e.g., `"fr"`)
+2. Fallback to `"en"` if requested locale is absent
+3. If `"en"` is also absent, pick the first available locale sorted alphabetically
+4. If `translations` is empty → entity is malformed; log a warning and skip
+
+### i18n in Detail Views
+The API exposes the full `translations` map. Detail views display the active locale and allow the user to switch between available locales without a new network request.
+
+---
+
+## 2. Source Field
+
+### Decision
+Every entity has a `source` field — a single string identifying its origin.
+
+```json
+"source": "srd_5.1"
+```
+
+### Known Values
+| Value       | Description                                   |
+|-------------|-----------------------------------------------|
+| `srd_5.1`   | D&D 5e SRD 2014 (5.1)                         |
+| `srd_5.2`   | D&D 5e SRD 2024 (5.2)                         |
+| `phb_2014`  | Player's Handbook 2014                        |
+| `phb_2024`  | Player's Handbook 2024                        |
+| `tasha`     | Tasha's Cauldron of Everything                |
+| `xanathar`  | Xanathar's Guide to Everything                |
+| `fateforge` | Fateforge (Black Book Éditions)               |
+| `custom`    | User-created content                          |
+
+### Rationale
+- A single string is the simplest model that supports filtering by source and distinguishing official from user-created content.
+- Official supplements and core books are treated the same way — no distinction needed between "official SRD" and "supplement".
+- `isCustom: true` (present in the current raw data) is replaced by `source: "custom"`.
+- The model can be enriched later (e.g., adding author identity for UGC) without breaking existing data.
+
+---
+
+## 3. Lowercase English Enum Values in JSON
+
+### Decision
+All enum values in JSON source files and API responses use **lowercase English with underscores** (e.g., `"conjuration"`, `"wondrous_item"`, `"neutral_evil"`).
+
+### Rationale
+- Lowercase is idiomatic in JSON APIs and easier to read.
+- English is the canonical language for all mechanical keys and values — French content is confined to `translations.fr`.
+- Enum names in code (Kotlin, Rust, Go) remain `UPPER_CASE` as per each language's convention; the serialization layer handles case mapping transparently.
+
+### Serialization Convention Per Language
+- **Kotlin**: `@SerialName("conjuration")` on each enum entry, or a custom serializer
+- **Rust**: `#[serde(rename_all = "snake_case")]` on the enum
+- **Go**: lowercase string in JSON struct tags
+
+### Reference
+Complete FR↔EN mapping tables: [`docs/i18n/srd-fr-en.md`](../i18n/srd-fr-en.md)
+
+---
+
+## 4. Proficiency-Based Modifier Computation
+
+### Decision
+Numeric modifiers (skill check bonuses, saving throw bonuses) are **always computed at runtime**, never stored.
+
+### Formula
+```
+abilityModifier  = floor((abilityScore - 10) / 2)
+proficiencyBonus = derived from level (characters) or challengeRating (creatures)
+
+skillModifier    = abilityModifier                          (Proficiency.NONE)
+                 = abilityModifier + proficiencyBonus       (Proficiency.PROFICIENT)
+                 = abilityModifier + proficiencyBonus × 2   (Proficiency.EXPERT)
+```
+
+### Proficiency Bonus by CR / Level
+| CR or Level | Proficiency Bonus |
+|-------------|-------------------|
+| 0–4         | +2                |
+| 5–8         | +3                |
+| 9–12        | +4                |
+| 13–16       | +5                |
+| 17–20       | +6                |
+| 21+         | +7 (creatures only) |
+
+### Rationale
+- Storing pre-computed modifiers duplicates data derivable from ability scores and proficiency level.
+- Pre-computed values become inconsistent if scores change (custom creatures, character progression).
+- This matches the D&D 5e SRD design.
+
+---
+
+## 5. Saving Throw Proficiency Embedded in Ability
+
+### Decision
+Each `Ability` holds both the raw score and the saving throw proficiency for that ability. There is no separate `SavingThrows` class.
+
+```kotlin
+class Ability(
+    val value: Int,
+    val savingThrowProficiency: Proficiency = Proficiency.NONE,
+) {
+    val modifier: Int = getModifier(value)
+    // savingThrowModifier = modifier + proficiencyBonus (caller-provided)
+}
+```
+
+### Rationale
+- A saving throw is intrinsically tied to its ability (STR save uses STR modifier). Co-locating proficiency with the ability makes this relationship explicit.
+- Avoids a redundant parallel structure (an `Abilities` object + a `SavingThrows` object with identical keys).
+- Simplifies serialization: each ability entry in JSON carries both its score and its saving throw proficiency.
+
+---
+
+## 6. Bounded Object Pattern for Skills
+
+### Decision
+`Skills` is a data class with all 18 D&D 5e skills as **named properties** typed as `Proficiency`. No dynamic map or list.
+
+```kotlin
+data class Skills(
+    val acrobatics: Proficiency = Proficiency.NONE,
+    val arcana: Proficiency = Proficiency.NONE,
+    // ... all 18 skills
+)
+```
+
+### Rationale
+- The set of skills in D&D 5e is bounded and fixed (18 skills). A dynamic structure is unnecessary and error-prone.
+- Named properties give compile-time safety: a typo in a skill name is a compile error, not a silent null.
+- DB-ready: maps directly to columns without requiring a join table.
+
+### Skill → Ability Mapping (D&D 5e SRD)
+| Skill           | Ability |
+|-----------------|---------|
+| Athletics       | STR     |
+| Acrobatics      | DEX     |
+| Sleight of Hand | DEX     |
+| Stealth         | DEX     |
+| Arcana          | INT     |
+| History         | INT     |
+| Investigation   | INT     |
+| Nature          | INT     |
+| Religion        | INT     |
+| Animal Handling | WIS     |
+| Insight         | WIS     |
+| Medicine        | WIS     |
+| Perception      | WIS     |
+| Survival        | WIS     |
+| Deception       | CHA     |
+| Intimidation    | CHA     |
+| Performance     | CHA     |
+| Persuasion      | CHA     |
+
+---
+
+## 7. DamageAffinity Enum for Resistances and Immunities
+
+### Decision
+Damage affinities use a structured object with each damage type as a **named property** typed as `DamageAffinity`. Condition immunities use the same bounded pattern with `Boolean` properties.
+
+```kotlin
+enum class DamageAffinity { NONE, RESISTANT, IMMUNE, VULNERABLE }
+
+data class DamageAffinities(
+    val acid: DamageAffinity = DamageAffinity.NONE,
+    val bludgeoning: DamageAffinity = DamageAffinity.NONE,
+    val cold: DamageAffinity = DamageAffinity.NONE,
+    val fire: DamageAffinity = DamageAffinity.NONE,
+    val force: DamageAffinity = DamageAffinity.NONE,
+    val lightning: DamageAffinity = DamageAffinity.NONE,
+    val necrotic: DamageAffinity = DamageAffinity.NONE,
+    val piercing: DamageAffinity = DamageAffinity.NONE,
+    val poison: DamageAffinity = DamageAffinity.NONE,
+    val psychic: DamageAffinity = DamageAffinity.NONE,
+    val radiant: DamageAffinity = DamageAffinity.NONE,
+    val slashing: DamageAffinity = DamageAffinity.NONE,
+    val thunder: DamageAffinity = DamageAffinity.NONE,
+    val bludgeoningNonMagical: DamageAffinity = DamageAffinity.NONE,
+    val piercingNonMagical: DamageAffinity = DamageAffinity.NONE,
+    val slashingNonMagical: DamageAffinity = DamageAffinity.NONE,
+)
+
+data class ConditionImmunities(
+    val blinded: Boolean = false,
+    val charmed: Boolean = false,
+    val deafened: Boolean = false,
+    val exhaustion: Boolean = false,
+    val frightened: Boolean = false,
+    val grappled: Boolean = false,
+    val incapacitated: Boolean = false,
+    val paralyzed: Boolean = false,
+    val petrified: Boolean = false,
+    val poisoned: Boolean = false,
+    val prone: Boolean = false,
+    val restrained: Boolean = false,
+    val stunned: Boolean = false,
+    val unconscious: Boolean = false,
+)
+```
+
+### Rationale
+- A free list of strings allows contradictions (a creature cannot be both resistant and immune to the same damage type).
+- A single enum value per damage type is unambiguous.
+- DB-ready: each damage type maps to a column.
+
+---
+
+## 8. currentHitPoints Belongs Outside the Compendium Model
+
+### Decision
+`currentHitPoints` is **not** part of `Creature` or any compendium entity.
+
+### Rationale
+- Compendium entities are **reference data**: they describe a creature type (template), not a specific instance.
+- A single encounter may have multiple instances of the same creature type, each with independent current HP.
+- Tracking current HP belongs in a future **combat tracker** feature, using a `CombatInstance` entity referencing a `Creature` by ID.
+- For `PlayerCharacter` (Phase 5), `currentHitPoints` is appropriate because there is one persistent instance per character.
+
+---
+
+## 9. hitDice on Creature Only, Not BaseCreature
+
+### Decision
+`hitDice` (e.g., `"6d8+6"`) is a field on `Creature` only. It is **not** on `BaseCreature` and **not** on `PlayerCharacter`.
+
+For `PlayerCharacter`, hit dice are computed from `level` and `clazz.hitDie` — never stored.
+
+### Rationale
+- Storing `hitDice` on `PlayerCharacter` would create a redundant source of truth alongside `level` and `class`, with risk of inconsistency.
+- For creatures, `hitDice` cannot be derived (there is no fixed "class" for monsters), so it must be stored explicitly.
+- The D&D 5e SRD displays stat blocks as `"33 (6d8+6)"` — `maxHitPoints` is the average, `hitDice` is the formula used when rolling HP.
+
+### Hit Die Per Class (computed, never stored on PlayerCharacter)
+| Class     | Hit Die |
+|-----------|---------|
+| Barbarian | d12     |
+| Fighter   | d10     |
+| Paladin   | d10     |
+| Ranger    | d10     |
+| Bard      | d8      |
+| Cleric    | d8      |
+| Druid     | d8      |
+| Monk      | d8      |
+| Rogue     | d8      |
+| Warlock   | d8      |
+| Sorcerer  | d6      |
+| Wizard    | d6      |

--- a/docs/adr/ADR-001-data-model.md
+++ b/docs/adr/ADR-001-data-model.md
@@ -109,15 +109,7 @@ skillModifier    = abilityModifier                          (Proficiency.NONE)
                  = abilityModifier + proficiencyBonus × 2   (Proficiency.EXPERT)
 ```
 
-### Proficiency Bonus by CR / Level
-| CR or Level | Proficiency Bonus |
-|-------------|-------------------|
-| 0–4         | +2                |
-| 5–8         | +3                |
-| 9–12        | +4                |
-| 13–16       | +5                |
-| 17–20       | +6                |
-| 21+         | +7 (creatures only) |
+Proficiency bonus table (game rule): see [`docs/rules/dnd-5e.md`](../rules/dnd-5e.md).
 
 ### Rationale
 - Storing pre-computed modifiers duplicates data derivable from ability scores and proficiency level.

--- a/docs/adr/ADR-001-data-model.md
+++ b/docs/adr/ADR-001-data-model.md
@@ -55,16 +55,16 @@ Every entity has a `source` field — a single string identifying its origin.
 ```
 
 ### Known Values
-| Value       | Description                                   |
-|-------------|-----------------------------------------------|
-| `srd_5.1`   | D&D 5e SRD 2014 (5.1)                         |
-| `srd_5.2`   | D&D 5e SRD 2024 (5.2)                         |
-| `phb_2014`  | Player's Handbook 2014                        |
-| `phb_2024`  | Player's Handbook 2024                        |
-| `tasha`     | Tasha's Cauldron of Everything                |
-| `xanathar`  | Xanathar's Guide to Everything                |
-| `fateforge` | Fateforge (Black Book Éditions)               |
-| `custom`    | User-created content                          |
+| Value       | Description                             |
+|-------------|-----------------------------------------|
+| `srd_5.1`   | D&D 5e SRD 2014                         |
+| `srd_5.2`   | D&D 5e SRD 2024                         |
+| `phb_2014`  | Player's Handbook 2014                  |
+| `phb_2024`  | Player's Handbook 2024                  |
+| `tasha`     | Tasha's Cauldron of Everything          |
+| `xanathar`  | Xanathar's Guide to Everything          |
+| `fateforge` | Fateforge (Studio Agate)                |
+| `custom`    | User-created content                    |
 
 ### Rationale
 - A single string is the simplest model that supports filtering by source and distinguishing official from user-created content.
@@ -166,27 +166,7 @@ data class Skills(
 - Named properties give compile-time safety: a typo in a skill name is a compile error, not a silent null.
 - DB-ready: maps directly to columns without requiring a join table.
 
-### Skill → Ability Mapping (D&D 5e SRD)
-| Skill           | Ability |
-|-----------------|---------|
-| Athletics       | STR     |
-| Acrobatics      | DEX     |
-| Sleight of Hand | DEX     |
-| Stealth         | DEX     |
-| Arcana          | INT     |
-| History         | INT     |
-| Investigation   | INT     |
-| Nature          | INT     |
-| Religion        | INT     |
-| Animal Handling | WIS     |
-| Insight         | WIS     |
-| Medicine        | WIS     |
-| Perception      | WIS     |
-| Survival        | WIS     |
-| Deception       | CHA     |
-| Intimidation    | CHA     |
-| Performance     | CHA     |
-| Persuasion      | CHA     |
+Skill → ability mapping (game rule, not architecture): see [`docs/rules/dnd-5e.md`](../rules/dnd-5e.md).
 
 ---
 
@@ -267,18 +247,4 @@ For `PlayerCharacter`, hit dice are computed from `level` and `clazz.hitDie` —
 - For creatures, `hitDice` cannot be derived (there is no fixed "class" for monsters), so it must be stored explicitly.
 - The D&D 5e SRD displays stat blocks as `"33 (6d8+6)"` — `maxHitPoints` is the average, `hitDice` is the formula used when rolling HP.
 
-### Hit Die Per Class (computed, never stored on PlayerCharacter)
-| Class     | Hit Die |
-|-----------|---------|
-| Barbarian | d12     |
-| Fighter   | d10     |
-| Paladin   | d10     |
-| Ranger    | d10     |
-| Bard      | d8      |
-| Cleric    | d8      |
-| Druid     | d8      |
-| Monk      | d8      |
-| Rogue     | d8      |
-| Warlock   | d8      |
-| Sorcerer  | d6      |
-| Wizard    | d6      |
+Hit die per class (game rule): see [`docs/rules/dnd-5e.md`](../rules/dnd-5e.md).

--- a/docs/i18n/data-ingestion.md
+++ b/docs/i18n/data-ingestion.md
@@ -11,23 +11,11 @@ For the data model decisions behind these formats, see [`docs/adr/ADR-001-data-m
 
 - All enum values use **lowercase English with underscores** (e.g., `"conjuration"`, `"wondrous_item"`).
 - All keys are in English. French content belongs only inside `translations.fr`.
-- The `source` field identifies the origin of the entry. See [known source values](#known-source-values).
+- The `source` field identifies the origin of the entry — see [known source values](../adr/ADR-001-data-model.md#2-source-field).
 - Ability scores are **integers only** — never strings like `"15 (+2)"`.
 - Armor class is an **integer only** — the armor type belongs in the creature description.
 - No pre-computed modifiers — store scores and proficiency levels only.
 - An entity with an empty `translations` map is considered malformed.
-
-### Known Source Values
-| Value       | Description                             |
-|-------------|-----------------------------------------|
-| `srd_5.1`   | D&D 5e SRD 2014                         |
-| `srd_5.2`   | D&D 5e SRD 2024                         |
-| `phb_2014`  | Player's Handbook 2014                  |
-| `phb_2024`  | Player's Handbook 2024                  |
-| `tasha`     | Tasha's Cauldron of Everything          |
-| `xanathar`  | Xanathar's Guide to Everything          |
-| `fateforge` | Fateforge (Black Book Éditions)         |
-| `custom`    | User-created content                    |
 
 ---
 

--- a/docs/i18n/data-ingestion.md
+++ b/docs/i18n/data-ingestion.md
@@ -145,7 +145,7 @@ For the data model decisions behind these formats, see [`docs/adr/ADR-001-data-m
 
 ### Notes
 - `abilities`: raw integer scores only; `savingThrowProficiency` is `"proficient"` or `"expert"` when applicable
-- `skills`: all 18 keys required; only non-`none` values need to be set
+- `skills`: all 18 keys required (set to "none" if the creature is not proficient)
 - `senses`: only include present senses (distances in meters); omit null senses entirely
 - `damageAffinities`: only include non-`none` values; omit the rest
 - `conditionImmunities`: only include `true` values; omit the rest

--- a/docs/i18n/data-ingestion.md
+++ b/docs/i18n/data-ingestion.md
@@ -170,7 +170,6 @@ For the data model decisions behind these formats, see [`docs/adr/ADR-001-data-m
 - [ ] `senses` — only present senses, in meters
 - [ ] `damageAffinities` — see [Damage Affinities](srd-fr-en.md#damage-affinities)
 - [ ] `conditionImmunities` — see [Conditions](srd-fr-en.md#conditions)
-- [ ] `isCustom` — boolean
 - [ ] `translations.fr.name`
 - [ ] `translations.fr.languages` — array of strings
 - [ ] `translations.fr.description` — HTML

--- a/docs/i18n/data-ingestion.md
+++ b/docs/i18n/data-ingestion.md
@@ -1,0 +1,199 @@
+# Data Ingestion Guide
+
+Guide for contributors adding or migrating compendium data into the normalized JSON format.
+
+For the complete FR↔EN term mapping, see [`srd-fr-en.md`](srd-fr-en.md).  
+For the data model decisions behind these formats, see [`docs/adr/ADR-001-data-model.md`](../adr/ADR-001-data-model.md).
+
+---
+
+## General Rules
+
+- All enum values use **lowercase English with underscores** (e.g., `"conjuration"`, `"wondrous_item"`).
+- All keys are in English. French content belongs only inside `translations.fr`.
+- The `source` field identifies the origin of the entry. See [known source values](#known-source-values).
+- Ability scores are **integers only** — never strings like `"15 (+2)"`.
+- Armor class is an **integer only** — the armor type belongs in the creature description.
+- No pre-computed modifiers — store scores and proficiency levels only.
+- An entity with an empty `translations` map is considered malformed.
+
+### Known Source Values
+| Value       | Description                             |
+|-------------|-----------------------------------------|
+| `srd_5.1`   | D&D 5e SRD 2014                         |
+| `srd_5.2`   | D&D 5e SRD 2024                         |
+| `phb_2014`  | Player's Handbook 2014                  |
+| `phb_2024`  | Player's Handbook 2024                  |
+| `tasha`     | Tasha's Cauldron of Everything          |
+| `xanathar`  | Xanathar's Guide to Everything          |
+| `fateforge` | Fateforge (Black Book Éditions)         |
+| `custom`    | User-created content                    |
+
+---
+
+## Spell Entry Format
+
+```json
+{
+  "id": "acid-splash",
+  "source": "srd_5.1",
+  "level": 0,
+  "school": "conjuration",
+  "concentration": false,
+  "ritual": false,
+  "components": {
+    "verbal": true,
+    "somatic": true,
+    "material": false
+  },
+  "availableClasses": ["sorcerer", "wizard"],
+  "translations": {
+    "fr": {
+      "name": "Aspersion acide",
+      "castingTime": "1 action",
+      "range": "18 mètres",
+      "duration": "instantanée",
+      "materialDescription": null,
+      "description": "<p>...</p>"
+    }
+  }
+}
+```
+
+### Spell Checklist
+- [ ] `id` — slugified English name (e.g., `"acid-splash"`, `"fireball"`)
+- [ ] `source` — source string from known values
+- [ ] `level` — integer, `0` for cantrips
+- [ ] `school` — see [Spell Schools](srd-fr-en.md#spell-schools)
+- [ ] `concentration` — boolean; `true` if the spell requires concentration
+- [ ] `ritual` — boolean; `true` if the spell can be cast as a ritual
+- [ ] `components.verbal`, `components.somatic`, `components.material` — booleans
+- [ ] `availableClasses` — array; see [Character Classes](srd-fr-en.md#character-classes)
+- [ ] `translations.fr.name`
+- [ ] `translations.fr.castingTime`
+- [ ] `translations.fr.range`
+- [ ] `translations.fr.duration`
+- [ ] `translations.fr.materialDescription` — string or `null`
+- [ ] `translations.fr.description` — HTML
+
+---
+
+## Magical Item Entry Format
+
+```json
+{
+  "id": "amulet-of-health",
+  "source": "srd_5.1",
+  "type": "wondrous_item",
+  "rarity": "uncommon",
+  "attunement": true,
+  "translations": {
+    "fr": {
+      "name": "Amulette de cicatrisation",
+      "description": "<p>...</p>"
+    }
+  }
+}
+```
+
+### Notes
+- `attunement`: any non-null French source string (e.g., `"harmonisation requise"`) maps to `true`
+- The display subtitle (`"Objet merveilleux · Peu courant · Harmonisation"`) is computed by the client from typed fields — not stored
+
+### Item Checklist
+- [ ] `id` — slugified English name
+- [ ] `source` — source string from known values
+- [ ] `type` — see [Magical Item Types](srd-fr-en.md#magical-item-types)
+- [ ] `rarity` — see [Magical Item Rarities](srd-fr-en.md#magical-item-rarities)
+- [ ] `attunement` — boolean
+- [ ] `translations.fr.name`
+- [ ] `translations.fr.description` — HTML
+
+---
+
+## Creature Entry Format
+
+```json
+{
+  "id": "goblin",
+  "source": "srd_5.1",
+  "type": "humanoid",
+  "subtype": "goblinoid",
+  "size": "small",
+  "alignment": "neutral_evil",
+  "challengeRating": 0.25,
+  "armorClass": 15,
+  "maxHitPoints": 7,
+  "hitDice": "2d6",
+  "speed": { "walk": 9 },
+  "abilities": {
+    "str": { "value": 8,  "savingThrowProficiency": "none" },
+    "dex": { "value": 14, "savingThrowProficiency": "none" },
+    "con": { "value": 10, "savingThrowProficiency": "none" },
+    "int": { "value": 10, "savingThrowProficiency": "none" },
+    "wis": { "value": 8,  "savingThrowProficiency": "none" },
+    "cha": { "value": 8,  "savingThrowProficiency": "none" }
+  },
+  "skills": {
+    "acrobatics": "none", "animalHandling": "none", "arcana": "none",
+    "athletics": "none", "deception": "none", "history": "none",
+    "insight": "none", "intimidation": "none", "investigation": "none",
+    "medicine": "none", "nature": "none", "perception": "none",
+    "performance": "none", "persuasion": "none", "religion": "none",
+    "sleightOfHand": "none", "stealth": "proficient", "survival": "none"
+  },
+  "senses": { "darkvision": 18 },
+  "damageAffinities": {},
+  "conditionImmunities": {},
+  "isCustom": false,
+  "translations": {
+    "fr": {
+      "name": "Gobelin",
+      "languages": ["commun", "gobelin"],
+      "description": "<h2>Actions</h2><p>...</p>"
+    }
+  }
+}
+```
+
+### Notes
+- `abilities`: raw integer scores only; `savingThrowProficiency` is `"proficient"` or `"expert"` when applicable
+- `skills`: all 18 keys required; only non-`none` values need to be set
+- `senses`: only include present senses (distances in meters); omit null senses entirely
+- `damageAffinities`: only include non-`none` values; omit the rest
+- `conditionImmunities`: only include `true` values; omit the rest
+- `hitDice`: format is `"NdX"` or `"NdX+Y"` (e.g., `"2d6"`, `"6d8+6"`)
+- `languages` is locale-specific — stored in `translations`
+- `description` is locale-specific HTML containing traits, actions, reactions, legendary actions
+
+### Creature Checklist
+- [ ] `id` — slugified English or transliterated name
+- [ ] `source` — source string from known values
+- [ ] `type` — see [Creature Types](srd-fr-en.md#creature-types)
+- [ ] `subtype` — lowercase English string or omit if none
+- [ ] `size` — see [Creature Sizes](srd-fr-en.md#creature-sizes)
+- [ ] `alignment` — see [Alignments](srd-fr-en.md#alignments)
+- [ ] `challengeRating` — float (e.g., `0.25`, `0.5`, `1.0`, `20.0`)
+- [ ] `armorClass` — integer only (no armor type string)
+- [ ] `maxHitPoints` — integer (average)
+- [ ] `hitDice` — string (e.g., `"2d6"`, `"6d8+6"`)
+- [ ] `speed.walk` — integer in meters; add `swim`, `fly`, `climb`, `burrow` if applicable
+- [ ] `abilities.*` — each with integer `value` and `savingThrowProficiency`
+- [ ] `skills` — all 18 keys present
+- [ ] `senses` — only present senses, in meters
+- [ ] `damageAffinities` — see [Damage Affinities](srd-fr-en.md#damage-affinities)
+- [ ] `conditionImmunities` — see [Conditions](srd-fr-en.md#conditions)
+- [ ] `isCustom` — boolean
+- [ ] `translations.fr.name`
+- [ ] `translations.fr.languages` — array of strings
+- [ ] `translations.fr.description` — HTML
+
+---
+
+## Validation Rules
+
+- **No unknown fallback without documentation**: if a source value has no matching entry in the translation map, document it in [`srd-fr-en.md`](srd-fr-en.md) before adding it to the data file.
+- **Ability scores must be integers**: reject `"15 (+2)"` — store `15` only.
+- **AC must be an integer**: reject `"11 (armure de cuir)"` — store `11` only.
+- **Languages belong in `translations`**: never store language names as locale-independent data.
+- **No pre-computed modifiers**: store scores and proficiency levels; let the app compute bonuses.

--- a/docs/i18n/data-ingestion.md
+++ b/docs/i18n/data-ingestion.md
@@ -133,7 +133,6 @@ For the data model decisions behind these formats, see [`docs/adr/ADR-001-data-m
   "senses": { "darkvision": 18 },
   "damageAffinities": {},
   "conditionImmunities": {},
-  "isCustom": false,
   "translations": {
     "fr": {
       "name": "Gobelin",

--- a/docs/i18n/srd-fr-en.md
+++ b/docs/i18n/srd-fr-en.md
@@ -72,7 +72,7 @@ All JSON enum values use the **English key** column in lowercase with underscore
 | `paladin`    | Paladin    | Paladin               |
 | `ranger`     | Ranger     | Rôdeur                |
 | `rogue`      | Rogue      | Roublard              |
-| `sorcerer`   | Sorcerer   | Ensorceleur/Sorcelame |
+| `sorcerer`   | Sorcerer   | Ensorceleur           |
 | `warlock`    | Warlock    | Occultiste            |
 | `wizard`     | Wizard     | Magicien              |
 

--- a/docs/i18n/srd-fr-en.md
+++ b/docs/i18n/srd-fr-en.md
@@ -1,0 +1,255 @@
+# D&D 5e SRD — Translation Map
+
+Canonical mapping of D&D 5e SRD mechanical terms across languages.
+
+This document serves as a reference for:
+- **Data ingestion**: transforming source data into normalized JSON (see [`data-ingestion.md`](data-ingestion.md))
+- **Auto-translation assistance**: populating `translations.en` from `translations.fr` entries, or vice versa
+- **UI localization**: resolving display strings from JSON enum values in the app
+
+All JSON enum values use the **English key** column in lowercase with underscores (e.g., `"conjuration"`, `"humanoid"`).
+
+**SRD versions covered**: `srd_5.1` (2014) and `srd_5.2` (2024). Sections marked with a version apply to that version only; unmarked sections apply to both.
+
+---
+
+## Ability Scores
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key | Display EN   | Display FR    |
+|-------------|--------------|---------------|
+| `str`       | Strength     | Force         |
+| `dex`       | Dexterity    | Dextérité     |
+| `con`       | Constitution | Constitution  |
+| `int`       | Intelligence | Intelligence  |
+| `wis`       | Wisdom       | Sagesse       |
+| `cha`       | Charisma     | Charisme      |
+
+---
+
+## Proficiency Levels
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key  | Display EN | Display FR  |
+|--------------|------------|-------------|
+| `none`       | —          | —           |
+| `proficient` | Proficient | Maîtrise    |
+| `expert`     | Expertise  | Expertise   |
+
+---
+
+## Spell Schools
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key     | Display EN    | Display FR    |
+|-----------------|---------------|---------------|
+| `abjuration`    | Abjuration    | Abjuration    |
+| `conjuration`   | Conjuration   | Invocation    |
+| `divination`    | Divination    | Divination    |
+| `enchantment`   | Enchantment   | Enchantement  |
+| `evocation`     | Evocation     | Évocation     |
+| `illusion`      | Illusion      | Illusion      |
+| `necromancy`    | Necromancy    | Nécromancie   |
+| `transmutation` | Transmutation | Transmutation |
+
+---
+
+## Character Classes
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key  | Display EN | Display FR            |
+|--------------|------------|-----------------------|
+| `barbarian`  | Barbarian  | Barbare               |
+| `bard`       | Bard       | Barde                 |
+| `cleric`     | Cleric     | Clerc                 |
+| `druid`      | Druid      | Druide                |
+| `fighter`    | Fighter    | Guerrier              |
+| `monk`       | Monk       | Moine                 |
+| `paladin`    | Paladin    | Paladin               |
+| `ranger`     | Ranger     | Rôdeur                |
+| `rogue`      | Rogue      | Roublard              |
+| `sorcerer`   | Sorcerer   | Ensorceleur/Sorcelame |
+| `warlock`    | Warlock    | Occultiste            |
+| `wizard`     | Wizard     | Magicien              |
+
+---
+
+## Creature Types
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key   | Display EN  | Display FR              |
+|---------------|-------------|-------------------------|
+| `aberration`  | Aberration  | Aberration              |
+| `beast`       | Beast       | Bête                    |
+| `celestial`   | Celestial   | Céleste                 |
+| `construct`   | Construct   | Créature artificielle   |
+| `dragon`      | Dragon      | Dragon                  |
+| `elemental`   | Elemental   | Élémentaire             |
+| `fey`         | Fey         | Fée                     |
+| `fiend`       | Fiend       | Fiélon                  |
+| `giant`       | Giant       | Géant                   |
+| `humanoid`    | Humanoid    | Humanoïde               |
+| `monstrosity` | Monstrosity | Monstruosité            |
+| `ooze`        | Ooze        | Vase                    |
+| `plant`       | Plant       | Plante                  |
+| `undead`      | Undead      | Mort-vivant             |
+
+---
+
+## Creature Sizes
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key  | Display EN | Display FR   | FR code |
+|--------------|------------|--------------|---------|
+| `tiny`       | Tiny       | Très petite  | TP      |
+| `small`      | Small      | Petite       | P       |
+| `medium`     | Medium     | Moyenne      | M       |
+| `large`      | Large      | Grande       | G       |
+| `huge`       | Huge       | Très grande  | TG      |
+| `gargantuan` | Gargantuan | Gigantesque  | Gig     |
+
+---
+
+## Alignments
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key        | Display EN        | Display FR            |
+|--------------------|-------------------|-----------------------|
+| `lawful_good`      | Lawful Good       | Loyal bon             |
+| `lawful_neutral`   | Lawful Neutral    | Loyal neutre          |
+| `lawful_evil`      | Lawful Evil       | Loyal mauvais         |
+| `neutral_good`     | Neutral Good      | Neutre bon            |
+| `neutral`          | Neutral           | Neutre                |
+| `neutral_evil`     | Neutral Evil      | Neutre mauvais        |
+| `chaotic_good`     | Chaotic Good      | Chaotique bon         |
+| `chaotic_neutral`  | Chaotic Neutral   | Chaotique neutre      |
+| `chaotic_evil`     | Chaotic Evil      | Chaotique mauvais     |
+| `unaligned`        | Unaligned         | Sans alignement       |
+
+---
+
+## Magical Item Types
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key     | Display EN    | Display FR        |
+|-----------------|---------------|-------------------|
+| `armor`         | Armor         | Armure            |
+| `potion`        | Potion        | Potion            |
+| `ring`          | Ring          | Anneau            |
+| `rod`           | Rod           | Sceptre           |
+| `scroll`        | Scroll        | Parchemin         |
+| `staff`         | Staff         | Bâton             |
+| `wand`          | Wand          | Baguette          |
+| `weapon`        | Weapon        | Arme              |
+| `wondrous_item` | Wondrous Item | Objet merveilleux |
+
+---
+
+## Magical Item Rarities
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key  | Display EN | Display FR    |
+|--------------|------------|---------------|
+| `common`     | Common     | Courant       |
+| `uncommon`   | Uncommon   | Peu courant   |
+| `rare`       | Rare       | Rare          |
+| `very_rare`  | Very Rare  | Très rare     |
+| `legendary`  | Legendary  | Légendaire    |
+| `artifact`   | Artifact   | Artéfact      |
+
+---
+
+## Skills
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key      | Display EN      | Display FR      | Ability |
+|------------------|-----------------|-----------------|---------|
+| `athletics`      | Athletics       | Athlétisme      | STR     |
+| `acrobatics`     | Acrobatics      | Acrobaties      | DEX     |
+| `sleightOfHand`  | Sleight of Hand | Escamotage      | DEX     |
+| `stealth`        | Stealth         | Discrétion      | DEX     |
+| `arcana`         | Arcana          | Arcanes         | INT     |
+| `history`        | History         | Histoire        | INT     |
+| `investigation`  | Investigation   | Investigation   | INT     |
+| `nature`         | Nature          | Nature          | INT     |
+| `religion`       | Religion        | Religion        | INT     |
+| `animalHandling` | Animal Handling | Dressage        | WIS     |
+| `insight`        | Insight         | Intuition       | WIS     |
+| `medicine`       | Medicine        | Médecine        | WIS     |
+| `perception`     | Perception      | Perception      | WIS     |
+| `survival`       | Survival        | Survie          | WIS     |
+| `deception`      | Deception       | Tromperie       | CHA     |
+| `intimidation`   | Intimidation    | Intimidation    | CHA     |
+| `performance`    | Performance     | Représentation  | CHA     |
+| `persuasion`     | Persuasion      | Persuasion      | CHA     |
+
+---
+
+## Damage Types
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key               | Display EN                 | Display FR                  |
+|---------------------------|----------------------------|-----------------------------|
+| `acid`                    | Acid                       | Acide                       |
+| `bludgeoning`             | Bludgeoning                | Contondant                  |
+| `cold`                    | Cold                       | Froid                       |
+| `fire`                    | Fire                       | Feu                         |
+| `force`                   | Force                      | Force                       |
+| `lightning`               | Lightning                  | Foudre                      |
+| `necrotic`                | Necrotic                   | Nécrotique                  |
+| `piercing`                | Piercing                   | Perforant                   |
+| `poison`                  | Poison                     | Poison                      |
+| `psychic`                 | Psychic                    | Psychique                   |
+| `radiant`                 | Radiant                    | Radiant                     |
+| `slashing`                | Slashing                   | Tranchant                   |
+| `thunder`                 | Thunder                    | Tonnerre                    |
+| `bludgeoningNonMagical`   | Bludgeoning (non-magical)  | Contondant (non magique)    |
+| `piercingNonMagical`      | Piercing (non-magical)     | Perforant (non magique)     |
+| `slashingNonMagical`      | Slashing (non-magical)     | Tranchant (non magique)     |
+
+---
+
+## Damage Affinities
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key  | Display EN | Display FR    |
+|--------------|------------|---------------|
+| `none`       | —          | —             |
+| `resistant`  | Resistant  | Résistance    |
+| `immune`     | Immune     | Immunité      |
+| `vulnerable` | Vulnerable | Vulnérabilité |
+
+---
+
+## Conditions
+
+> Applies to: `srd_5.1`, `srd_5.2`
+
+| English key      | Display EN    | Display FR          |
+|------------------|---------------|---------------------|
+| `blinded`        | Blinded       | Aveuglé             |
+| `charmed`        | Charmed       | Charmé              |
+| `deafened`       | Deafened      | Assourdi            |
+| `exhaustion`     | Exhaustion    | Épuisement          |
+| `frightened`     | Frightened    | Effrayé             |
+| `grappled`       | Grappled      | Agrippé             |
+| `incapacitated`  | Incapacitated | Incapable d'agir    |
+| `paralyzed`      | Paralyzed     | Paralysé            |
+| `petrified`      | Petrified     | Pétrifié            |
+| `poisoned`       | Poisoned      | Empoisonné          |
+| `prone`          | Prone         | À terre             |
+| `restrained`     | Restrained    | Entravé             |
+| `stunned`        | Stunned       | Étourdi             |
+| `unconscious`    | Unconscious   | Inconscient         |

--- a/docs/i18n/srd-fr-en.md
+++ b/docs/i18n/srd-fr-en.md
@@ -172,26 +172,26 @@ All JSON enum values use the **English key** column in lowercase with underscore
 
 > Applies to: `srd_5.1`, `srd_5.2`
 
-| English key      | Display EN      | Display FR      | Ability |
-|------------------|-----------------|-----------------|---------|
-| `athletics`      | Athletics       | Athlétisme      | STR     |
-| `acrobatics`     | Acrobatics      | Acrobaties      | DEX     |
-| `sleightOfHand`  | Sleight of Hand | Escamotage      | DEX     |
-| `stealth`        | Stealth         | Discrétion      | DEX     |
-| `arcana`         | Arcana          | Arcanes         | INT     |
-| `history`        | History         | Histoire        | INT     |
-| `investigation`  | Investigation   | Investigation   | INT     |
-| `nature`         | Nature          | Nature          | INT     |
-| `religion`       | Religion        | Religion        | INT     |
-| `animalHandling` | Animal Handling | Dressage        | WIS     |
-| `insight`        | Insight         | Intuition       | WIS     |
-| `medicine`       | Medicine        | Médecine        | WIS     |
-| `perception`     | Perception      | Perception      | WIS     |
-| `survival`       | Survival        | Survie          | WIS     |
-| `deception`      | Deception       | Tromperie       | CHA     |
-| `intimidation`   | Intimidation    | Intimidation    | CHA     |
-| `performance`    | Performance     | Représentation  | CHA     |
-| `persuasion`     | Persuasion      | Persuasion      | CHA     |
+| English key      | Display EN      | Display FR      |
+|------------------|-----------------|-----------------|
+| `athletics`      | Athletics       | Athlétisme      |
+| `acrobatics`     | Acrobatics      | Acrobaties      |
+| `sleightOfHand`  | Sleight of Hand | Escamotage      |
+| `stealth`        | Stealth         | Discrétion      |
+| `arcana`         | Arcana          | Arcanes         |
+| `history`        | History         | Histoire        |
+| `investigation`  | Investigation   | Investigation   |
+| `nature`         | Nature          | Nature          |
+| `religion`       | Religion        | Religion        |
+| `animalHandling` | Animal Handling | Dressage        |
+| `insight`        | Insight         | Intuition       |
+| `medicine`       | Medicine        | Médecine        |
+| `perception`     | Perception      | Perception      |
+| `survival`       | Survival        | Survie          |
+| `deception`      | Deception       | Tromperie       |
+| `intimidation`   | Intimidation    | Intimidation    |
+| `performance`    | Performance     | Représentation  |
+| `persuasion`     | Persuasion      | Persuasion      |
 
 ---
 

--- a/docs/i18n/srd-fr-en.md
+++ b/docs/i18n/srd-fr-en.md
@@ -105,14 +105,14 @@ All JSON enum values use the **English key** column in lowercase with underscore
 
 > Applies to: `srd_5.1`, `srd_5.2`
 
-| English key  | Display EN | Display FR   | FR code |
-|--------------|------------|--------------|---------|
-| `tiny`       | Tiny       | Très petite  | TP      |
-| `small`      | Small      | Petite       | P       |
-| `medium`     | Medium     | Moyenne      | M       |
-| `large`      | Large      | Grande       | G       |
-| `huge`       | Huge       | Très grande  | TG      |
-| `gargantuan` | Gargantuan | Gigantesque  | Gig     |
+| English key  | Display EN | EN code | Display FR   | FR code |
+|--------------|------------|---------|--------------|---------|
+| `tiny`       | Tiny       | T       | Très petite  | TP      |
+| `small`      | Small      | S       | Petite       | P       |
+| `medium`     | Medium     | M       | Moyenne      | M       |
+| `large`      | Large      | L       | Grande       | G       |
+| `huge`       | Huge       | H       | Très grande  | TG      |
+| `gargantuan` | Gargantuan | G       | Gigantesque  | Gig     |
 
 ---
 

--- a/docs/rules/dnd-5e.md
+++ b/docs/rules/dnd-5e.md
@@ -1,0 +1,101 @@
+# D&D 5e — Rules Reference
+
+Game mechanics reference for D&D 5e (SRD 5.1 and 5.2).
+
+This document contains rules that drive computed values in the app — modifier formulas, proficiency tables, class hit dice. It is distinct from translations ([`docs/i18n/srd-fr-en.md`](../i18n/srd-fr-en.md)) and architecture decisions ([`docs/adr/ADR-001-data-model.md`](../adr/ADR-001-data-model.md)).
+
+---
+
+## Ability Score Modifier
+
+```
+modifier = floor((score - 10) / 2)
+```
+
+| Score | Modifier |
+|-------|----------|
+| 1     | -5       |
+| 2–3   | -4       |
+| 4–5   | -3       |
+| 6–7   | -2       |
+| 8–9   | -1       |
+| 10–11 | +0       |
+| 12–13 | +1       |
+| 14–15 | +2       |
+| 16–17 | +3       |
+| 18–19 | +4       |
+| 20–21 | +5       |
+| 22–23 | +6       |
+| 24–25 | +7       |
+| 26–27 | +8       |
+| 28–29 | +9       |
+| 30    | +10      |
+
+---
+
+## Proficiency Bonus
+
+Applies identically to characters (by level) and creatures (by challenge rating).
+
+| Level / CR | Proficiency Bonus |
+|------------|-------------------|
+| 0–4        | +2                |
+| 5–8        | +3                |
+| 9–12       | +4                |
+| 13–16      | +5                |
+| 17–20      | +6                |
+| 21+        | +7                |
+
+---
+
+## Skill Check Modifier
+
+```
+skillModifier = abilityModifier                          (Proficiency.NONE)
+              = abilityModifier + proficiencyBonus       (Proficiency.PROFICIENT)
+              = abilityModifier + proficiencyBonus × 2   (Proficiency.EXPERT)
+```
+
+### Skill → Ability Mapping
+
+| Skill           | Ability |
+|-----------------|---------|
+| Athletics       | STR     |
+| Acrobatics      | DEX     |
+| Sleight of Hand | DEX     |
+| Stealth         | DEX     |
+| Arcana          | INT     |
+| History         | INT     |
+| Investigation   | INT     |
+| Nature          | INT     |
+| Religion        | INT     |
+| Animal Handling | WIS     |
+| Insight         | WIS     |
+| Medicine        | WIS     |
+| Perception      | WIS     |
+| Survival        | WIS     |
+| Deception       | CHA     |
+| Intimidation    | CHA     |
+| Performance     | CHA     |
+| Persuasion      | CHA     |
+
+---
+
+## Hit Die Per Class
+
+Used to compute `hitDice` for `PlayerCharacter` (never stored, always derived from `level` and `class`).
+
+| Class     | Hit Die |
+|-----------|---------|
+| Barbarian | d12     |
+| Fighter   | d10     |
+| Paladin   | d10     |
+| Ranger    | d10     |
+| Bard      | d8      |
+| Cleric    | d8      |
+| Druid     | d8      |
+| Monk      | d8      |
+| Rogue     | d8      |
+| Warlock   | d8      |
+| Sorcerer  | d6      |
+| Wizard    | d6      |

--- a/docs/rules/dnd-5e.md
+++ b/docs/rules/dnd-5e.md
@@ -83,7 +83,7 @@ skillModifier = abilityModifier                          (Proficiency.NONE)
 
 ## Hit Die Per Class
 
-Used to compute `hitDice` for `PlayerCharacter` (never stored, always derived from `level` and `class`).
+A character's hit dice formula (e.g., `"6d8"` for a level-6 Cleric) is derived at runtime from `level × hitDie` — it is never stored.
 
 | Class     | Hit Die |
 |-----------|---------|


### PR DESCRIPTION
## 📝 Description

Establishes the architecture documentation for the data quality & coherence intermediate step (Phase 4), before implementing the normalized data models for spells, items, and creatures.

**Why this step exists**: before fetching data from the backend, the compendium data models need to be well-typed, DB-ready, multilingual, and coherent across all layers (KMP, Rust, Go). This PR documents the decisions that will guide the 3 following implementation PRs.

**Documents added**:
- `docs/adr/ADR-001-data-model.md`: 9 architecture decisions — entity+translations pattern, `source` field (single string), lowercase English enum values, proficiency-based modifier computation, saving throw proficiency embedded in `Ability`, bounded `Skills` object, `DamageAffinity` enum, `currentHitPoints` scope, `hitDice` on `Creature` only
- `docs/i18n/srd-fr-en.md`: canonical FR↔EN translation map for all D&D 5e SRD mechanical terms (schools, classes, creature types, sizes with EN+FR codes, alignments, item types, rarities, skills, damage types, conditions) — supports data ingestion, auto-translation, and UI localization
- `docs/i18n/data-ingestion.md`: contributor guide with normalized JSON formats, per-entity checklists, and validation rules for spells, items, and creatures
- `docs/rules/dnd-5e.md`: D&D 5e game rules reference — ability modifier formula, proficiency bonus table, skill→ability mapping, hit die per class. Kept separate from translations and architecture decisions to allow future addition of other game systems (Pathfinder, 7th Sea, etc.)
- `docs/ROADMAP.md`: data quality step added between "Setup backend" and "Fetch from backend"

**Design principles applied**:
- No duplication: source values table canonical in ADR-001, game rules in `rules/dnd-5e.md`, translations in `i18n/srd-fr-en.md`
- Translation map contains only translation data (Ability column removed from Skills table)
- Game rules kept separate from architecture decisions to support multi-system extensibility

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed