### PR TITLE
feat(magicalitem): data quality & i18n - normalized JSON, translations map, typed import errors

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -7,7 +7,7 @@
     <string name="btn_spell_book">Grimoire</string>
     <string name="btn_alternative_spell_book">Grimoire alternatif</string>
     <string name="btn_bestiary">Bestiaire</string>
-    <string name="btn_inventory">Objets magiques</string>
+    <string name="btn_magical_items">Objets magiques</string>
 
     <!-- Search -->
     <string name="hint_search_campaign">Oblivion, La chute de Londres, etc.</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -7,7 +7,7 @@
     <string name="btn_spell_book">Spellbook</string>
     <string name="btn_alternative_spell_book">Alternative Spellbook</string>
     <string name="btn_bestiary">Bestiary</string>
-    <string name="btn_inventory">Magical items</string>
+    <string name="btn_magical_items">Magical items</string>
 
     <!-- Search -->
     <string name="hint_search_campaign">Oblivion, The fall of London, etc.</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/CreatureItemProvider.kt
@@ -22,7 +22,7 @@ class CreatureItemProvider(
 
     override fun getId(entity: Creature): String = entity.id
 
-    override fun getDisplayName(entity: Creature): String = entity.name
+    override fun getDisplayName(entity: Creature, locale: String): String = entity.name
 
     @Composable
     override fun ListItem(entity: Creature, modifier: Modifier) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -27,7 +27,7 @@ import rpg_companion.composeapp.generated.resources.app_name
 import rpg_companion.composeapp.generated.resources.btn_bestiary
 import rpg_companion.composeapp.generated.resources.btn_campaign_list
 import rpg_companion.composeapp.generated.resources.btn_character_sheets
-import rpg_companion.composeapp.generated.resources.btn_inventory
+import rpg_companion.composeapp.generated.resources.btn_magical_items
 import rpg_companion.composeapp.generated.resources.btn_my_bestiary_lists
 import rpg_companion.composeapp.generated.resources.btn_my_item_lists
 import rpg_companion.composeapp.generated.resources.btn_my_spell_lists
@@ -72,7 +72,7 @@ fun HomeScreen(router: HomeRouter) {
                     modifier = Modifier.weight(1f),
                 )
                 IconLabelButton(
-                    label = stringResource(Res.string.btn_inventory),
+                    label = stringResource(Res.string.btn_magical_items),
                     icon = Icons.Filled.Diamond,
                     onClick = router::openMagicalItemCompendium,
                     modifier = Modifier.weight(1f),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemAddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemAddToListProvider.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -40,13 +41,14 @@ class MagicalItemAddToListProvider(
 
     @Composable
     override fun Header(entity: MagicalItem) {
+        val translation = entity.resolveTranslation(currentLocale())
         Column(
             verticalArrangement = Arrangement.spacedBy(spacingSmall),
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
-                text = entity.title,
+                text = translation.name,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
@@ -5,7 +5,6 @@ import androidx.compose.material.icons.outlined.Stars
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
@@ -23,8 +22,8 @@ class MagicalItemItemProvider(
 
     override fun getId(entity: MagicalItem): String = entity.id
 
-    override fun getDisplayName(entity: MagicalItem): String =
-        entity.resolveTranslation(currentLocale()).name
+    override fun getDisplayName(entity: MagicalItem, locale: String): String =
+        entity.resolveTranslation(locale).name
 
     @Composable
     override fun ListItem(entity: MagicalItem, modifier: Modifier) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemItemProvider.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.outlined.Stars
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
@@ -22,7 +23,8 @@ class MagicalItemItemProvider(
 
     override fun getId(entity: MagicalItem): String = entity.id
 
-    override fun getDisplayName(entity: MagicalItem): String = entity.title
+    override fun getDisplayName(entity: MagicalItem): String =
+        entity.resolveTranslation(currentLocale()).name
 
     @Composable
     override fun ListItem(entity: MagicalItem, modifier: Modifier) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
@@ -32,6 +33,7 @@ fun MagicalItemCard(
     magicalItem: MagicalItem,
     modifier: Modifier = Modifier,
 ) {
+    val translation = magicalItem.resolveTranslation(currentLocale())
     val color = magicalItem.getColor()
     Card(
         modifier = modifier
@@ -42,7 +44,7 @@ fun MagicalItemCard(
     ) {
         Column(Modifier.padding(borderStroke)) {
             Text(
-                text = magicalItem.title,
+                text = translation.name,
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold,
                 color = Color.White,
@@ -56,20 +58,22 @@ fun MagicalItemCard(
                         bottom = textPadding / 2,
                     ),
             )
-            Text(
-                text = magicalItem.subtitle,
-                fontSize = 14.sp,
-                fontStyle = FontStyle.Italic,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        start = textPadding,
-                        end = textPadding,
-                        top = textPadding,
-                    ),
-            )
+            translation.subtype?.let { subtype ->
+                Text(
+                    text = subtype,
+                    fontSize = 14.sp,
+                    fontStyle = FontStyle.Italic,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = textPadding,
+                            end = textPadding,
+                            top = textPadding,
+                        ),
+                )
+            }
             HtmlText(
-                text = magicalItem.description,
+                text = translation.description,
                 fontSize = 16.sp,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
@@ -34,6 +35,7 @@ fun MagicalItemListItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val translation = magicalItem.resolveTranslation(currentLocale())
     Card(
         onClick = onClick,
         shape = MaterialTheme.shapes.medium,
@@ -50,19 +52,21 @@ fun MagicalItemListItem(
                 modifier = Modifier.weight(1f),
             ) {
                 Text(
-                    text = magicalItem.title,
+                    text = translation.name,
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 
-                Text(
-                    text = magicalItem.subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                translation.subtype?.let { subtype ->
+                    Text(
+                        text = subtype,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.width(spacingMedium))

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/SpellItemProvider.kt
@@ -5,7 +5,6 @@ import androidx.compose.material.icons.outlined.MenuBook
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.component.SpellListItem
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
@@ -23,8 +22,8 @@ class SpellItemProvider(
 
     override fun getId(entity: Spell): String = entity.id
 
-    override fun getDisplayName(entity: Spell): String =
-        entity.resolveTranslation(currentLocale()).name
+    override fun getDisplayName(entity: Spell, locale: String): String =
+        entity.resolveTranslation(locale).name
 
     @Composable
     override fun ListItem(entity: Spell, modifier: Modifier) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/ListItemProvider.kt
@@ -15,7 +15,7 @@ interface ListItemProvider<T> {
     val onEmptyLayoutBtnClicked: () -> Unit get() = {}
 
     fun getId(entity: T): String
-    fun getDisplayName(entity: T): String
+    fun getDisplayName(entity: T, locale: String): String
 
     @Composable
     fun ListItem(entity: T, modifier: Modifier)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -41,6 +41,7 @@ import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
+import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -98,7 +99,7 @@ fun <T> ListDetailScreen(
         events.collect { event ->
             when (event) {
                 is ListDetailViewModel.Event.RemovalError -> {
-                    val displayName = itemProvider.getDisplayName(event.item)
+                    val displayName = itemProvider.getDisplayName(event.item, currentLocale())
                     val errorMessage = getString(Res.string.snackbar_error_removing_from_list, displayName)
                     snackbarHostState.showSnackbar(
                         message = errorMessage,
@@ -113,7 +114,7 @@ fun <T> ListDetailScreen(
         val pending = onRemoveItemOptimistically(itemProvider.getId(item), item) ?: return
 
         coroutineScope.launch {
-            val displayName = itemProvider.getDisplayName(item)
+            val displayName = itemProvider.getDisplayName(item, currentLocale())
             val removedMessage = getString(Res.string.snackbar_removed_from_list, displayName)
             val result = snackbarHostState.showSnackbar(
                 message = removedMessage,

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemDetailViewModelTest.kt
@@ -70,6 +70,6 @@ class MagicalItemDetailViewModelTest {
         val state = viewModel.state.value
         assertIs<DetailState.Found<MagicalItem>>(state)
         assertEquals(expected = item.id, actual = state.item.id)
-        assertEquals(expected = item.title, actual = state.item.title)
+        assertEquals(expected = item.translations, actual = state.item.translations)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -106,7 +106,7 @@ class MagicalItemListViewModelTest {
 
         advanceUntilIdle()
 
-        val itemName = requireNotNull(item.translations["en"]).name
+        val itemName = item.resolveTranslation("en").name
         viewModel.onSearchQueryChanged(itemName)
 
         advanceUntilIdle()
@@ -114,7 +114,7 @@ class MagicalItemListViewModelTest {
         val state = viewModel.state.value
         val body = assertIs<MagicalItemListState.Body.WithData>(state.body)
         assertEquals(expected = 1, actual = body.searchResults.size)
-        assertEquals(expected = itemName, actual = requireNotNull(body.searchResults.first().translations["en"]).name)
+        assertEquals(expected = itemName, actual = body.searchResults.first().resolveTranslation("en").name)
     }
 
     @Test

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -106,14 +106,15 @@ class MagicalItemListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.onSearchQueryChanged(item.title)
+        val itemName = requireNotNull(item.translations["en"]).name
+        viewModel.onSearchQueryChanged(itemName)
 
         advanceUntilIdle()
 
         val state = viewModel.state.value
         val body = assertIs<MagicalItemListState.Body.WithData>(state.body)
         assertEquals(expected = 1, actual = body.searchResults.size)
-        assertEquals(expected = item.title, actual = body.searchResults.first().title)
+        assertEquals(expected = itemName, actual = requireNotNull(body.searchResults.first().translations["en"]).name)
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
@@ -20,3 +20,17 @@ fun <T, Data, E : Error> List<T>.partitionBy(
 }
 
 fun <Data, E : Error> List<Result<Data, E>>.partition(): Pair<List<Data>, List<E>> = partitionBy { it }
+
+fun <K, V, NewV, E : Error> Map<K, V>.partitionBy(
+    transform: (K, V) -> Result<NewV, E>,
+): Pair<Map<K, NewV>, List<E>> {
+    val successes = mutableMapOf<K, NewV>()
+    val failures = mutableListOf<E>()
+    for ((key, value) in this) {
+        when (val result = transform(key, value)) {
+            is Result.Success -> successes[key] = result.value
+            is Result.Failure -> failures.add(result.error)
+        }
+    }
+    return successes to failures
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
@@ -4,3 +4,15 @@ sealed interface Result<out Data, out E : Error> {
     data class Success<out Data>(val value: Data) : Result<Data, Nothing>
     data class Failure<out E : Error>(val error: E) : Result<Nothing, E>
 }
+
+fun <Data, E : Error> List<Result<Data, E>>.partition(): Pair<List<Data>, List<E>> {
+    val successes = mutableListOf<Data>()
+    val failures = mutableListOf<E>()
+    for (result in this) {
+        when (result) {
+            is Result.Success -> successes.add(result.value)
+            is Result.Failure -> failures.add(result.error)
+        }
+    }
+    return successes to failures
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
@@ -19,5 +19,4 @@ fun <T, Data, E : Error> List<T>.partitionBy(
     return successes to failures
 }
 
-fun <Data, E : Error> List<Result<Data, E>>.partition(): Pair<List<Data>, List<E>> =
-    partitionBy { it }
+fun <Data, E : Error> List<Result<Data, E>>.partition(): Pair<List<Data>, List<E>> = partitionBy { it }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Result.kt
@@ -5,14 +5,19 @@ sealed interface Result<out Data, out E : Error> {
     data class Failure<out E : Error>(val error: E) : Result<Nothing, E>
 }
 
-fun <Data, E : Error> List<Result<Data, E>>.partition(): Pair<List<Data>, List<E>> {
+fun <T, Data, E : Error> List<T>.partitionBy(
+    transform: (T) -> Result<Data, E>,
+): Pair<List<Data>, List<E>> {
     val successes = mutableListOf<Data>()
     val failures = mutableListOf<E>()
-    for (result in this) {
-        when (result) {
+    for (item in this) {
+        when (val result = transform(item)) {
             is Result.Success -> successes.add(result.value)
             is Result.Failure -> failures.add(result.error)
         }
     }
     return successes to failures
 }
+
+fun <Data, E : Error> List<Result<Data, E>>.partition(): Pair<List<Data>, List<E>> =
+    partitionBy { it }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -14,10 +14,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     private var cache: List<MagicalItem>? = null
 
     override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
-        val allItems = cache ?: loadFromFile()
-            .map { it.toMagicalItem() }
-            .also { cache = it }
-
+        val allItems = cache ?: loadAndParse()
         return allItems.applyFilter(filter)
     }
 
@@ -29,6 +26,16 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
         return ids.mapNotNull { all[it] }
     }
 
+    private suspend fun loadAndParse(): List<MagicalItem> {
+        val apiItems = loadFromFile()
+        val results = apiItems.map { it.toMagicalItem() }
+
+        val failures = results.filterIsInstance<Result.Failure<MagicalItemImportError>>()
+        val successes = results.filterIsInstance<Result.Success<MagicalItem>>()
+        failures.forEach { println("WARNING: magical item import error: ${it.error}") }
+        return successes.map { it.value }.also { cache = it }
+    }
+
     private suspend fun loadFromFile(): List<ApiInventoryItem> {
         val result = fileReader.readFile("files/magical-items.json")
         if (result is Result.Success) {
@@ -38,44 +45,68 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     }
 
     companion object {
-        private fun ApiInventoryItem.toMagicalItem(): MagicalItem {
-            return MagicalItem(
-                id = title,
-                title = title,
-                subtitle = getSubtitle(),
-                description = content,
-                type = getType(),
-                rarity = getRarity(),
-                attunement = attunement != null,
+        private typealias ItemResult = Result<MagicalItem, MagicalItemImportError>
+
+        private fun ApiInventoryItem.toMagicalItem(): ItemResult {
+            val id = id
+                ?: return Result.Failure(MagicalItemImportError.MissingId)
+            val source = source
+                ?: return Result.Failure(MagicalItemImportError.MissingSource(id))
+            val apiType = type
+                ?: return Result.Failure(MagicalItemImportError.MissingType(id))
+            val type = apiType.toType()
+                ?: return Result.Failure(MagicalItemImportError.UnknownType(id, apiType))
+            val apiRarity = rarity
+                ?: return Result.Failure(MagicalItemImportError.MissingRarity(id))
+            val rarity = apiRarity.toRarity()
+                ?: return Result.Failure(MagicalItemImportError.UnknownRarity(id, apiRarity))
+            val apiTranslations = translations
+                ?: return Result.Failure(MagicalItemImportError.MissingTranslations(id))
+            val translations = apiTranslations
+                .mapNotNull { (locale, t) ->
+                    when (val result = t.toDomain(id, locale)) {
+                        is Result.Success -> locale to result.value
+                        is Result.Failure -> {
+                            println("WARNING: magical item import error: ${result.error}")
+                            null
+                        }
+                    }
+                }
+                .toMap()
+                .takeIf { it.isNotEmpty() }
+                ?: return Result.Failure(MagicalItemImportError.MissingTranslations(id))
+
+            return Result.Success(
+                MagicalItem(
+                    id = id,
+                    source = source,
+                    type = type,
+                    rarity = rarity,
+                    attunement = attunement ?: false,
+                    translations = translations,
+                )
             )
         }
 
-        private fun ApiInventoryItem.getSubtitle(): String {
-            val attunementString = attunement?.let { " ($attunement)" } ?: ""
-            return "$type, $rarity$attunementString"
+        private fun ApiInventoryItem.Translation.toDomain(
+            itemId: String,
+            locale: String,
+        ): Result<MagicalItem.Translation, MagicalItemImportError> {
+            val name = name ?: return Result.Failure(MagicalItemImportError.InvalidTranslation(itemId, locale))
+            val description = description ?: return Result.Failure(MagicalItemImportError.InvalidTranslation(itemId, locale))
+            return Result.Success(
+                MagicalItem.Translation(
+                    name = name,
+                    subtype = subtype,
+                    description = description,
+                )
+            )
         }
 
-        private fun ApiInventoryItem.getType(): MagicalItem.Type = when (type) {
-            "Armure" -> MagicalItem.Type.ARMOR
-            "Potion" -> MagicalItem.Type.POTION
-            "Anneau" -> MagicalItem.Type.RING
-            "Septre" -> MagicalItem.Type.ROD
-            "Parchemin" -> MagicalItem.Type.SCROLL
-            "Bâton" -> MagicalItem.Type.STAFF
-            "Baguette" -> MagicalItem.Type.WAND
-            "Arme" -> MagicalItem.Type.WEAPON
-            "Objet merveilleux" -> MagicalItem.Type.WONDROUS_ITEM
-            else -> MagicalItem.Type.WONDROUS_ITEM
-        }
+        private fun String.toType(): MagicalItem.Type? =
+            MagicalItem.Type.entries.find { it.name.equals(this, ignoreCase = true) }
 
-        private fun ApiInventoryItem.getRarity(): MagicalItem.Rarity = when (rarity) {
-            "Courant" -> MagicalItem.Rarity.COMMON
-            "Peu courant" -> MagicalItem.Rarity.UNCOMMON
-            "Rare" -> MagicalItem.Rarity.RARE
-            "Très rare" -> MagicalItem.Rarity.VERY_RARE
-            "Légendaire" -> MagicalItem.Rarity.LEGENDARY
-            "Artefact" -> MagicalItem.Rarity.ARTIFACT
-            else -> MagicalItem.Rarity.UNCOMMON
-        }
+        private fun String.toRarity(): MagicalItem.Rarity? =
+            MagicalItem.Rarity.entries.find { it.name.equals(this, ignoreCase = true) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -59,18 +59,11 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
                 ?: return Result.Failure(MagicalItemImportError.UnknownRarity(id, apiRarity))
             val apiTranslations = translations
                 ?: return Result.Failure(MagicalItemImportError.MissingTranslations(id))
-            val translations = apiTranslations
-                .mapNotNull { (locale, t) ->
-                    when (val result = t.toDomain(id, locale)) {
-                        is Result.Success -> locale to result.value
-                        is Result.Failure -> {
-                            println("WARNING: magical item import error: ${result.error}")
-                            null
-                        }
-                    }
-                }
-                .toMap()
-                .takeIf { it.isNotEmpty() }
+            val (translationMap, translationErrors) = apiTranslations.partitionBy { locale, t ->
+                t.toDomain(id, locale)
+            }
+            translationErrors.forEach { println("WARNING: magical item import error: $it") }
+            val translations = translationMap.takeIf { it.isNotEmpty() }
                 ?: return Result.Failure(MagicalItemImportError.MissingTranslations(id))
 
             return Result.Success(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.magicalitem.data
 import com.cyrillrx.core.data.FileReader
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
+import com.cyrillrx.core.domain.partition
 import com.cyrillrx.rpg.magicalitem.data.api.ApiMagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
@@ -27,13 +28,9 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     }
 
     private suspend fun loadAndParse(): List<MagicalItem> {
-        val apiItems = loadFromFile()
-        val results = apiItems.map { it.toMagicalItem() }
-
-        val failures = results.filterIsInstance<Result.Failure<MagicalItemImportError>>()
-        val successes = results.filterIsInstance<Result.Success<MagicalItem>>()
-        failures.forEach { println("WARNING: magical item import error: ${it.error}") }
-        return successes.map { it.value }.also { cache = it }
+        val (items, errors) = loadFromFile().map { it.toMagicalItem() }.partition()
+        errors.forEach { println("WARNING: magical item import error: $it") }
+        return items.also { cache = it }
     }
 
     private suspend fun loadFromFile(): List<ApiMagicalItem> {
@@ -45,9 +42,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     }
 
     companion object {
-        private typealias ItemResult = Result<MagicalItem, MagicalItemImportError>
-
-        private fun ApiMagicalItem.toMagicalItem(): ItemResult {
+        private fun ApiMagicalItem.toMagicalItem(): Result<MagicalItem, MagicalItemImportError> {
             val id = id
                 ?: return Result.Failure(MagicalItemImportError.MissingId)
             val source = source
@@ -84,7 +79,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
                     rarity = rarity,
                     attunement = attunement ?: false,
                     translations = translations,
-                )
+                ),
             )
         }
 
@@ -93,13 +88,14 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
             locale: String,
         ): Result<MagicalItem.Translation, MagicalItemImportError> {
             val name = name ?: return Result.Failure(MagicalItemImportError.InvalidTranslation(itemId, locale))
-            val description = description ?: return Result.Failure(MagicalItemImportError.InvalidTranslation(itemId, locale))
+            val description =
+                description ?: return Result.Failure(MagicalItemImportError.InvalidTranslation(itemId, locale))
             return Result.Success(
                 MagicalItem.Translation(
                     name = name,
                     subtype = subtype,
                     description = description,
-                )
+                ),
             )
         }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -15,7 +15,9 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     private var cache: List<MagicalItem>? = null
 
     override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
-        val allItems = cache ?: loadAndParse()
+        val allItems = cache ?: loadFromFile()
+            .parse()
+            .also { cache = it }
         return allItems.applyFilter(filter)
     }
 
@@ -27,12 +29,6 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
         return ids.mapNotNull { all[it] }
     }
 
-    private suspend fun loadAndParse(): List<MagicalItem> {
-        val (items, errors) = loadFromFile().partitionBy { it.toMagicalItem() }
-        errors.forEach { println("WARNING: magical item import error: $it") }
-        return items.also { cache = it }
-    }
-
     private suspend fun loadFromFile(): List<ApiMagicalItem> {
         val result = fileReader.readFile("files/magical-items.json")
         if (result is Result.Success) {
@@ -42,6 +38,12 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     }
 
     companion object {
+        private fun List<ApiMagicalItem>.parse(): List<MagicalItem> {
+            val (items, errors) = partitionBy { it.toMagicalItem() }
+            errors.forEach { println("WARNING: magical item import error: $it") }
+            return items
+        }
+
         private fun ApiMagicalItem.toMagicalItem(): Result<MagicalItem, MagicalItemImportError> {
             val id = id
                 ?: return Result.Failure(MagicalItemImportError.MissingId)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.magicalitem.data
 import com.cyrillrx.core.data.FileReader
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
-import com.cyrillrx.core.domain.partition
+import com.cyrillrx.core.domain.partitionBy
 import com.cyrillrx.rpg.magicalitem.data.api.ApiMagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
@@ -28,7 +28,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     }
 
     private suspend fun loadAndParse(): List<MagicalItem> {
-        val (items, errors) = loadFromFile().map { it.toMagicalItem() }.partition()
+        val (items, errors) = loadFromFile().partitionBy { it.toMagicalItem() }
         errors.forEach { println("WARNING: magical item import error: $it") }
         return items.also { cache = it }
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.magicalitem.data
 import com.cyrillrx.core.data.FileReader
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
-import com.cyrillrx.rpg.magicalitem.data.api.ApiInventoryItem
+import com.cyrillrx.rpg.magicalitem.data.api.ApiMagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
@@ -36,7 +36,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
         return successes.map { it.value }.also { cache = it }
     }
 
-    private suspend fun loadFromFile(): List<ApiInventoryItem> {
+    private suspend fun loadFromFile(): List<ApiMagicalItem> {
         val result = fileReader.readFile("files/magical-items.json")
         if (result is Result.Success) {
             return result.value.deserialize() ?: listOf()
@@ -47,7 +47,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
     companion object {
         private typealias ItemResult = Result<MagicalItem, MagicalItemImportError>
 
-        private fun ApiInventoryItem.toMagicalItem(): ItemResult {
+        private fun ApiMagicalItem.toMagicalItem(): ItemResult {
             val id = id
                 ?: return Result.Failure(MagicalItemImportError.MissingId)
             val source = source
@@ -88,7 +88,7 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
             )
         }
 
-        private fun ApiInventoryItem.Translation.toDomain(
+        private fun ApiMagicalItem.Translation.toDomain(
             itemId: String,
             locale: String,
         ): Result<MagicalItem.Translation, MagicalItemImportError> {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/MagicalItemImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/MagicalItemImportError.kt
@@ -1,0 +1,14 @@
+package com.cyrillrx.rpg.magicalitem.data
+
+import com.cyrillrx.core.domain.Error
+
+sealed interface MagicalItemImportError : Error {
+    data object MissingId : MagicalItemImportError
+    data class MissingSource(val id: String) : MagicalItemImportError
+    data class MissingType(val id: String) : MagicalItemImportError
+    data class UnknownType(val id: String, val raw: String) : MagicalItemImportError
+    data class MissingRarity(val id: String) : MagicalItemImportError
+    data class UnknownRarity(val id: String, val raw: String) : MagicalItemImportError
+    data class MissingTranslations(val id: String) : MagicalItemImportError
+    data class InvalidTranslation(val id: String, val locale: String) : MagicalItemImportError
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
@@ -29,83 +29,128 @@ class SampleMagicalItemRepository : MagicalItemRepository {
         fun getFirst(): MagicalItem = items.first()
 
         fun oathAxe() = MagicalItem(
-            id = "Oath Axe",
-            title = "Oath Axe",
-            subtitle = "Weapon (battleaxe), unique (requires attunement)",
-            description = "When you make a melee attack with this weapon, you can speak its command word. The target of your attack becomes your sworn enemy.",
+            id = "oath-axe",
+            source = "srd_5.1",
             type = MagicalItem.Type.WEAPON,
             rarity = MagicalItem.Rarity.RARE,
             attunement = true,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Oath Axe",
+                    subtype = null,
+                    description = "When you make a melee attack with this weapon, you can speak its command word. The target of your attack becomes your sworn enemy.",
+                ),
+            ),
         )
 
         fun healingPotion() = MagicalItem(
-            id = "Healing Potion",
-            title = "Healing Potion",
-            subtitle = "Potion, common",
-            description = "You regain 2d4 + 2 hit points when you drink this potion.",
+            id = "healing-potion",
+            source = "srd_5.1",
             type = MagicalItem.Type.POTION,
             rarity = MagicalItem.Rarity.COMMON,
             attunement = false,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Healing Potion",
+                    subtype = null,
+                    description = "You regain 2d4 + 2 hit points when you drink this potion.",
+                ),
+                "fr" to MagicalItem.Translation(
+                    name = "Potion de soin",
+                    subtype = null,
+                    description = "Vous récupérez 2d4 + 2 points de vie lorsque vous buvez cette potion.",
+                ),
+            ),
         )
 
         private fun cloakOfProtection() = MagicalItem(
-            id = "Cloak of Protection",
-            title = "Cloak of Protection",
-            subtitle = "Wondrous item, uncommon (requires attunement)",
-            description = "You gain a +1 bonus to AC and saving throws while you wear this cloak.",
+            id = "cloak-of-protection",
+            source = "srd_5.1",
             type = MagicalItem.Type.WONDROUS_ITEM,
             rarity = MagicalItem.Rarity.UNCOMMON,
             attunement = true,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Cloak of Protection",
+                    subtype = null,
+                    description = "You gain a +1 bonus to AC and saving throws while you wear this cloak.",
+                ),
+            ),
         )
 
         private fun shieldPlus1() = MagicalItem(
-            id = "Shield +1",
-            title = "Shield +1",
-            subtitle = "Armor (shield), uncommon",
-            description = "While holding this shield, you have a +1 bonus to AC in addition to the shield's normal bonus.",
+            id = "shield-plus-1",
+            source = "srd_5.1",
             type = MagicalItem.Type.ARMOR,
             rarity = MagicalItem.Rarity.UNCOMMON,
             attunement = false,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Shield +1",
+                    subtype = "shield",
+                    description = "While holding this shield, you have a +1 bonus to AC in addition to the shield's normal bonus.",
+                ),
+            ),
         )
 
         private fun wandOfFireballs() = MagicalItem(
-            id = "Wand of Fireballs",
-            title = "Wand of Fireballs",
-            subtitle = "Wand, rare (requires attunement by a spellcaster)",
-            description = "This wand has 7 charges. While holding it, you can use an action to expend 1 or more of its charges to cast the fireball spell.",
+            id = "wand-of-fireballs",
+            source = "srd_5.1",
             type = MagicalItem.Type.WAND,
             rarity = MagicalItem.Rarity.RARE,
             attunement = true,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Wand of Fireballs",
+                    subtype = null,
+                    description = "This wand has 7 charges. While holding it, you can use an action to expend 1 or more of its charges to cast the fireball spell.",
+                ),
+            ),
         )
 
         private fun ringOfProtection() = MagicalItem(
-            id = "Ring of Protection",
-            title = "Ring of Protection",
-            subtitle = "Ring, rare (requires attunement)",
-            description = "You gain a +1 bonus to AC and saving throws while wearing this ring.",
+            id = "ring-of-protection",
+            source = "srd_5.1",
             type = MagicalItem.Type.RING,
             rarity = MagicalItem.Rarity.RARE,
             attunement = true,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Ring of Protection",
+                    subtype = null,
+                    description = "You gain a +1 bonus to AC and saving throws while wearing this ring.",
+                ),
+            ),
         )
 
         private fun fireballScroll() = MagicalItem(
-            id = "Fireball Scroll",
-            title = "Fireball Scroll",
-            subtitle = "Scroll, uncommon",
-            description = "A fireball spell is written on this scroll. If the spell is on your class's spell list, you can cast it.",
+            id = "fireball-scroll",
+            source = "srd_5.1",
             type = MagicalItem.Type.SCROLL,
             rarity = MagicalItem.Rarity.UNCOMMON,
             attunement = false,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Fireball Scroll",
+                    subtype = null,
+                    description = "A fireball spell is written on this scroll. If the spell is on your class's spell list, you can cast it.",
+                ),
+            ),
         )
 
         private fun staffOfPower() = MagicalItem(
-            id = "Staff of Power",
-            title = "Staff of Power",
-            subtitle = "Staff, very rare (requires attunement by a spellcaster)",
-            description = "This staff grants a +2 bonus to attack and damage rolls made with it as a melee weapon.",
+            id = "staff-of-power",
+            source = "srd_5.1",
             type = MagicalItem.Type.STAFF,
             rarity = MagicalItem.Rarity.VERY_RARE,
             attunement = true,
+            translations = mapOf(
+                "en" to MagicalItem.Translation(
+                    name = "Staff of Power",
+                    subtype = null,
+                    description = "This staff grants a +2 bonus to attack and damage rolls made with it as a melee weapon.",
+                ),
+            ),
         )
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/api/ApiInventoryItem.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/api/ApiInventoryItem.kt
@@ -4,28 +4,17 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal class ApiInventoryItem(
-    val title: String,
-    val content: String,
-    val type: String,
-    val subtype: String?,
-    val rarity: String,
-    val attunement: String?,
-    val header: Header,
+    val id: String?,
+    val source: String?,
+    val type: String?,
+    val rarity: String?,
+    val attunement: Boolean?,
+    val translations: Map<String, Translation>?,
 ) {
     @Serializable
-    class Header(val magicitem: MagicalItem, val taxonomy: Taxonomy) {
-
-        @Serializable
-        class MagicalItem(
-            val type: String,
-            val rarity: String,
-            val attunement: String?,
-        )
-
-        @Serializable
-        class Taxonomy(
-            val category: Array<String>,
-            val source: Array<String>,
-        )
-    }
+    class Translation(
+        val name: String?,
+        val subtype: String?,
+        val description: String?,
+    )
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/api/ApiMagicalItem.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/api/ApiMagicalItem.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.magicalitem.data.api
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ApiInventoryItem(
+internal class ApiMagicalItem(
     val id: String?,
     val source: String?,
     val type: String?,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
@@ -2,16 +2,35 @@ package com.cyrillrx.rpg.magicalitem.domain
 
 import kotlinx.serialization.Serializable
 
+private const val FALLBACK_LOCALE = "en"
+
 @Serializable
 class MagicalItem(
     val id: String,
-    val title: String,
-    val subtitle: String,
-    val description: String,
+    val source: String,
     val type: Type,
     val rarity: Rarity,
     val attunement: Boolean,
+    val translations: Map<String, Translation>,
 ) {
+    init {
+        require(translations.isNotEmpty()) { "MagicalItem $id must have at least one translation" }
+    }
+
+    fun resolveTranslation(locale: String): Translation =
+        translations[locale]
+            ?: translations[FALLBACK_LOCALE]
+            ?: requireNotNull(translations.entries.minByOrNull { it.key }?.value) {
+                "MagicalItem $id has empty translations"
+            }
+
     enum class Type { ARMOR, POTION, RING, ROD, SCROLL, STAFF, WAND, WEAPON, WONDROUS_ITEM }
     enum class Rarity { COMMON, UNCOMMON, RARE, VERY_RARE, LEGENDARY, ARTIFACT }
+
+    @Serializable
+    data class Translation(
+        val name: String,
+        val subtype: String?,
+        val description: String,
+    )
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -16,13 +16,13 @@ fun List<MagicalItem>.applyFilter(filter: MagicalItemFilter?): List<MagicalItem>
 internal fun MagicalItem.matches(filter: MagicalItemFilter): Boolean {
     return (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.rarities.isEmpty() || filter.rarities.contains(rarity)) &&
-        (filter.query.isBlank() || matches(filter.query))
+        (filter.query.isBlank() || matchesQuery(filter.query))
 }
 
-private fun MagicalItem.matches(query: String): Boolean {
-    val trimmedQuery = query.trim()
-
-    return title.contains(trimmedQuery, ignoreCase = true) ||
-        subtitle.contains(trimmedQuery, ignoreCase = true) ||
-        description.contains(trimmedQuery, ignoreCase = true)
+private fun MagicalItem.matchesQuery(query: String): Boolean {
+    val trimmed = query.trim()
+    return translations.values.any { translation ->
+        translation.name.contains(trimmed, ignoreCase = true) ||
+            translation.description.contains(trimmed, ignoreCase = true)
+    }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.spell.data
 
 import com.cyrillrx.core.data.FileReader
 import com.cyrillrx.core.data.deserialize
+import com.cyrillrx.core.domain.Result
 import com.cyrillrx.core.domain.partitionBy
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.spell.data.api.ApiSpell
@@ -15,7 +16,9 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
     private var cache: List<Spell>? = null
 
     override suspend fun getAll(filter: SpellFilter?): List<Spell> {
-        val allSpells = cache ?: loadAndParse()
+        val allSpells = cache ?: loadFromFile()
+            .parse()
+            .also { cache = it }
         return allSpells.applyFilter(filter)
     }
 
@@ -27,12 +30,6 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
         return ids.mapNotNull { all[it] }
     }
 
-    private suspend fun loadAndParse(): List<Spell> {
-        val (spells, errors) = loadFromFile().partitionBy { it.toSpell() }
-        errors.forEach { println("WARNING: spell import error: $it") }
-        return spells.also { cache = it }
-    }
-
     private suspend fun loadFromFile(): List<ApiSpell> {
         val result = fileReader.readFile("files/spells.json")
         if (result is Result.Success) {
@@ -42,6 +39,12 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
     }
 
     companion object {
+        private fun List<ApiSpell>.parse(): List<Spell> {
+            val (spells, errors) = partitionBy { it.toSpell() }
+            errors.forEach { println("WARNING: spell import error: $it") }
+            return spells
+        }
+
         private fun ApiSpell.toSpell(): Result<Spell, SpellImportError> {
             val id = id
                 ?: return Result.Failure(SpellImportError.MissingId)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -2,8 +2,7 @@ package com.cyrillrx.rpg.spell.data
 
 import com.cyrillrx.core.data.FileReader
 import com.cyrillrx.core.data.deserialize
-import com.cyrillrx.core.domain.Result
-import com.cyrillrx.core.domain.partition
+import com.cyrillrx.core.domain.partitionBy
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.spell.data.api.ApiSpell
 import com.cyrillrx.rpg.spell.domain.Spell
@@ -29,7 +28,7 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
     }
 
     private suspend fun loadAndParse(): List<Spell> {
-        val (spells, errors) = loadFromFile().map { it.toSpell() }.partition()
+        val (spells, errors) = loadFromFile().partitionBy { it.toSpell() }
         errors.forEach { println("WARNING: spell import error: $it") }
         return spells.also { cache = it }
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.spell.data
 import com.cyrillrx.core.data.FileReader
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
+import com.cyrillrx.core.domain.partition
 import com.cyrillrx.rpg.character.domain.PlayerCharacter
 import com.cyrillrx.rpg.spell.data.api.ApiSpell
 import com.cyrillrx.rpg.spell.domain.Spell
@@ -19,22 +20,18 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
         return allSpells.applyFilter(filter)
     }
 
-    private suspend fun loadAndParse(): List<Spell> {
-        val apiSpells = loadFromFile()
-        val results = apiSpells.map { it.toSpell() }
-
-        val failures = results.filterIsInstance<Result.Failure<SpellImportError>>()
-        val successes = results.filterIsInstance<Result.Success<Spell>>()
-        failures.forEach { println("WARNING: spell import error: ${it.error}") }
-        return successes.map { it.value }.also { cache = it }
-    }
-
     override suspend fun getById(id: String): Spell? =
         getAll(null).firstOrNull { it.id == id }
 
     override suspend fun getByIds(ids: List<String>): List<Spell> {
         val all = getAll(null).associateBy { it.id }
         return ids.mapNotNull { all[it] }
+    }
+
+    private suspend fun loadAndParse(): List<Spell> {
+        val (spells, errors) = loadFromFile().map { it.toSpell() }.partition()
+        errors.forEach { println("WARNING: spell import error: $it") }
+        return spells.also { cache = it }
     }
 
     private suspend fun loadFromFile(): List<ApiSpell> {
@@ -46,9 +43,7 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
     }
 
     companion object {
-        private typealias SpellResult = Result<Spell, SpellImportError>
-
-        private fun ApiSpell.toSpell(): SpellResult {
+        private fun ApiSpell.toSpell(): Result<Spell, SpellImportError> {
             val id = id
                 ?: return Result.Failure(SpellImportError.MissingId)
             val source = source
@@ -105,11 +100,14 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
                     ),
                     availableClasses = availableClasses,
                     translations = translations,
-                )
+                ),
             )
         }
 
-        private fun ApiSpell.Translation.toDomain(spellId: String, locale: String): Result<Spell.Translation, SpellImportError> {
+        private fun ApiSpell.Translation.toDomain(
+            spellId: String,
+            locale: String,
+        ): Result<Spell.Translation, SpellImportError> {
             val name = name ?: return Result.Failure(SpellImportError.InvalidTranslation(spellId, locale))
             val castingTime = castingTime ?: return Result.Failure(SpellImportError.InvalidTranslation(spellId, locale))
             val range = range ?: return Result.Failure(SpellImportError.InvalidTranslation(spellId, locale))
@@ -123,7 +121,7 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
                     duration = duration,
                     materialDescription = materialDescription,
                     description = description,
-                )
+                ),
             )
         }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -63,28 +63,19 @@ class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository 
                 ?: return Result.Failure(SpellImportError.MissingComponents(id))
             val apiAvailableClasses = availableClasses
                 ?: return Result.Failure(SpellImportError.MissingAvailableClasses(id))
-            val availableClasses = apiAvailableClasses.mapNotNull { apiClass ->
-                val playerClass = apiClass.toPlayerClass()
-                if (playerClass == null) println("WARNING: spell '$id': unknown class '$apiClass'")
-                playerClass
+            val (availableClasses, classErrors) = apiAvailableClasses.partitionBy { apiClass ->
+                apiClass.toPlayerClass()?.let { Result.Success(it) }
+                    ?: Result.Failure(SpellImportError.UnknownClass(id, apiClass))
             }
-            if (availableClasses.isEmpty()) {
-                return Result.Failure(SpellImportError.EmptyAvailableClasses(id))
-            }
+            classErrors.forEach { println("WARNING: $it") }
+            if (availableClasses.isEmpty()) return Result.Failure(SpellImportError.EmptyAvailableClasses(id))
             val apiTranslations = translations
                 ?: return Result.Failure(SpellImportError.MissingTranslations(id))
-            val translations = apiTranslations
-                .mapNotNull { (locale, t) ->
-                    when (val result = t.toDomain(id, locale)) {
-                        is Result.Success -> locale to result.value
-                        is Result.Failure -> {
-                            println("WARNING: spell import error: ${result.error}")
-                            null
-                        }
-                    }
-                }
-                .toMap()
-                .takeIf { it.isNotEmpty() }
+            val (translationMap, translationErrors) = apiTranslations.partitionBy { locale, t ->
+                t.toDomain(id, locale)
+            }
+            translationErrors.forEach { println("WARNING: spell import error: $it") }
+            val translations = translationMap.takeIf { it.isNotEmpty() }
                 ?: return Result.Failure(SpellImportError.MissingTranslations(id))
 
             return Result.Success(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SpellImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SpellImportError.kt
@@ -10,6 +10,7 @@ sealed interface SpellImportError : Error {
     data class MissingRitual(val id: String) : SpellImportError
     data class MissingComponents(val id: String) : SpellImportError
     data class MissingAvailableClasses(val id: String) : SpellImportError
+    data class UnknownClass(val id: String, val raw: String) : SpellImportError
     data class EmptyAvailableClasses(val id: String) : SpellImportError
     data class MissingTranslations(val id: String) : SpellImportError
     data class InvalidTranslation(val id: String, val locale: String) : SpellImportError

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
@@ -4,9 +4,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-private object TestError : Error
-
 class MapPartitionByExtTest {
+    private object TestError : Error
 
     @Test
     fun `partitionBy all successes returns full map and empty errors`() {

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
@@ -47,4 +47,11 @@ class MapPartitionByExtTest {
         val (result, _) = input.partitionBy<String, String, String, Error> { _, v -> Result.Success(v.uppercase()) }
         assertEquals(expected = "VALUE", actual = result["locale"])
     }
+
+    @Test
+    fun `partitionBy preserves insertion order of input map`() {
+        val input = linkedMapOf("c" to 3, "a" to 1, "b" to 2)
+        val (result, _) = input.partitionBy<String, Int, Int, Error> { _, v -> Result.Success(v) }
+        assertEquals(expected = listOf("c", "a", "b"), actual = result.keys.toList())
+    }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
@@ -1,0 +1,50 @@
+package com.cyrillrx.core.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private object TestError : Error
+
+class MapPartitionByExtTest {
+
+    @Test
+    fun `partitionBy all successes returns full map and empty errors`() {
+        val input = mapOf("a" to 1, "b" to 2, "c" to 3)
+        val (result, errors) = input.partitionBy<String, Int, Int, Error> { _, v -> Result.Success(v * 10) }
+        assertEquals(expected = mapOf("a" to 10, "b" to 20, "c" to 30), actual = result)
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun `partitionBy all failures returns empty map and all errors`() {
+        val input = mapOf("a" to 1, "b" to 2)
+        val (result, errors) = input.partitionBy<String, Int, Int, Error> { _, _ -> Result.Failure(TestError) }
+        assertTrue(result.isEmpty())
+        assertEquals(expected = 2, actual = errors.size)
+    }
+
+    @Test
+    fun `partitionBy mixed results splits correctly`() {
+        val input = mapOf("a" to 1, "b" to 2, "c" to 3, "d" to 4)
+        val (result, errors) = input.partitionBy<String, Int, Int, Error> { _, v ->
+            if (v % 2 == 0) Result.Success(v) else Result.Failure(TestError)
+        }
+        assertEquals(expected = mapOf("b" to 2, "d" to 4), actual = result)
+        assertEquals(expected = 2, actual = errors.size)
+    }
+
+    @Test
+    fun `partitionBy empty map returns empty map and empty errors`() {
+        val (result, errors) = emptyMap<String, Int>().partitionBy<String, Int, Int, Error> { _, v -> Result.Success(v) }
+        assertTrue(result.isEmpty())
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun `partitionBy key is preserved in result map`() {
+        val input = mapOf("locale" to "value")
+        val (result, _) = input.partitionBy<String, String, String, Error> { _, v -> Result.Success(v.uppercase()) }
+        assertEquals(expected = "VALUE", actual = result["locale"])
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionByExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionByExtTest.kt
@@ -1,0 +1,43 @@
+package com.cyrillrx.core.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private object TestError : Error
+
+class PartitionByExtTest {
+
+    @Test
+    fun `partitionBy all successes returns all data and empty errors`() {
+        val input = listOf(1, 2, 3)
+        val (data, errors) = input.partitionBy<Int, Int, Error> { Result.Success(it * 10) }
+        assertEquals(expected = listOf(10, 20, 30), actual = data)
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun `partitionBy all failures returns empty data and all errors`() {
+        val input = listOf(1, 2, 3)
+        val (data, errors) = input.partitionBy<Int, Int, Error> { Result.Failure(TestError) }
+        assertTrue(data.isEmpty())
+        assertEquals(expected = 3, actual = errors.size)
+    }
+
+    @Test
+    fun `partitionBy mixed results splits correctly`() {
+        val input = listOf(1, 2, 3, 4)
+        val (data, errors) = input.partitionBy<Int, Int, Error> { n ->
+            if (n % 2 == 0) Result.Success(n) else Result.Failure(TestError)
+        }
+        assertEquals(expected = listOf(2, 4), actual = data)
+        assertEquals(expected = 2, actual = errors.size)
+    }
+
+    @Test
+    fun `partitionBy empty list returns two empty lists`() {
+        val (data, errors) = emptyList<Int>().partitionBy<Int, Int, Error> { Result.Success(it) }
+        assertTrue(data.isEmpty())
+        assertTrue(errors.isEmpty())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionByExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionByExtTest.kt
@@ -4,9 +4,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-private object TestError : Error
-
 class PartitionByExtTest {
+    private object TestError : Error
 
     @Test
     fun `partitionBy all successes returns all data and empty errors`() {

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionExtTest.kt
@@ -4,9 +4,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-private object TestError : Error
-
 class PartitionExtTest {
+    private object TestError : Error
 
     @Test
     fun `partition all successes returns all data and empty errors`() {

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/PartitionExtTest.kt
@@ -1,0 +1,52 @@
+package com.cyrillrx.core.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private object TestError : Error
+
+class PartitionExtTest {
+
+    @Test
+    fun `partition all successes returns all data and empty errors`() {
+        val results = listOf<Result<Int, Error>>(
+            Result.Success(1),
+            Result.Success(2),
+            Result.Success(3),
+        )
+        val (data, errors) = results.partition()
+        assertEquals(expected = listOf(1, 2, 3), actual = data)
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun `partition all failures returns empty data and all errors`() {
+        val results = listOf<Result<Int, Error>>(
+            Result.Failure(TestError),
+            Result.Failure(TestError),
+        )
+        val (data, errors) = results.partition()
+        assertTrue(data.isEmpty())
+        assertEquals(expected = 2, actual = errors.size)
+    }
+
+    @Test
+    fun `partition mixed results splits correctly`() {
+        val results = listOf<Result<Int, Error>>(
+            Result.Success(1),
+            Result.Failure(TestError),
+            Result.Success(3),
+        )
+        val (data, errors) = results.partition()
+        assertEquals(expected = listOf(1, 3), actual = data)
+        assertEquals(expected = 1, actual = errors.size)
+    }
+
+    @Test
+    fun `partition empty list returns two empty lists`() {
+        val (data, errors) = emptyList<Result<Int, Error>>().partition()
+        assertTrue(data.isEmpty())
+        assertTrue(errors.isEmpty())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemMatchesFilterTest.kt
@@ -54,14 +54,14 @@ class MagicalItemMatchesFilterTest {
     }
 
     @Test
-    fun `filter by text query matches subtitle`() {
-        val filter = MagicalItemFilter(query = "axe")
+    fun `filter by text query matches description`() {
+        val filter = MagicalItemFilter(query = "command word")
         assertTrue(oathAxe.matches(filter))
     }
 
     @Test
-    fun `filter by text query matches description`() {
-        val filter = MagicalItemFilter(query = "command word")
-        assertTrue(oathAxe.matches(filter))
+    fun `filter by text query matches name in translation`() {
+        val filter = MagicalItemFilter(query = "Potion de soin")
+        assertTrue(healingPotion.matches(filter))
     }
 }

--- a/data/compendium/magical-items.json
+++ b/data/compendium/magical-items.json
@@ -1,2171 +1,1150 @@
 [
-    {
-      "header": {
-        "title": "Amulette d'antidétection",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez cette amulette, vous êtes caché aux yeux de la magie de divination. Ce genre de magie ne peut plus vous prendre pour cible et ne vous perçoit plus à travers ses organes de scrutation magiques.</p>",
-      "link": "/liste-objets-magiques/amulette-dantidetection",
-      "title": "Amulette d'antidétection",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Amulette de cicatrisation",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce pendentif, vous vous stabilisez automatiquement au début de votre tour si vous êtes mourant. De plus, à chaque fois que vous lancez un dé de vie pour récupérer des points de vie, vous doublez le nombre de points de vie rendus.</p>",
-      "link": "/liste-objets-magiques/amulette-de-cicatrisation",
-      "title": "Amulette de cicatrisation",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Amulette de santé",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce pendentif, vous êtes immunisé contre toutes les maladies. Si vous êtes déjà malade, les effets de la maladie sont supprimés tant que vous portez l'amulette.</p>",
-      "link": "/liste-objets-magiques/amulette-de-sante",
-      "title": "Amulette de santé",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Anneau de chaleur",
-        "magicitem": {
-          "type": "Anneau",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous bénéficiez d'une résistance contre les dégâts de froid tant que vous portez cet anneau au doigt. De plus, vous et tout l'équipement que vous portez êtes protégés contre les températures extrêmement basses (jusque -10 degrés Celsius).</p>",
-      "link": "/liste-objets-magiques/anneau-de-chaleur",
-      "title": "Anneau de chaleur",
-      "type": "Anneau",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Anneau de marche sur l'eau",
-        "magicitem": {
-          "type": "Anneau",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous pouvez vous tenir debout sur toute surface liquide et vous déplacer dessus comme si elle était solide.</p>",
-      "link": "/liste-objets-magiques/anneau-de-marche-sur-leau",
-      "title": "Anneau de marche sur l'eau",
-      "type": "Anneau",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Anneau de nage",
-        "magicitem": {
-          "type": "Anneau",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous possédez une vitesse de déplacement à la nage de 12 mètres tant que vous portez cet anneau au doigt.</p>",
-      "link": "/liste-objets-magiques/anneau-de-nage",
-      "title": "Anneau de nage",
-      "type": "Anneau",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Anneau de protection mentale",
-        "magicitem": {
-          "type": "Anneau",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez cet anneau, vous êtes immunisé à la magie utilisée par d'autres créatures pour lire vos pensées, déterminer si vous mentez, connaître votre alignement ou le type de créature que vous êtes. Les créatures peuvent communiquer par télépathie avec vous seulement si vous les y autorisez.</p>\n<p>Vous pouvez utiliser une action pour que l'anneau devienne <a href=\"/gerer-la-sante-du-personnage#invisible\"><em>invisible</em></a> jusqu'à ce que vous utilisiez une autre action pour le rendre visible, que vous le retiriez ou que vous mourriez.</p>\n<p>Si vous perdez la vie avec l'anneau au doigt, votre âme se réfugie à l'intérieur, à moins qu'il ne contienne déjà une âme. Vous pouvez rester dans l'anneau ou vous en aller pour l'après-vie. Tant que votre âme est à l'intérieur de l'anneau, vous pouvez communiquer par télépathie avec la créature qui l'enfile. Un porteur ne peut pas empêcher cette communication télépathique.</p>",
-      "link": "/liste-objets-magiques/anneau-de-protection-mentale",
-      "title": "Anneau de protection mentale",
-      "type": "Anneau",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Anneau de saut",
-        "magicitem": {
-          "type": "Anneau",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous pouvez lancer le sort de <a href=\"/grimoire/saut\"><em>saut</em></a>, à volonté et par une action bonus, tant que vous portez cet anneau au doigt. Seul vous bénéficiez des effets de ce sort.</p>",
-      "link": "/liste-objets-magiques/anneau-de-saut",
-      "title": "Anneau de saut",
-      "type": "Anneau",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Arme +1",
-        "magicitem": {
-          "type": "Arme",
-          "subtype": "N'importe quelle arme",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>",
-      "link": "/liste-objets-magiques/arme-1",
-      "title": "Arme +1",
-      "type": "Arme",
-      "subtype": "N'importe quelle arme",
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Armure de mithral",
-        "magicitem": {
-          "type": "Armure",
-          "subtype": "Intermédiaire ou lourde mais pas en peau",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Le mithral est un métal léger et flexible, à tel point qu'on peut porter une chemise de mailles ou une cuirasse de cette matière sous des vêtements normaux. Si le type d'armure impose d'ordinaire un <a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>désavantage</em></a> lors des tests de Dextérité (Discrétion) ou si une certaine valeur de Force figure parmi ses conditions requises, ce n'est pas le cas de sa version en mithral.</p>",
-      "link": "/liste-objets-magiques/armure-de-mithral",
-      "title": "Armure de mithral",
-      "type": "Armure",
-      "subtype": "Intermédiaire ou lourde mais pas en peau",
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Armure en adamantium",
-        "magicitem": {
-          "type": "Armure",
-          "subtype": "Intermédiaire ou lourde, mais pas en peau",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette armure est renforcée à base d'adamantium, l'une des substances les plus solides au monde. Tant que vous la portez, tous les coups critiques réussis contre vous se muent en coups normaux.</p>",
-      "link": "/liste-objets-magiques/armure-en-adamantium",
-      "title": "Armure en adamantium",
-      "type": "Armure",
-      "subtype": "Intermédiaire ou lourde, mais pas en peau",
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Baguette de détection de la magie",
-        "magicitem": {
-          "type": "Baguette",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette baguette contient 3 charges. Avec cette baguette en main, vous pouvez dépenser 1 charge par une action pour lancer le sort <a href=\"/grimoire/detection-de-la-magie\">détection de la magie</a> par son biais. La baguette récupère 1d3 charges dépensées chaque jour, à l'aube.</p>",
-      "link": "/liste-objets-magiques/baguette-de-detection-de-la-magie",
-      "title": "Baguette de détection de la magie",
-      "type": "Baguette",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Baguette de projectiles magiques",
-        "magicitem": {
-          "type": "Baguette",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette baguette contient 7 charges. Avec cette baguette en main, vous pouvez utiliser une action pour dépenser 1 ou plusieurs charges et lancer le sort de <a href=\"/grimoire/projectile-magique\"><em>projectile magique</em></a> par son biais. Pour 1 charge, vous lancez la version de niveau 1 de ce sort. Vous pouvez augmenter de un le niveau de l'emplacement du sort pour chaque charge supplémentaire que vous dépensez.</p>\n<p>La baguette récupère 1d6+1 charges dépensées chaque jour, à l'aube. Lancez un d20 si vous dépensez la dernière charge. La baguette est détruite et tombe en cendres sur un résultat de 1.</p>",
-      "link": "/liste-objets-magiques/baguette-de-projectiles-magiques",
-      "title": "Baguette de projectiles magiques",
-      "type": "Baguette",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Baguette des secrets",
-        "magicitem": {
-          "type": "Baguette",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette baguette contient 3 charges. Avec cette baguette en main, vous pouvez utiliser une action pour dépenser 1 de ses charges et, si une porte secrète ou un piège est présent à 9 mètres ou moins de vous, la baguette se met à pulser et pointe dans la direction du plus proche de vous. La baguette récupère 1d3 charges dépensées chaque jour, à l'aube.</p>",
-      "link": "/liste-objets-magiques/baguette-des-secrets",
-      "title": "Baguette des secrets",
-      "type": "Baguette",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Baguette du mage de guerre +1",
-        "magicitem": {
-          "type": "Baguette",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation avec un lanceur de sorts exigée"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Avec cette baguette en main, vous bénéficiez d'un bonus de +1 aux jets d'attaque des sorts. En outre, vous ignorez les abris partiels lorsque vous effectuez une attaque de sort.</p>",
-      "link": "/liste-objets-magiques/baguette-du-mage-de-guerre-1",
-      "title": "Baguette du mage de guerre +1",
-      "type": "Baguette",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation avec un lanceur de sorts exigée"
-    },
-    {
-      "header": {
-        "title": "Baguette entoilée",
-        "magicitem": {
-          "type": "Baguette",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation avec un lanceur de sorts exigée"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette baguette contient 7 charges. Avec cette baguette en main, vous pouvez utiliser une action pour dépenser 1 de ses charges et lancer le sort <a href=\"/grimoire/toile-daraignee\"><em>toile d'araignée</em></a> (DD des jets de sauvegarde contre le sort 15) par son biais.</p>\n<p>La baguette récupère 1d6+1 charges dépensées chaque jour, à l'aube. Lancez un d20 si vous dépensez la dernière charge. La baguette est détruite et tombe en cendres sur un résultat de 1.</p>",
-      "link": "/liste-objets-magiques/baguette-entoilee",
-      "title": "Baguette entoilée",
-      "type": "Baguette",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation avec un lanceur de sorts exigée"
-    },
-    {
-      "header": {
-        "title": "Balai volant",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce balai de bois pèse 1,5 kilo et fonctionne comme un balai ordinaire, à moins que vous ne vous mettiez à califourchon dessus et prononciez son mot de commande. Il se met alors à flotter et vous pouvez le chevaucher pour vous déplacer dans les airs. Il dispose d'une vitesse de vol de 15 mètres et porte jusqu'à 200 kilos, mais sa vitesse se réduit à 9 mètres si la charge dépasse les 100 kilos. Le balai cesse de flotter dès que vous atterrissez.</p>\n<p>Vous pouvez envoyer le balai rejoindre seul une destination située dans un rayon de 1,5 kilomètre, à condition de prononcer le mot de commande, le nom de la destination et de bien connaître cette dernière. Le balai revient à vous quand vous prononcez un autre mot de commande, à condition qu'il se trouve encore dans un rayon de 1,5 kilomètre autour de vous.</p>",
-      "link": "/liste-objets-magiques/balai-volant",
-      "title": "Balai volant",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Bandeau d'intelligence",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce bandeau, votre Intelligence passe à 19. Si elle est déjà de 19 ou plus, il n'a aucun effet sur vous.</p>",
-      "link": "/liste-objets-magiques/bandeau-dintelligence",
-      "title": "Bandeau d'intelligence",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Bâton du python",
-        "magicitem": {
-          "type": "Bâton",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation avec un clerc, un druide ou un sorcier exigée"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous pouvez utiliser une action pour prononcer le mot de commande de ce bâton et le lancer par terre, à 3 mètres ou moins de vous. Le bâton se transforme alors en <a href=\"/bestiaire/serpent-constricteur-geant\">serpent constricteur géant</a>. Il agit lors de son propre décompte d'initiative mais reste sous votre contrôle. En utilisant une action bonus pour prononcer une nouvelle fois le mot de commande, le bâton reprend sa forme normale dans le dernier espace occupé lorsqu'il était serpent.</p>\n<p>Lors de votre tour, vous pouvez mentalement diriger le serpent si celui-ci se situe à 18 mètres ou moins de vous et si vous n'êtes pas <a href=\"/gerer-la-sante-du-personnage#neutralisé\"><em>neutralisé</em></a>. Vous choisissez l'action qu'entreprend le serpent et l'endroit vers lequel il se déplace lors de son prochain tour. Vous pouvez également donner un ordre moins spécifique (attaquer vos ennemis ou protéger un endroit).</p>\n<p>Si le nombre de points de vie du serpent tombe à 0, il meurt et reprend sa forme de bâton. Le bâton est alors détruit et vole en éclats. Si le serpent reprend sa forme de bâton avant de perdre la totalité de ses points de vie, il les récupère tous.</p>",
-      "link": "/liste-objets-magiques/baton-du-python",
-      "title": "Bâton du python",
-      "type": "Bâton",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation avec un clerc, un druide ou un sorcier exigée"
-    },
-    {
-      "header": {
-        "title": "Baume revigorant",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce pot en verre de 7 à 8 centimètres de diamètre contient 1d4+1 doses d'une mixture épaisse qui sent légèrement l'aloès. Le pot et son contenu pèsent un total de 250 grammes.</p>\n<p>Par une action, il est possible d'avaler ou d'appliquer sur la peau une dose de baume. La créature qui en bénéficie récupère 2d8+2 points de vie, elle n'est plus <a href=\"/gerer-la-sante-du-personnage#empoisonné\"><em>empoisonnée</em></a> et toutes les maladies dont elle est victime sont soignées.</p>",
-      "link": "/liste-objets-magiques/baume-revigorant",
-      "title": "Baume revigorant",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Bottes ailées",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ces bottes aux pieds, vous disposez d'une vitesse de déplacement en vol égale à votre vitesse au sol. Vous pouvez utiliser les bottes pour voler pendant un maximum de 4 heures d'affilée ou lors de vols plus courts. Toutefois, chaque utilisation dépense au minimum 1 minute de cette durée. Si vous volez au moment où cette durée prend fin, vous descendez à une vitesse de 9 mètres par round jusqu'à toucher le sol.</p>\n<p>Les bottes récupèrent 2 heures de capacité de vol pour chaque période de 12 heures passées sans être utilisées.</p>",
-      "link": "/liste-objets-magiques/bottes-ailees",
-      "title": "Bottes ailées",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Bottes de marche et de saut",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ces bottes, votre vitesse au sol passe à 9 mètres (à moins qu'elle ne soit déjà supérieure) et elle ne se réduit pas si vous êtes encombré ou portez une armure lourde. De plus, vous pouvez sauter trois fois plus loin que la normale, sans dépasser la distance que vous pourriez parcourir avec la distance de déplacement qui vous reste.</p>",
-      "link": "/liste-objets-magiques/bottes-de-marche-et-de-saut",
-      "title": "Bottes de marche et de saut",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Bottes des terres gelées",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ces bottes fourrées sont chaudes et bien douillettes. Tant que vous les portez, vous bénéficiez des avantages suivants.</p>\n<ul>\n<li>Vous êtes résistants aux dégâts de froid.</li>\n<li>Vous ignorez les terrains rendus difficiles à cause de la glace ou de la neige.</li>\n<li>Vous supportez des températures descendant jusqu'à -45°C sans protection supplémentaire. Si vous portez des vêtements chauds, vous supportez des températures allant jusqu'à -75°C.</li>\n</ul>",
-      "link": "/liste-objets-magiques/bottes-des-terres-gelees",
-      "title": "Bottes des terres gelées",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Bottes elfiques",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ces bottes, vos pas ne s'accompagnent d'aucun bruit, quelle que soit la surface que vous traversez. Vous obtenez également l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests de Dextérité (Discrétion) basés sur le silence de vos déplacements.</p>",
-      "link": "/liste-objets-magiques/bottes-elfiques",
-      "title": "Bottes elfiques",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Bouclier +1",
-        "magicitem": {
-          "type": "Armure",
-          "subtype": "Bouclier",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous tenez ce bouclier, vous bénéficiez d'un bonus de +1 à la CA. Ce bonus vient en plus du bonus normal à la CA que le bouclier confère.</p>",
-      "link": "/liste-objets-magiques/bouclier-1",
-      "title": "Bouclier +1",
-      "type": "Armure",
-      "subtype": "Bouclier",
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Bouteille fumigène",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>De la fumée s'échappe du goulot de cette bouteille pourtant scellée au plomb et pesant 0,5 kilo. Quand vous utilisez une action pour la déboucher, un épais nuage de fumée se déverse dans un rayon de 18 mètres autour de la bouteille. La visibilité est nulle dans le nuage. À chaque fois que la bouteille passe une minute ouverte au sein du nuage, le rayon de ce dernier augmente de 3 mètres, jusqu'à ce qu'il atteigne son rayon maximum, à savoir 36 mètres.</p>\n<p>Le nuage persiste tant que la bouteille est ouverte. Pour la fermer, vous devez prononcer son mot de commande par une action. Une fois la bouteille fermée, le nuage se dissipe en 10 minutes. Un vent modéré (16 à 30 km/h) disperse la fumée en 1 minute tandis qu'un vent fort (31 km/h ou plus) la dissipe en 1 round.</p>",
-      "link": "/liste-objets-magiques/bouteille-fumigene",
-      "title": "Bouteille fumigène",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Bracelets d'archerie",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ces bracelets, vous maîtrisez l'arc long et l'arc court et gagnez un bonus de +2 aux jets de dégâts des attaques à distance avec ces armes.</p>",
-      "link": "/liste-objets-magiques/bracelets-darcherie",
-      "title": "Bracelets d'archerie",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Broche de protection",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez cette broche, vous êtes résistant aux dégâts de force et vous êtes immunisé contre les dégâts du sort de <a href=\"/grimoire/projectile-magique\"><em>projectile magique</em></a>.</p>",
-      "link": "/liste-objets-magiques/broche-de-protection",
-      "title": "Broche de protection",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Cape de la raie manta",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez cette cape avec le capuchon tiré, vous pouvez respirer sous l'eau et vous bénéficiez d'une vitesse de nage de 18 mètres. Il faut dépenser une action pour coiffer le capuchon ou le repousser.</p>",
-      "link": "/liste-objets-magiques/cape-de-la-raie-manta",
-      "title": "Cape de la raie manta",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Cape de protection",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous gagnez un bonus de +1 à la CA et aux jets de sauvegarde tant que vous portez cette cape.</p>",
-      "link": "/liste-objets-magiques/cape-de-protection",
-      "title": "Cape de protection",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Cape elfique",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez cette cape avec le capuchon tiré, les créatures qui tentent un test de Sagesse (Perception) pour vous voir subissent un <a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>désavantage</em></a>, tandis que vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> sur les tests de Dextérité (Discrétion) effectués pour vous cacher, car les teintes de la cape se modifient pour vous camoufler au mieux. Il faut une action pour tirer ou rabattre la capuche.</p>",
-      "link": "/liste-objets-magiques/cape-elfique",
-      "title": "Cape elfique",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Carafe intarissable",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette carafe coiffée d'un couvercle fait un bruit de liquide quand on la secoue, comme si elle contenait de l'eau. Elle pèse 1 kilo.</p>\n<p>Vous pouvez dépenser une action pour enlever le couvercle et prononcer l'un des trois mots de commande. De l'eau douce ou salée (à vous de choisir) se déverse alors. Elle cesse de couler au début de votre prochain tour. Choisissez l'une des options suivantes.</p>\n<ul>\n<li>« Ruisseau » produit 3,5 litres d'eau.</li>\n<li>« Fontaine » produit 17,5 litres d'eau.</li>\n<li>« Geyser » produit 105 litres d'eau qui jaillissent en un geyser de 9 mètres de long pour 30 centimètres de large. Vous pouvez utiliser une action bonus tout en tenant la carafe pour diriger le geyser contre une créature située dans un rayon de 9 mètres autour de vous. Elle doit réussir un jet de sauvegarde de Force DD 13 ou subir 1d4 dégâts contondants et tomber <a href=\"/gerer-la-sante-du-personnage#à-terre\"><em>à terre</em></a>. Vous pouvez viser un objet au lieu d'une créature, à condition que personne ne l'ait équipé ou ne le transporte et qu'il pèse au maximum 100 kilos. L'objet est renversé ou repoussé à 4,50 mètres de vous.</li>\n</ul>",
-      "link": "/liste-objets-magiques/carafe-intarissable",
-      "title": "Carafe intarissable",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Carquois efficace",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce carquois dispose de trois compartiments, chacun étant relié à un espace extradimensionnel qui lui permet de contenir de nombreux objets sans jamais peser plus de 1 kilo. Le compartiment le plus court peut accueillir jusqu'à soixante flèches, carreaux ou objets similaires. Le compartiment de taille intermédiaire peut recevoir jusqu'à dix-huit javelines ou objets similaires et le plus long peut contenir six objets tout en longueur, comme des arcs, des bâtons ou des lances.</p>\n<p>Vous pouvez tirer ces objets du carquois comme vous le feriez avec un carquois ou un fourreau ordinaire.</p>",
-      "link": "/liste-objets-magiques/carquois-efficace",
-      "title": "Carquois efficace",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Cartes d'illusion",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette boîte contient un jeu de cartes faites de parchemin. Le jeu complet compte 34 cartes mais, quand on trouve un jeu, il lui manque souvent 1d20 - 1 cartes.</p>\n<p>La magie du jeu fonctionne uniquement si on tire les cartes au hasard (vous pouvez utiliser un jeu de cartes ordinaire modifié pour simuler les <em>cartes d'illusion</em>). Vous pouvez dépenser une action pour tirer une carte au hasard dans le jeu et la lancer au sol, à une distance maximum de 9 mètres.</p>\n<p>L'illusion d'une ou plusieurs créatures se forme au-dessus de la carte lancée et persiste jusqu'à dissipation. Une créature illusoire semble réelle. Elle est de la taille appropriée et se comporte comme un véritable membre de son espèce, si ce n'est qu'elle ne peut pas causer le moindre mal. Tant que vous vous trouvez dans un rayon de 36 mètres autour de la créature illusoire et que vous la voyez, vous pouvez utiliser une action pour la déplacer magiquement n'importe où dans un rayon de 9 mètres autour de sa carte. Toute interaction physique avec la créature révèle qu'elle n'est qu'une illusion, car les objets la traversent. Quelqu'un qui utilise une action pour inspecter visuellement la créature illusoire comprend qu'elle n'est pas réelle s'il réussit un test d'Intelligence (Investigation) DD 15. La créature lui paraît ensuite translucide.</p>\n<p>L'illusion persiste jusqu'à ce qu'on la dissipe ou que l'on déplace la carte. Quand l'illusion se termine, l'image de la carte s'efface et on ne peut plus s'en servir.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: left;\">Carte à jouer</th>\n<th style=\"text-align: left;\">Illusion</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: left;\"><strong>As de cœur</strong></td>\n<td style=\"text-align: left;\">Dragon rouge</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de cœur</strong></td>\n<td style=\"text-align: left;\">Chevalier et quatre gardes</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de cœur</strong></td>\n<td style=\"text-align: left;\">Succube ou incube</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de cœur</strong></td>\n<td style=\"text-align: left;\">Druide</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de cœur</strong></td>\n<td style=\"text-align: left;\">Géant des nuages</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de cœur</strong></td>\n<td style=\"text-align: left;\">Ettin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de cœur</strong></td>\n<td style=\"text-align: left;\">Gobelours</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de cœur</strong></td>\n<td style=\"text-align: left;\">Gobelin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>As de carreau</strong></td>\n<td style=\"text-align: left;\">Tyrannœil</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de carreau</strong></td>\n<td style=\"text-align: left;\">Archimage et apprenti mage</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de carreau</strong></td>\n<td style=\"text-align: left;\">Guenaude nocturne</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de carreau</strong></td>\n<td style=\"text-align: left;\">Assassin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de carreau</strong></td>\n<td style=\"text-align: left;\">Géant du feu</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de carreau</strong></td>\n<td style=\"text-align: left;\">Ogre mage</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de carreau</strong></td>\n<td style=\"text-align: left;\">Gnoll</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de carreau</strong></td>\n<td style=\"text-align: left;\">Kobold</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>As de pique</strong></td>\n<td style=\"text-align: left;\">Liche</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de pique</strong></td>\n<td style=\"text-align: left;\">Clerc et deux acolytes</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de pique</strong></td>\n<td style=\"text-align: left;\">Méduse</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de pique</strong></td>\n<td style=\"text-align: left;\">Vétéran</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de pique</strong></td>\n<td style=\"text-align: left;\">Géant du givre</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de pique</strong></td>\n<td style=\"text-align: left;\">Troll</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de pique</strong></td>\n<td style=\"text-align: left;\">Hobgobelin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de pique</strong></td>\n<td style=\"text-align: left;\">Gobelin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>As de trèfle</strong></td>\n<td style=\"text-align: left;\">Golem de fer</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de trèfle</strong></td>\n<td style=\"text-align: left;\">Capitaine des bandits et trois bandits</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de trèfle</strong></td>\n<td style=\"text-align: left;\">Érinyes</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de trèfle</strong></td>\n<td style=\"text-align: left;\">Berserker</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de trèfle</strong></td>\n<td style=\"text-align: left;\">Géant des collines</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de trèfle</strong></td>\n<td style=\"text-align: left;\">Ogre</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de trèfle</strong></td>\n<td style=\"text-align: left;\">Orc</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de trèfle</strong></td>\n<td style=\"text-align: left;\">Kobold</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Joker</strong></td>\n<td style=\"text-align: left;\">Vous (le propriétaire des cartes)</td>\n</tr>\n</tbody>\n</table></div></div>",
-      "link": "/liste-objets-magiques/cartes-dillusion",
-      "title": "Cartes d'illusion",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Chapeau de déguisement",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce chapeau, vous pouvez lancer <a href=\"/grimoire/deguisement\"><em>déguisement</em></a> sur vous par son intermédiaire, et ce à volonté. Le sort se termine si vous enlevez le chapeau.</p>",
-      "link": "/liste-objets-magiques/chapeau-de-deguisement",
-      "title": "Chapeau de déguisement",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Chaussons de l'araignée",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ces souliers légers aux pieds, vous pouvez vous déplacer vers le haut, le bas et le long de surfaces verticales, ou la tête en bas le long de plafonds, tout en gardant les mains libres. Vous disposez d'une vitesse d'escalade égale à votre vitesse au sol. Les chaussons ne permettent toutefois pas de se déplacer de cette façon sur des surfaces glissantes, si elles sont recouvertes de glace ou d'huile, par exemple.</p>",
-      "link": "/liste-objets-magiques/chaussons-de-laraignee",
-      "title": "Chaussons de l'araignée",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Collier d'adaptation",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce collier, vous pouvez respirer normalement quel que soit l'environnement dans lequel vous vous trouvez, et vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des jets de sauvegarde contre les gaz et vapeurs toxiques (comme un <a href=\"/grimoire/nuage-mortel\"><em>nuage mortel</em></a> ou un <a href=\"/grimoire/nuage-puant\"><em>nuage puant</em></a>, un poison par inhalation ou le souffle de certains dragons).</p>",
-      "link": "/liste-objets-magiques/collier-dadaptation",
-      "title": "Collier d'adaptation",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Corde d'escalade",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette corde en soie de 18 mètres de long pèse 1,5 kilo et peut soutenir un maximum de 1500 kilos. La corde s'anime si vous tenez en main une extrémité et utilisez une action pour prononcer le mot de commande. Pour une action bonus, vous pouvez ordonner à l'autre extrémité de se déplacer vers la destination de votre choix. Cette extrémité se déplace de 3 mètres lors du tour où vous lui avez donné l'ordre et de 3 mètres lors de chacun de vos tours, jusqu'à ce qu'elle atteigne sa destination, que sa longueur maximale soit atteinte ou que vous lui ordonniez de s'arrêter. Vous pouvez également ordonner à la corde de s'attacher fermement à un objet ou de s'en détacher, de se nouer ou se dénouer, ou de s'enrouler pour faciliter son transport.</p>\n<p>Si vous ordonnez à la corde de se nouer, des gros nœuds apparaissent sur sa longueur à 30 centimètres les uns des autres. Nouée de la sorte, la corde ne fait plus que 15 mètres de long et permet d'obtenir l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests effectués pour la grimper.</p>\n<p>La corde possède une CA de 20 et 20 points de vie. Elle récupère 1 point de vie toutes les 5 minutes tant qu'il lui reste au moins 1 point de vie. Elle est détruite si son nombre de points de vie tombe à 0.</p>",
-      "link": "/liste-objets-magiques/corde-descalade",
-      "title": "Corde d'escalade",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Diadème de destruction",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce diadème, vous pouvez utiliser votre action pour lancer le sort <a href=\"/grimoire/rayon-ardent\"><em>rayon ardent</em></a> par son intermédiaire. Quand vous effectuez l'attaque de sort, votre bonus d'attaque est de +5. Il faut attendre l'aube suivante avant d'utiliser de nouveau le diadème de cette manière.</p>",
-      "link": "/liste-objets-magiques/diademe-de-destruction",
-      "title": "Diadème de destruction",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Éventail enchanté",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Avec cet éventail en main, vous pouvez utiliser une action pour lancer le sort <a href=\"/grimoire/bourrasque\"><em>bourrasque</em></a> (DD des jets de sauvegarde contre le sort 13). Suite à cette première utilisation, l'éventail ne peut plus être utilisé sans risque de l'abîmer avant l'aube suivante. Chaque fois qu'il est utilisé une fois de plus avant l'aube prochaine, il y a 20% de chances cumulatives qu'il ne fonctionne pas et se casse pour devenir un éventail déchiré ordinaire et inutile.</p>",
-      "link": "/liste-objets-magiques/eventail-enchante",
-      "title": "Éventail enchanté",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Figurine merveilleuse de corbeau d'argent",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Une <em>figurine merveilleuse</em> est une statuette représentant un animal et assez petite pour tenir dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, elle se change en créature vivante. Si l'emplacement qu'elle devrait occuper accueille déjà d'autres créatures ou objets, ou s'il n'y a pas assez de place pour l'animal, la figurine ne se métamorphose pas.</p>\n<p>La créature issue de la figurine existe pendant une durée dépendant de sa statuette. Ensuite, elle se change de nouveau en bibelot. Elle reprend sa forme de figurine avant cela si elle tombe à 0 point de vie ou si vous utilisez une action pour prononcer de nouveau le mot de commande en la touchant. Une fois la créature redevenue bibelot, il faut attendre un certain temps avant qu'elle puisse se transformer de nouveau, comme indiqué dans sa description.</p>\n<p>Cette statuette de corbeau en argent peut se changer en véritable <a href=\"/bestiaire/corbeau\">corbeau</a> pendant un maximum de 12 heures. Ensuite, il faut attendre 2 jours avant de pouvoir s'en servir de nouveau. Sous forme de corbeau, la figurine vous permet de lancer le sort <a href=\"/grimoire/messager-animal\"><em>messager animal</em></a> sur elle à volonté.</p>",
-      "link": "/liste-objets-magiques/figurine-merveilleuse-de-corbeau-dargent",
-      "title": "Figurine merveilleuse de corbeau d'argent",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Flûte des égouts",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous devez maîtriser les instruments à vent si vous voulez jouer de cette flûte. Tant que vous êtes harmonisé avec elle, les rats ordinaires et les rats géants sont indifférents envers vous et ne vous attaquent pas, à moins que vous ne les menaciez ou les blessiez.</p>\n<p>La flûte a trois charges. Si vous utilisez une action pour jouer de la flûte, vous pouvez dépenser une action bonus pour utiliser de 1 à 3 charges et appeler une <a href=\"/bestiaire/nuee-de-rats\">nuée de rats</a> par charge dépensée, à condition qu'il y ait assez de rats dans un rayon d'un kilomètre pour répondre ainsi à votre appel (c'est au MJ d'en décider). S'il n'y a pas assez de rats pour former une nuée, la charge est gaspillée. Une nuée ainsi appelée se précipite vers l'origine de la musique par le chemin le plus court, mais vous ne la contrôlez pas. Chaque jour à l'aube, la flûte récupère 1d3 charges dépensées.</p>\n<p>Quand une <a href=\"/bestiaire/nuee-de-rats\">nuée de rats</a> qui ne se trouve pas sous le contrôle d'une tierce personne arrive dans un rayon de 9 mètres autour de vous alors que vous jouez de la flûte, vous pouvez faire un test de Charisme opposé au test de Sagesse de la nuée. Si vous perdez, la nuée se comporte comme elle le ferait d'ordinaire et ne se laisse plus influencer par la musique de la flûte pendant les 24 heures qui suivent. Si vous l'emportez, la nuée est envoûtée par votre mélodie et se montre amicale envers vous et vos compagnons tant que vous continuez de jouer en dépensant une action à chaque round. Une nuée amicale obéit à vos ordres. Si vous n'en donnez pas, elle se défend mais, en dehors de cela, elle n'entreprend pas la moindre action. Si une nuée est amicale mais débute son tour dans l'incapacité d'entendre la flûte, vous en perdez le contrôle et elle se comporte comme le veut sa nature. La musique de la flûte ne l'influence plus pendant les 24 heures suivantes.</p>",
-      "link": "/liste-objets-magiques/flute-des-egouts",
-      "title": "Flûte des égouts",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Flûte terrifiante",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous devez maîtriser les instruments à vent si vous voulez jouer de cette flûte dotée de 3 charges. Vous pouvez utiliser une action pour jouer et dépenser une charge pour créer une étrange mélodie envoûtante. Chaque créature qui se situe dans un rayon de 9 mètres autour de vous et vous entend jouer doit réussir un jet de sauvegarde de Sagesse DD 15, sans quoi vous la <em>terrorisez</em> pendant 1 minute. Si vous le désirez, toutes les créatures qui ne sont pas hostiles envers vous mais sont présentes dans la zone réussissent automatiquement leur jet de sauvegarde. Une créature qui a raté son jet de sauvegarde peut le refaire à la fin de chacun de ses tours. L'effet se termine pour elle dès qu'elle le réussit. Si une créature réussit son jet de sauvegarde contre la flûte, elle est immunisée contre ses effets pendant 24 heures. Chaque matin à l'aube, la flûte récupère 1d3 charges dépensées.</p>",
-      "link": "/liste-objets-magiques/flute-terrifiante",
-      "title": "Flûte terrifiante",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Gantelets de puissance d'ogre",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ces gants, votre valeur de Force est de 19. Si elle est déjà de 19 ou plus, ils n'ont aucun effet sur vous.</p>",
-      "link": "/liste-objets-magiques/gantelets-de-puissance-dogre",
-      "title": "Gantelets de puissance d'ogre",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Gants de nage et d'escalade",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ces gants, la natation et l'escalade ne vous demandent pas de déplacement supplémentaire et vous gagnez un bonus de +5 aux tests de Force (Athlétisme) pour grimper ou nager.</p>",
-      "link": "/liste-objets-magiques/gants-de-nage-et-descalade",
-      "title": "Gants de nage et d'escalade",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Gants piégeurs de projectiles",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Quand vous enfliez ces gants, ils semblent presque fusionner avec votre peau. Quand vous êtes touché par une attaque d'arme à distance alors que vous les portez, vous pouvez utiliser votre réaction pour réduire les dégâts subis de 1d10 + votre modificateur de Dextérité, à condition que vous ayez une main libre. Si vous réduisez les dégâts à 0, vous attrapez le projectile (s'il est de taille assez réduite pour que vous puissiez le tenir d'une main).</p>",
-      "link": "/liste-objets-magiques/gants-piegeurs-de-projectiles",
-      "title": "Gants piégeurs de projectiles",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Gemme élémentaire",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette gemme contient une particule d'énergie élémentaire. Quand vous brisez la gemme par une action, un élémentaire apparaît, comme si vous l'aviez invoqué avec un sort d'<a href=\"/grimoire/invoquer-un-elementaire\"><em>invoquer un élémentaire</em></a> et la gemme perd toute magie. Le type d'élémentaire invoqué dépend de la gemme utilisée.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: left;\">Gemme</th>\n<th style=\"text-align: left;\">Élémentaire invoqué</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: left;\"><strong>Saphir bleu</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-de-lair\">Élémentaire de l'air</a></td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Diamant jaune</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-de-la-terre\">Élémentaire de la terre</a></td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Corindon rouge</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-du-feu\">Élémentaire du feu</a></td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Émeraude</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-de-leau\">Élémentaire de l'eau</a></td>\n</tr>\n</tbody>\n</table></div></div>",
-      "link": "/liste-objets-magiques/gemme-elementaire",
-      "title": "Gemme élémentaire",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Heaume de compréhension des langages",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce heaume, vous pouvez utiliser une action pour lancer <a href=\"/grimoire/comprehension-des-langues\"><em>compréhension des langues</em></a> à volonté par son intermédiaire.</p>",
-      "link": "/liste-objets-magiques/heaume-de-comprehension-des-langages",
-      "title": "Heaume de compréhension des langages",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Heaume de télépathie",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez ce heaume, vous pouvez utiliser une action pour lancer <a href=\"/grimoire/detection-des-pensees\"><em>détection des pensées</em></a> (DD 13) par son intermédiaire. Tant que vous restez concentré sur le sort, vous pouvez utiliser une action bonus pour envoyer un message télépathique à une créature sur laquelle vous vous concentrez. Elle peut vous répondre (en utilisant une action bonus) tant que vous restez concentré sur elle.</p>\n<p>Tant que vous vous concentrez sur une créature avec <a href=\"/grimoire/detection-des-pensees\"><em>détection des pensées</em></a>, vous pouvez utiliser une action pour lancer le sort <a href=\"/grimoire/suggestion\"><em>suggestion</em></a> (DD 13) sur elle par l'intermédiaire du heaume. Une fois que vous avez utilisé ce pouvoir, vous devez attendre l'aube suivante avant de pouvoir recommencer.</p>",
-      "link": "/liste-objets-magiques/heaume-de-telepathie",
-      "title": "Heaume de télépathie",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Huile glissante",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cet épais onguent noir est dense et lourd tant qu'il reste dans son récipient, mais il coule avec fluidité dès qu'on le verse. Il permet de recouvrir une créature de taille M ou inférieure (il faut verser une fiole de plus pour chaque catégorie de taille au-dessus de M). Il faut 10 minutes pour appliquer l'huile. La créature affectée bénéficie alors des effets du sort <a href=\"/grimoire/liberte-de-mouvement\"><em>liberté de mouvement</em></a> pendant 8 heures.</p>\n<p>Sinon, vous pouvez verser l'huile à terre par une action. Elle recouvre une zone de 3 mètres de côté et produit les mêmes effets que le sort <a href=\"/grimoire/graisse\"><em>graisse</em></a>.</p>",
-      "link": "/liste-objets-magiques/huile-glissante",
-      "title": "Huile glissante",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Javeline de foudre",
-        "magicitem": {
-          "type": "Arme",
-          "subtype": "Javeline",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette javeline est une arme magique. Quand vous la lancez et prononcez son mot de commande, elle se transforme en éclair, formant une ligne de 1,50 mètre de large qui s'étend de votre personne jusqu'à une cible située à une distance maximale de 36 mètres. Chaque créature présente sur cette ligne, à l'exception de vous et de votre cible, doit faire un jet de sauvegarde de Dextérité DD 13. Celles qui échouent subissent 4d6 points de dégâts de foudre, les autres la moitié seulement. L'éclair reprend sa forme de javeline quand il atteint sa cible. Faites une attaque d'arme à distance contre elle. Si vous touchez, la cible subit les dégâts habituels de la javeline plus 4d6 dégâts de foudre.</p>\n<p>Il faut attendre l'aube suivante pour se servir de nouveau de cette propriété de la javeline. En attendant, elle fonctionne tout de même comme une arme magique.</p>",
-      "link": "/liste-objets-magiques/javeline-de-foudre",
-      "title": "Javeline de foudre",
-      "type": "Arme",
-      "subtype": "Javeline",
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Lanterne de révélation",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Quand cette lanterne à capote est allumée, elle brûle pendant 6 heures en consommant 0,5 litre d'huile. Elle émet alors une vive lumière dans un rayon de 9 mètres et une faible lumière dans un rayon de 9 mètres de plus. Les créatures et les objets <a href=\"/gerer-la-sante-du-personnage#invisible\"><em>invisibles</em></a> situés dans la zone de vive lumière de la lanterne deviennent visibles. Vous pouvez utiliser une action pour baisser la capote et réduire la luminosité à une faible lumière dans un rayon de 1,50 mètre.</p>",
-      "link": "/liste-objets-magiques/lanterne-de-revelation",
-      "title": "Lanterne de révélation",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Lentilles de netteté",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ces lentilles de cristal se portent sur les yeux. Tant que vous les portez, votre vue est bien meilleure que d'habitude dans un rayon de 30 centimètres. Vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests d'Intelligence (Investigation) basés sur la vue quand vous fouillez une zone ou étudiez un objet situé dans ce rayon.</p>",
-      "link": "/liste-objets-magiques/lentilles-de-nettete",
-      "title": "Lentilles de netteté",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Lunettes nocturnes",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Quand vous portez ces verres sombres, vous bénéficiez de la vision dans le noir à 18 mètres. Si vous disposez déjà de ce pouvoir, son rayon augmente de 18 mètres.</p>",
-      "link": "/liste-objets-magiques/lunettes-nocturnes",
-      "title": "Lunettes nocturnes",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Médaillon des pensées",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Le médaillon a 3 charges. Tant que vous le portez, vous pouvez utiliser une action et dépenser une charge pour lancer <a href=\"/grimoire/detection-des-pensees\"><em>détection des pensées</em></a> (DD 13) par son intermédiaire. Chaque matin à l'aube, il récupère 1d3 charges dépensées.</p>",
-      "link": "/liste-objets-magiques/medaillon-des-pensees",
-      "title": "Médaillon des pensées",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Munition +1",
-        "magicitem": {
-          "type": "Arme",
-          "subtype": "N'importe quelle munition",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous bénéficiez d'un bonus aux jets d'attaque et de dégâts de +1 effectués avec cette munition. Cette dernière perd toute magie dès qu'elle a touché une cible.</p>",
-      "link": "/liste-objets-magiques/munition-1",
-      "title": "Munition +1",
-      "type": "Arme",
-      "subtype": "N'importe quelle munition",
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Œil de lynx",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ces lentilles de cristal se portent sur les yeux. Tant que vous les portez, vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests de Sagesse (Perception) basés sur la vue. Si la visibilité est bien dégagée, vous percevez tous les détails des créatures et des objets, même très éloignés, à conditions que ces créatures et objets fassent au moins 60 centimètres de large.</p>",
-      "link": "/liste-objets-magiques/oeil-de-lynx",
-      "title": "Œil de lynx",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Parchemin magique (Niveau 1)",
-        "magicitem": {
-          "type": "Parchemin",
-          "rarity": "Courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 13<br>\n<strong>Bonus à l'attaque</strong> : +5</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>",
-      "link": "/liste-objets-magiques/parchemin-magique-1",
-      "title": "Parchemin magique (Niveau 1)",
-      "type": "Parchemin",
-      "subtype": null,
-      "rarity": "Courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Parchemin magique (Niveau 2)",
-        "magicitem": {
-          "type": "Parchemin",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 13<br>\n<strong>Bonus à l'attaque</strong> : +5</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>",
-      "link": "/liste-objets-magiques/parchemin-magique-2",
-      "title": "Parchemin magique (Niveau 2)",
-      "type": "Parchemin",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Parchemin magique (Niveau 3)",
-        "magicitem": {
-          "type": "Parchemin",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 15<br>\n<strong>Bonus à l'attaque</strong> : +7</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>",
-      "link": "/liste-objets-magiques/parchemin-magique-3",
-      "title": "Parchemin magique (Niveau 3)",
-      "type": "Parchemin",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Parchemin magique (Tour de magie)",
-        "magicitem": {
-          "type": "Parchemin",
-          "rarity": "Courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 13<br>\n<strong>Bonus à l'attaque</strong> : +5</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>",
-      "link": "/liste-objets-magiques/parchemin-magique-0",
-      "title": "Parchemin magique (Tour de magie)",
-      "type": "Parchemin",
-      "subtype": null,
-      "rarity": "Courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Perle de puissance",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise avec un lanceur de sorts"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez cette perle sur vous, vous pouvez utiliser une action pour prononcer son mot de commande et récupérer un emplacement de sort dépensé. En revanche, si ce dernier est de niveau 4 ou supérieur, le nouvel emplacement est de niveau 3. Une fois que vous avez utilisé la perle, vous devez attendre l'aube suivante pour vous en servir à nouveau.</p>",
-      "link": "/liste-objets-magiques/perle-de-puissance",
-      "title": "Perle de puissance",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise avec un lanceur de sorts"
-    },
-    {
-      "header": {
-        "title": "Philtre d'amour",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Dans les 10 minutes qui suivent l'absorption de cette potion, vous êtes <a href=\"/gerer-la-sante-du-personnage#charmé\"><em>charmé</em></a> pendant 1 heure par la première créature que vous voyez. Si cette créature est d'une espèce et d'un sexe pour lesquels vous êtes susceptible de ressentir une attirance naturelle, vous considérez vos sentiments comme un amour véritable pendant toute la durée du charme. La potion est effervescente et de teinte rose et contient une bulle en forme de cœur, mais on peut facilement ne pas la voir parmi les autres.</p>",
-      "link": "/liste-objets-magiques/philtre-damour",
-      "title": "Philtre d'amour",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Pierre porte-bonheur",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Tant que vous portez sur vous cette agate lustrée, vous bénéficiez d'un bonus de +1 aux tests de caractéristique et aux jets de sauvegarde.</p>",
-      "link": "/liste-objets-magiques/pierre-porte-bonheur",
-      "title": "Pierre porte-bonheur",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Potion d'agrandissement",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Quand vous buvez cette potion, vous êtes affecté par la version « <em>agrandir</em> » du sort <a href=\"/grimoire/agrandir-retrecir\"><em>agrandir/rétrécir</em></a> pendant 1d4 heures (sans avoir besoin de vous concentrer). Une tache rouge dans le liquide s'étend jusqu'à colorer tout le liquide translucide et se rétracte pour former une petite bille. Ce cycle se répète sans cesse sans interruption, même si on secoue la bouteille.</p>",
-      "link": "/liste-objets-magiques/potion-dagrandissement",
-      "title": "Potion d'agrandissement",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion d'amitié avec les animaux",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Quand vous buvez cette potion, vous pouvez lancer le sort <a href=\"/grimoire/amitie-avec-les-animaux\"><em>amitié avec les animaux</em></a> (DD 13) à volonté pendant 1 heure. Si on agite ce liquide trouble, on distingue de petits morceaux : une écaille de poisson, une langue de colibri, une griffe de chat ou des poils d'écureuil.</p>",
-      "link": "/liste-objets-magiques/potion-damitie-avec-les-animaux",
-      "title": "Potion d'amitié avec les animaux",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion d'escalade",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Quand vous buvez cette potion, vous gagnez une vitesse d'escalade égale à votre vitesse au sol pendant 1 heure. Pendant tout ce temps, vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests de Force (Escalade) que vous effectuez pour grimper. La potion se divise en couches brunes, argent et grises qui rappellent des stries dans la roche. Les couleurs ne se mélangent pas, même quand on agite la bouteille.</p>",
-      "link": "/liste-objets-magiques/potion-descalade",
-      "title": "Potion d'escalade",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion de force de géant des collines",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Quand vous buvez cette potion, votre valeur de Force est égale à 21 pendant 1 heure. La potion n'a aucun effet si votre Force est déjà égale ou supérieure à cette valeur.</p>\n<p>Une rognure d'ongle d'un géant du type approprié flotte dans cette potion transparente.</p>",
-      "link": "/liste-objets-magiques/potion-de-force-de-geant-des-collines",
-      "title": "Potion de force de géant des collines",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion de poison",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette concoction ressemble, tant au niveau du goût, de l'odeur et de l'aspect visuel, à une <a href=\"/liste-objets-magiques/potion-de-soins\"><em>potion de soins</em></a> ou autre potion bénéfique. C'est pourtant du poison dissimulé par une magie illusoire, et un sort d'<a href=\"/grimoire/identification\"><em>identification</em></a> révèle sa véritable nature.</p>\n<p>Vous subissez 3d6 dégâts de poison et devez réussir un jet de sauvegarde de Constitution DD 13 pour ne pas être <a href=\"/gerer-la-sante-du-personnage#empoisonné\"><em>empoisonné</em></a> si vous la buvez. Vous subissez 3d6 dégâts de poison au début de chacun de vos tours tant que vous êtes <a href=\"/gerer-la-sante-du-personnage#empoisonné\"><em>empoisonné</em></a> de cette façon. À la fin de chacun de vos tours, vous pouvez retenter le jet de sauvegarde. En cas de réussite, les dégâts de poison subis lors des tours suivants diminuent de 1d6, et le poison disparaît quand les dégâts sont réduits à 0.</p>",
-      "link": "/liste-objets-magiques/potion-de-poison",
-      "title": "Potion de poison",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion de résistance",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous bénéficiez d'une résistance à un type spécifique de dégâts pendant 1 heure après avoir bu cette potion. Le MJ choisit le type ou le détermine au hasard parmi les potions suivantes.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D10</th>\n<th style=\"text-align: center;\">Type de dégâts</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: center;\">Acide</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: center;\">Froid</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: center;\">Feu</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: center;\">Force</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: center;\">Foudre</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: center;\">Nécrotique</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: center;\">Poison</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: center;\">Psychique</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>9</strong></td>\n<td style=\"text-align: center;\">Radiant</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>10</strong></td>\n<td style=\"text-align: center;\">Tonnerre</td>\n</tr>\n</tbody>\n</table></div></div>",
-      "link": "/liste-objets-magiques/potion-de-resistance",
-      "title": "Potion de résistance",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion de respiration aquatique",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous pouvez respirer sous l'eau pendant 1 heure après avoir bu cette potion. Le liquide vert et trouble qu'elle contient, dans lequel flotte une bulle à l'aspect de méduse, sent la mer.</p>",
-      "link": "/liste-objets-magiques/potion-de-respiration-aquatique",
-      "title": "Potion de respiration aquatique",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion de soins",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous récupérez 2d4+2 points de vie quand vous buvez cette potion. Son liquide rouge scintille quand on l'agite.</p>",
-      "link": "/liste-objets-magiques/potion-de-soins",
-      "title": "Potion de soins",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Potion de soins supérieurs",
-        "magicitem": {
-          "type": "Potion",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Vous récupérez 4d4+4 points de vie quand vous buvez cette potion. Son liquide rouge scintille quand on l'agite.</p>",
-      "link": "/liste-objets-magiques/potion-de-soins-superieurs",
-      "title": "Potion de soins supérieurs",
-      "type": "Potion",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Poussière à éternuer",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette poudre se trouve dans un petit récipient et ressemble à du sable fin. On dirait de la <a href=\"/liste-objets-magiques/poussiere-de-disparition\"><em>poussière de disparition</em></a> et le sort d'<a href=\"/grimoire/identification\"><em>identification</em></a> confirme cette erreur. Il y en a assez pour une seule utilisation.</p>\n<p>Quand vous utilisez une action pour jeter une poignée de poussière dans les airs, vous et chaque créature qui a besoin de respirer et se trouve dans un rayon de 9 mètres autour de vous doit réussir un jet de sauvegarde de Constitution DD 15 ou se retrouver incapable de respirer tant elle tousse. Une créature ainsi affectée est <a href=\"/gerer-la-sante-du-personnage#neutralisé\"><em>neutralisée</em></a> et suffoque. Tant qu'elle est consciente, la créature peut refaire le jet de sauvegarde à la fin de chacun de ses tours, sachant que l'effet se termine pour elle si elle réussit. Le sort de <a href=\"/grimoire/restauration-inferieure\"><em>restauration inférieure</em></a> met aussi un terme à l'effet sur la créature qu'il touche.</p>",
-      "link": "/liste-objets-magiques/poussiere-a-eternuer",
-      "title": "Poussière à éternuer",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Poussière d'assèchement",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce petit paquet contient 1d6+4 pincées de poussière. Vous pouvez dépenser une action pour en saupoudrer une sur l'eau. La poussière transforme un cube d'eau de 4,50 mètres d'arête en une boulette de la taille d'une bille. Elle flotte ou repose près de l'endroit où vous avez saupoudré la poussière. Son poids est négligeable.</p>\n<p>Quelqu'un peut utiliser une action pour briser la boulette contre une surface solide : elle éclate alors et libère l'eau absorbée. La magie de la boulette disparaît alors.</p>\n<p>Un élémentaire majoritairement composé d'eau exposé à la poussière doit faire un jet de sauvegarde de Constitution. S'il échoue, il subit 10d6 dégâts nécrotiques, la moitié seulement sinon.</p>",
-      "link": "/liste-objets-magiques/poussiere-dassechement",
-      "title": "Poussière d'assèchement",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Poussière de disparition",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette poudre se trouve dans un petit paquet et ressemble à du sable fin. Il y en a assez pour une utilisation. Si vous utilisez une action pour lancer la poussière en l'air, vous et chaque créature et objet situé dans un rayon de 3 mètres autour de vous devenez <a href=\"/gerer-la-sante-du-personnage#invisible\"><em>invisible</em></a> pendant 2d4 minutes. La durée est la même pour toutes les cibles et la poussière est entièrement consumée dès que sa magie fait effet. Si une créature affectée par la poussière attaque ou lance un sort, l'invisibilité se termine pour elle.</p>",
-      "link": "/liste-objets-magiques/poussiere-de-disparition",
-      "title": "Poussière de disparition",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Regard charmeur",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ces lentilles de cristal se portent sur les yeux et possèdent trois charges. Tant que vous les portez, vous pouvez dépenser une charge pour lancer le sort <a href=\"/grimoire/charme-personne\"><em>charme-personne</em></a> (DD 13) sur un humanoïde situé dans un rayon de 9 mètres, à condition que vous voyiez la cible et qu'elle vous voie. Chaque jour à l'aube, les lentilles régénèrent toutes les charges dépensées.</p>",
-      "link": "/liste-objets-magiques/regard-charmeur",
-      "title": "Regard charmeur",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
-    },
-    {
-      "header": {
-        "title": "Robe d'objets pratiques",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Cette robe est couverte de pièces de tissu de formes et de couleurs diverses. Tant que vous portez ce vêtement, vous pouvez effectuer une action pour détacher une des pièces et provoquer sa transformation en l'objet ou la créature qu'elle représente. Dès que la dernière pièce est détachée, la robe devient un vêtement ordinaire.</p>\n<p>Deux pièces de chacun des éléments suivants sont cousues sur la robe :</p>\n<ul>\n<li>Dague</li>\n<li>Lanterne sourde (remplie et allumée)</li>\n<li>Miroir en acier</li>\n<li>Perche de 3 mètres</li>\n<li>Corde de chanvre (15 mètres, enroulée)</li>\n<li>Sac</li>\n</ul>\n<p>En outre, la robe se compose de 4d4 autres pièces. Le MJ choisit ces pièces ou les détermine au hasard.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D100</th>\n<th style=\"text-align: left;\">Pièce</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>01-08</strong></td>\n<td style=\"text-align: left;\">100 po dans un sac</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>09-15</strong></td>\n<td style=\"text-align: left;\">Coffre en argent (30 centimètres de long, 15 centimètres de large et de profondeur) d'une valeur de 500 po</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>16-22</strong></td>\n<td style=\"text-align: left;\">Porte en fer (d'une largeur et d'une hauteur maximales de 3 mètres, barrée du côté de votre choix) que vous pouvez placer dans une ouverture à votre portée ; la taille s'adapte aux dimensions de l'ouverture et s'y fixe d'elle-même.</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>23-30</strong></td>\n<td style=\"text-align: left;\">10 pierres précieuses d'une valeur de 100 po chacune</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>34-44</strong></td>\n<td style=\"text-align: left;\">Échelle en bois de 7,30 mètres de long</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>45-51</strong></td>\n<td style=\"text-align: left;\">Cheval de selle avec fontes</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>52-59</strong></td>\n<td style=\"text-align: left;\">Fosse (cube de 3 mètres d'arête) que vous pouvez placer dans le sol à 3 mètres ou moins de vous</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>60-68</strong></td>\n<td style=\"text-align: left;\">4 potions de soins</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>69-75</strong></td>\n<td style=\"text-align: left;\">Barque (3,60 mètres de long)</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>76-83</strong></td>\n<td style=\"text-align: left;\">Parchemin magique contenant un sort de niveau 1 à 3</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>84-90</strong></td>\n<td style=\"text-align: left;\">2 <a href=\"/bestiaire/mastiff\">molosses</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>91-96</strong></td>\n<td style=\"text-align: left;\">Fenêtre (60 centimètres sur 1,20 mètre et jusqu'à 60 centimètres d'épaisseur) que vous pouvez placer sur une surface verticale à votre portée</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>97-00</strong></td>\n<td style=\"text-align: left;\">Bélier portable</td>\n</tr>\n</tbody>\n</table></div></div>",
-      "link": "/liste-objets-magiques/robe-dobjets-pratiques",
-      "title": "Robe d'objets pratiques",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Sac à malice",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce banal sac gris, rouille ou brun semble vide. Cependant, si l'on plonge la main à l'intérieur, on sent un petit objet duveteux. Le sac pèse 250 grammes.</p>\n<p>Vous pouvez dépenser une action pour sortir l'objet duveteux du sac et le lancer à une distance maximale de 6 mètres. Quand il atterrit, il se transforme en une créature que vous déterminez en lançant un d8 dans la table correspondant à la couleur du sac.</p>\n<p>La créature se montre amicale envers vous et vos compagnons et agit à votre tour. Vous pouvez utiliser une action bonus pour gérer ses déplacements et son action lors de son prochain tour ou pour lui donner des ordres génériques, comme d'attaquer vos ennemis. En l'absence d'ordre, la créature se comporte en accord avec sa nature.</p>\n<p>Une fois que vous avez sorti trois objets duveteux du sac, il devient inutile jusqu'à l'aube suivante.</p>\n<div  class=\"table-container\">\n<h2 id=\"sac-a-malice-gris\">Sac à malice gris</h2>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D8</th>\n<th style=\"text-align: left;\">Créature</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/belette\">Belette</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/rat-geant\">Rat géant</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/blaireau\">Blaireau</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/sanglier\">Sanglier</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/panthere\">Panthère</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/blaireau-geant\">Blaireau géant</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/loup-sanguinaire\">Loup sanguinaire</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elan-geant\">Élan géant</a></td>\n</tr>\n</tbody>\n</table></div></div>\n</div>\n<div  class=\"table-container\">\n<h2 id=\"sac-a-malice-rouille\">Sac à malice rouille</h2>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D8</th>\n<th style=\"text-align: left;\">Créature</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/rat\">Rat</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chouette\">Chouette</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/mastiff\">Mastiff</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chevre\">Chèvre</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chevre-geante\">Chèvre géante</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/sanglier-geant\">Sanglier géant</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/lion\">Lion</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/ours-brun\">Ours brun</a></td>\n</tr>\n</tbody>\n</table></div></div>\n</div>\n<div  class=\"table-container\">\n<h2 id=\"sac-a-malice-brun\">Sac à malice brun</h2>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D8</th>\n<th style=\"text-align: left;\">Créature</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chacal\">Chacal</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/grand-singe\">Grand singe</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/babouin\">Babouin</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/bec-de-hache\">Bec de hache</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/ours-noir\">Ours noir</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/belette-geante\">Belette géante</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/hyene-geante\">Hyène géante</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/tigre\">Tigre</a></td>\n</tr>\n</tbody>\n</table></div></div>\n</div>",
-      "link": "/liste-objets-magiques/sac-a-malice",
-      "title": "Sac à malice",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Sac sans fond",
-        "magicitem": {
-          "type": "Objet merveilleux",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce sac abrite un espace intérieur bien plus grand que ce que ses dimensions extérieures laissent présager. Visuellement, il fait une soixantaine de centimètres de diamètre au niveau de l'ouverture pour 1,20 mètre de profondeur. En revanche, il peut contenir jusqu'à 250 kilos de matière, sans dépasser un volume de 2000 litres. Le sac pèse 7,5 kilos, quel que soit son contenu. Il faut dépenser une action pour récupérer un objet dans le sac.</p>\n<p>Si le sac est surchargé, percé ou déchiré, il se découd complètement. Il est alors détruit et son contenu s'éparpille sur le plan Astral. Si on retourne le sac sur l'envers, son contenu se répand à terre, sans dommage, mais il faut le remettre sur l'endroit avant de pouvoir s'en servir de nouveau. Si l'on place une créature ayant besoin de respirer dans le sac, sa survie est limitée : elle peut y rester un nombre de minutes égal à 10 divisé par le nombre de créatures présentes dans le sac (une minute au minimum), ensuite, elle commence à suffoquer.</p>\n<p>Si l'on place un sac sans fond dans l'espace extradimensionnel né d'un <a href=\"/liste-objets-magiques/havresac-magique\"><em>havresac magique</em></a>, d'un <a href=\"/liste-objets-magiques/puits-portatif\"><em>puits portatif</em></a> ou d'un objet similaire, les deux objets sont instantanément détruits et un portail s'ouvre vers le plan Astral. Il apparaît là où l'on a placé le premier objet dans le second et toutes les créatures situées dans un rayon de 3 mètres autour de ce portail sont emportées vers un endroit aléatoire du plan Astral. Le portail se referme ensuite, sachant qu'il est à sens unique et qu'il est impossible de le rouvrir.</p>",
-      "link": "/liste-objets-magiques/sac-sans-fond",
-      "title": "Sac sans fond",
-      "type": "Objet merveilleux",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Sceptre inamovible",
-        "magicitem": {
-          "type": "Sceptre",
-          "rarity": "Peu courant"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce sceptre plat en fer est équipé d'un bouton sur une extrémité. Vous pouvez utiliser une action pour appuyer dessus : il se fixe alors par magie à l'endroit où il se trouve. Il ne bouge plus tant que vous ou une tierce personne n'utilisez pas une action pour appuyer de nouveau sur le bouton, même s'il doit pour cela défier les lois de la gravité. Le sceptre peut soutenir jusqu'à 4 tonnes. Il se désactive et tombe si on lui fait porter plus de poids. Une créature peut utiliser une action pour faire un test de Force DD 30 afin de déplacer le sceptre. Si elle réussit, il bouge d'au maximum 3 mètres.</p>",
-      "link": "/liste-objets-magiques/sceptre-inamovible",
-      "title": "Sceptre inamovible",
-      "type": "Sceptre",
-      "subtype": null,
-      "rarity": "Peu courant",
-      "attunement": null
-    },
-    {
-      "header": {
-        "title": "Trident de domination aquatique",
-        "magicitem": {
-          "type": "Arme",
-          "subtype": "Trident",
-          "rarity": "Peu courant",
-          "attunement": "harmonisation requise"
-        },
-        "taxonomy": {
-          "category": [
-            "docs",
-            "meneur",
-            "objets magiques"
-          ],
-          "source": [
-            "Cadre de campagne"
-          ]
-        }
-      },
-      "content": "<p>Ce trident est une arme magique. Il contient 3 charges. Tant que vous le portez sur vous, vous pouvez utiliser une action et dépenser 1 charge pour lancer <a href=\"/grimoire/dominer-une-bete\"><em>dominer une bête</em></a> (DD du jet de sauvegarde 15) par son biais sur une créature qui sait nager de manière innée et possède une vitesse à la nage. Le trident récupère 1d3 charges dépensées chaque jour, à l'aube.</p>",
-      "link": "/liste-objets-magiques/trident-de-domination-aquatique",
-      "title": "Trident de domination aquatique",
-      "type": "Arme",
-      "subtype": "Trident",
-      "rarity": "Peu courant",
-      "attunement": "harmonisation requise"
+  {
+    "id": "amulet-of-proof-against-detection-and-location",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Amulette d'antidétection",
+        "subtype": null,
+        "description": "<p>Tant que vous portez cette amulette, vous êtes caché aux yeux de la magie de divination. Ce genre de magie ne peut plus vous prendre pour cible et ne vous perçoit plus à travers ses organes de scrutation magiques.</p>"
+      }
     }
-  ]
+  },
+  {
+    "id": "periapt-of-wound-closure",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Amulette de cicatrisation",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce pendentif, vous vous stabilisez automatiquement au début de votre tour si vous êtes mourant. De plus, à chaque fois que vous lancez un dé de vie pour récupérer des points de vie, vous doublez le nombre de points de vie rendus.</p>"
+      }
+    }
+  },
+  {
+    "id": "amulet-of-health",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Amulette de santé",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce pendentif, vous êtes immunisé contre toutes les maladies. Si vous êtes déjà malade, les effets de la maladie sont supprimés tant que vous portez l'amulette.</p>"
+      }
+    }
+  },
+  {
+    "id": "ring-of-warmth",
+    "source": "srd_5.1",
+    "type": "ring",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Anneau de chaleur",
+        "subtype": null,
+        "description": "<p>Vous bénéficiez d'une résistance contre les dégâts de froid tant que vous portez cet anneau au doigt. De plus, vous et tout l'équipement que vous portez êtes protégés contre les températures extrêmement basses (jusque -10 degrés Celsius).</p>"
+      }
+    }
+  },
+  {
+    "id": "ring-of-water-walking",
+    "source": "srd_5.1",
+    "type": "ring",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Anneau de marche sur l'eau",
+        "subtype": null,
+        "description": "<p>Vous pouvez vous tenir debout sur toute surface liquide et vous déplacer dessus comme si elle était solide.</p>"
+      }
+    }
+  },
+  {
+    "id": "ring-of-swimming",
+    "source": "srd_5.1",
+    "type": "ring",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Anneau de nage",
+        "subtype": null,
+        "description": "<p>Vous possédez une vitesse de déplacement à la nage de 12 mètres tant que vous portez cet anneau au doigt.</p>"
+      }
+    }
+  },
+  {
+    "id": "ring-of-mind-shielding",
+    "source": "srd_5.1",
+    "type": "ring",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Anneau de protection mentale",
+        "subtype": null,
+        "description": "<p>Tant que vous portez cet anneau, vous êtes immunisé à la magie utilisée par d'autres créatures pour lire vos pensées, déterminer si vous mentez, connaître votre alignement ou le type de créature que vous êtes. Les créatures peuvent communiquer par télépathie avec vous seulement si vous les y autorisez.</p>\n<p>Vous pouvez utiliser une action pour que l'anneau devienne <a href=\"/gerer-la-sante-du-personnage#invisible\"><em>invisible</em></a> jusqu'à ce que vous utilisiez une autre action pour le rendre visible, que vous le retiriez ou que vous mourriez.</p>\n<p>Si vous perdez la vie avec l'anneau au doigt, votre âme se réfugie à l'intérieur, à moins qu'il ne contienne déjà une âme. Vous pouvez rester dans l'anneau ou vous en aller pour l'après-vie. Tant que votre âme est à l'intérieur de l'anneau, vous pouvez communiquer par télépathie avec la créature qui l'enfile. Un porteur ne peut pas empêcher cette communication télépathique.</p>"
+      }
+    }
+  },
+  {
+    "id": "ring-of-jumping",
+    "source": "srd_5.1",
+    "type": "ring",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Anneau de saut",
+        "subtype": null,
+        "description": "<p>Vous pouvez lancer le sort de <a href=\"/grimoire/saut\"><em>saut</em></a>, à volonté et par une action bonus, tant que vous portez cet anneau au doigt. Seul vous bénéficiez des effets de ce sort.</p>"
+      }
+    }
+  },
+  {
+    "id": "weapon-plus-1",
+    "source": "srd_5.1",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Arme +1",
+        "subtype": "N'importe quelle arme",
+        "description": "<p>Vous bénéficiez d'un bonus de +1 aux jets d'attaque et de dégâts effectués avec cette arme magique.</p>"
+      }
+    }
+  },
+  {
+    "id": "mithral-armor",
+    "source": "srd_5.1",
+    "type": "armor",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Armure de mithral",
+        "subtype": "Intermédiaire ou lourde mais pas en peau",
+        "description": "<p>Le mithral est un métal léger et flexible, à tel point qu'on peut porter une chemise de mailles ou une cuirasse de cette matière sous des vêtements normaux. Si le type d'armure impose d'ordinaire un <a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>désavantage</em></a> lors des tests de Dextérité (Discrétion) ou si une certaine valeur de Force figure parmi ses conditions requises, ce n'est pas le cas de sa version en mithral.</p>"
+      }
+    }
+  },
+  {
+    "id": "adamantine-armor",
+    "source": "srd_5.1",
+    "type": "armor",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Armure en adamantium",
+        "subtype": "Intermédiaire ou lourde, mais pas en peau",
+        "description": "<p>Cette armure est renforcée à base d'adamantium, l'une des substances les plus solides au monde. Tant que vous la portez, tous les coups critiques réussis contre vous se muent en coups normaux.</p>"
+      }
+    }
+  },
+  {
+    "id": "wand-of-magic-detection",
+    "source": "srd_5.1",
+    "type": "wand",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Baguette de détection de la magie",
+        "subtype": null,
+        "description": "<p>Cette baguette contient 3 charges. Avec cette baguette en main, vous pouvez dépenser 1 charge par une action pour lancer le sort <a href=\"/grimoire/detection-de-la-magie\">détection de la magie</a> par son biais. La baguette récupère 1d3 charges dépensées chaque jour, à l'aube.</p>"
+      }
+    }
+  },
+  {
+    "id": "wand-of-magic-missiles",
+    "source": "srd_5.1",
+    "type": "wand",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Baguette de projectiles magiques",
+        "subtype": null,
+        "description": "<p>Cette baguette contient 7 charges. Avec cette baguette en main, vous pouvez utiliser une action pour dépenser 1 ou plusieurs charges et lancer le sort de <a href=\"/grimoire/projectile-magique\"><em>projectile magique</em></a> par son biais. Pour 1 charge, vous lancez la version de niveau 1 de ce sort. Vous pouvez augmenter de un le niveau de l'emplacement du sort pour chaque charge supplémentaire que vous dépensez.</p>\n<p>La baguette récupère 1d6+1 charges dépensées chaque jour, à l'aube. Lancez un d20 si vous dépensez la dernière charge. La baguette est détruite et tombe en cendres sur un résultat de 1.</p>"
+      }
+    }
+  },
+  {
+    "id": "wand-of-secrets",
+    "source": "srd_5.1",
+    "type": "wand",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Baguette des secrets",
+        "subtype": null,
+        "description": "<p>Cette baguette contient 3 charges. Avec cette baguette en main, vous pouvez utiliser une action pour dépenser 1 de ses charges et, si une porte secrète ou un piège est présent à 9 mètres ou moins de vous, la baguette se met à pulser et pointe dans la direction du plus proche de vous. La baguette récupère 1d3 charges dépensées chaque jour, à l'aube.</p>"
+      }
+    }
+  },
+  {
+    "id": "wand-of-the-war-mage-plus-1",
+    "source": "srd_5.1",
+    "type": "wand",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Baguette du mage de guerre +1",
+        "subtype": null,
+        "description": "<p>Avec cette baguette en main, vous bénéficiez d'un bonus de +1 aux jets d'attaque des sorts. En outre, vous ignorez les abris partiels lorsque vous effectuez une attaque de sort.</p>"
+      }
+    }
+  },
+  {
+    "id": "wand-of-entanglement",
+    "source": "srd_5.1",
+    "type": "wand",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Baguette entoilée",
+        "subtype": null,
+        "description": "<p>Cette baguette contient 7 charges. Avec cette baguette en main, vous pouvez utiliser une action pour dépenser 1 de ses charges et lancer le sort <a href=\"/grimoire/toile-daraignee\"><em>toile d'araignée</em></a> (DD des jets de sauvegarde contre le sort 15) par son biais.</p>\n<p>La baguette récupère 1d6+1 charges dépensées chaque jour, à l'aube. Lancez un d20 si vous dépensez la dernière charge. La baguette est détruite et tombe en cendres sur un résultat de 1.</p>"
+      }
+    }
+  },
+  {
+    "id": "broom-of-flying",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Balai volant",
+        "subtype": null,
+        "description": "<p>Ce balai de bois pèse 1,5 kilo et fonctionne comme un balai ordinaire, à moins que vous ne vous mettiez à califourchon dessus et prononciez son mot de commande. Il se met alors à flotter et vous pouvez le chevaucher pour vous déplacer dans les airs. Il dispose d'une vitesse de vol de 15 mètres et porte jusqu'à 200 kilos, mais sa vitesse se réduit à 9 mètres si la charge dépasse les 100 kilos. Le balai cesse de flotter dès que vous atterrissez.</p>\n<p>Vous pouvez envoyer le balai rejoindre seul une destination située dans un rayon de 1,5 kilomètre, à condition de prononcer le mot de commande, le nom de la destination et de bien connaître cette dernière. Le balai revient à vous quand vous prononcez un autre mot de commande, à condition qu'il se trouve encore dans un rayon de 1,5 kilomètre autour de vous.</p>"
+      }
+    }
+  },
+  {
+    "id": "headband-of-intellect",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Bandeau d'intelligence",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce bandeau, votre Intelligence passe à 19. Si elle est déjà de 19 ou plus, il n'a aucun effet sur vous.</p>"
+      }
+    }
+  },
+  {
+    "id": "staff-of-the-python",
+    "source": "srd_5.1",
+    "type": "staff",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Bâton du python",
+        "subtype": null,
+        "description": "<p>Vous pouvez utiliser une action pour prononcer le mot de commande de ce bâton et le lancer par terre, à 3 mètres ou moins de vous. Le bâton se transforme alors en <a href=\"/bestiaire/serpent-constricteur-geant\">serpent constricteur géant</a>. Il agit lors de son propre décompte d'initiative mais reste sous votre contrôle. En utilisant une action bonus pour prononcer une nouvelle fois le mot de commande, le bâton reprend sa forme normale dans le dernier espace occupé lorsqu'il était serpent.</p>\n<p>Lors de votre tour, vous pouvez mentalement diriger le serpent si celui-ci se situe à 18 mètres ou moins de vous et si vous n'êtes pas <a href=\"/gerer-la-sante-du-personnage#neutralisé\"><em>neutralisé</em></a>. Vous choisissez l'action qu'entreprend le serpent et l'endroit vers lequel il se déplace lors de son prochain tour. Vous pouvez également donner un ordre moins spécifique (attaquer vos ennemis ou protéger un endroit).</p>\n<p>Si le nombre de points de vie du serpent tombe à 0, il meurt et reprend sa forme de bâton. Le bâton est alors détruit et vole en éclats. Si le serpent reprend sa forme de bâton avant de perdre la totalité de ses points de vie, il les récupère tous.</p>"
+      }
+    }
+  },
+  {
+    "id": "keoghtoms-ointment",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Baume revigorant",
+        "subtype": null,
+        "description": "<p>Ce pot en verre de 7 à 8 centimètres de diamètre contient 1d4+1 doses d'une mixture épaisse qui sent légèrement l'aloès. Le pot et son contenu pèsent un total de 250 grammes.</p>\n<p>Par une action, il est possible d'avaler ou d'appliquer sur la peau une dose de baume. La créature qui en bénéficie récupère 2d8+2 points de vie, elle n'est plus <a href=\"/gerer-la-sante-du-personnage#empoisonné\"><em>empoisonnée</em></a> et toutes les maladies dont elle est victime sont soignées.</p>"
+      }
+    }
+  },
+  {
+    "id": "winged-boots",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Bottes ailées",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ces bottes aux pieds, vous disposez d'une vitesse de déplacement en vol égale à votre vitesse au sol. Vous pouvez utiliser les bottes pour voler pendant un maximum de 4 heures d'affilée ou lors de vols plus courts. Toutefois, chaque utilisation dépense au minimum 1 minute de cette durée. Si vous volez au moment où cette durée prend fin, vous descendez à une vitesse de 9 mètres par round jusqu'à toucher le sol.</p>\n<p>Les bottes récupèrent 2 heures de capacité de vol pour chaque période de 12 heures passées sans être utilisées.</p>"
+      }
+    }
+  },
+  {
+    "id": "boots-of-striding-and-springing",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Bottes de marche et de saut",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ces bottes, votre vitesse au sol passe à 9 mètres (à moins qu'elle ne soit déjà supérieure) et elle ne se réduit pas si vous êtes encombré ou portez une armure lourde. De plus, vous pouvez sauter trois fois plus loin que la normale, sans dépasser la distance que vous pourriez parcourir avec la distance de déplacement qui vous reste.</p>"
+      }
+    }
+  },
+  {
+    "id": "boots-of-the-winterlands",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Bottes des terres gelées",
+        "subtype": null,
+        "description": "<p>Ces bottes fourrées sont chaudes et bien douillettes. Tant que vous les portez, vous bénéficiez des avantages suivants.</p>\n<ul>\n<li>Vous êtes résistants aux dégâts de froid.</li>\n<li>Vous ignorez les terrains rendus difficiles à cause de la glace ou de la neige.</li>\n<li>Vous supportez des températures descendant jusqu'à -45°C sans protection supplémentaire. Si vous portez des vêtements chauds, vous supportez des températures allant jusqu'à -75°C.</li>\n</ul>"
+      }
+    }
+  },
+  {
+    "id": "boots-of-elvenkind",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Bottes elfiques",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ces bottes, vos pas ne s'accompagnent d'aucun bruit, quelle que soit la surface que vous traversez. Vous obtenez également l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests de Dextérité (Discrétion) basés sur le silence de vos déplacements.</p>"
+      }
+    }
+  },
+  {
+    "id": "shield-plus-1",
+    "source": "srd_5.1",
+    "type": "armor",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Bouclier +1",
+        "subtype": "Bouclier",
+        "description": "<p>Tant que vous tenez ce bouclier, vous bénéficiez d'un bonus de +1 à la CA. Ce bonus vient en plus du bonus normal à la CA que le bouclier confère.</p>"
+      }
+    }
+  },
+  {
+    "id": "eversmoking-bottle",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Bouteille fumigène",
+        "subtype": null,
+        "description": "<p>De la fumée s'échappe du goulot de cette bouteille pourtant scellée au plomb et pesant 0,5 kilo. Quand vous utilisez une action pour la déboucher, un épais nuage de fumée se déverse dans un rayon de 18 mètres autour de la bouteille. La visibilité est nulle dans le nuage. À chaque fois que la bouteille passe une minute ouverte au sein du nuage, le rayon de ce dernier augmente de 3 mètres, jusqu'à ce qu'il atteigne son rayon maximum, à savoir 36 mètres.</p>\n<p>Le nuage persiste tant que la bouteille est ouverte. Pour la fermer, vous devez prononcer son mot de commande par une action. Une fois la bouteille fermée, le nuage se dissipe en 10 minutes. Un vent modéré (16 à 30 km/h) disperse la fumée en 1 minute tandis qu'un vent fort (31 km/h ou plus) la dissipe en 1 round.</p>"
+      }
+    }
+  },
+  {
+    "id": "bracers-of-archery",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Bracelets d'archerie",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ces bracelets, vous maîtrisez l'arc long et l'arc court et gagnez un bonus de +2 aux jets de dégâts des attaques à distance avec ces armes.</p>"
+      }
+    }
+  },
+  {
+    "id": "brooch-of-shielding",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Broche de protection",
+        "subtype": null,
+        "description": "<p>Tant que vous portez cette broche, vous êtes résistant aux dégâts de force et vous êtes immunisé contre les dégâts du sort de <a href=\"/grimoire/projectile-magique\"><em>projectile magique</em></a>.</p>"
+      }
+    }
+  },
+  {
+    "id": "cloak-of-the-manta-ray",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Cape de la raie manta",
+        "subtype": null,
+        "description": "<p>Tant que vous portez cette cape avec le capuchon tiré, vous pouvez respirer sous l'eau et vous bénéficiez d'une vitesse de nage de 18 mètres. Il faut dépenser une action pour coiffer le capuchon ou le repousser.</p>"
+      }
+    }
+  },
+  {
+    "id": "cloak-of-protection",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Cape de protection",
+        "subtype": null,
+        "description": "<p>Vous gagnez un bonus de +1 à la CA et aux jets de sauvegarde tant que vous portez cette cape.</p>"
+      }
+    }
+  },
+  {
+    "id": "cloak-of-elvenkind",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Cape elfique",
+        "subtype": null,
+        "description": "<p>Tant que vous portez cette cape avec le capuchon tiré, les créatures qui tentent un test de Sagesse (Perception) pour vous voir subissent un <a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>désavantage</em></a>, tandis que vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> sur les tests de Dextérité (Discrétion) effectués pour vous cacher, car les teintes de la cape se modifient pour vous camoufler au mieux. Il faut une action pour tirer ou rabattre la capuche.</p>"
+      }
+    }
+  },
+  {
+    "id": "decanter-of-endless-water",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Carafe intarissable",
+        "subtype": null,
+        "description": "<p>Cette carafe coiffée d'un couvercle fait un bruit de liquide quand on la secoue, comme si elle contenait de l'eau. Elle pèse 1 kilo.</p>\n<p>Vous pouvez dépenser une action pour enlever le couvercle et prononcer l'un des trois mots de commande. De l'eau douce ou salée (à vous de choisir) se déverse alors. Elle cesse de couler au début de votre prochain tour. Choisissez l'une des options suivantes.</p>\n<ul>\n<li>« Ruisseau » produit 3,5 litres d'eau.</li>\n<li>« Fontaine » produit 17,5 litres d'eau.</li>\n<li>« Geyser » produit 105 litres d'eau qui jaillissent en un geyser de 9 mètres de long pour 30 centimètres de large. Vous pouvez utiliser une action bonus tout en tenant la carafe pour diriger le geyser contre une créature située dans un rayon de 9 mètres autour de vous. Elle doit réussir un jet de sauvegarde de Force DD 13 ou subir 1d4 dégâts contondants et tomber <a href=\"/gerer-la-sante-du-personnage#à-terre\"><em>à terre</em></a>. Vous pouvez viser un objet au lieu d'une créature, à condition que personne ne l'ait équipé ou ne le transporte et qu'il pèse au maximum 100 kilos. L'objet est renversé ou repoussé à 4,50 mètres de vous.</li>\n</ul>"
+      }
+    }
+  },
+  {
+    "id": "efficient-quiver",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Carquois efficace",
+        "subtype": null,
+        "description": "<p>Ce carquois dispose de trois compartiments, chacun étant relié à un espace extradimensionnel qui lui permet de contenir de nombreux objets sans jamais peser plus de 1 kilo. Le compartiment le plus court peut accueillir jusqu'à soixante flèches, carreaux ou objets similaires. Le compartiment de taille intermédiaire peut recevoir jusqu'à dix-huit javelines ou objets similaires et le plus long peut contenir six objets tout en longueur, comme des arcs, des bâtons ou des lances.</p>\n<p>Vous pouvez tirer ces objets du carquois comme vous le feriez avec un carquois ou un fourreau ordinaire.</p>"
+      }
+    }
+  },
+  {
+    "id": "deck-of-illusions",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Cartes d'illusion",
+        "subtype": null,
+        "description": "<p>Cette boîte contient un jeu de cartes faites de parchemin. Le jeu complet compte 34 cartes mais, quand on trouve un jeu, il lui manque souvent 1d20 - 1 cartes.</p>\n<p>La magie du jeu fonctionne uniquement si on tire les cartes au hasard (vous pouvez utiliser un jeu de cartes ordinaire modifié pour simuler les <em>cartes d'illusion</em>). Vous pouvez dépenser une action pour tirer une carte au hasard dans le jeu et la lancer au sol, à une distance maximum de 9 mètres.</p>\n<p>L'illusion d'une ou plusieurs créatures se forme au-dessus de la carte lancée et persiste jusqu'à dissipation. Une créature illusoire semble réelle. Elle est de la taille appropriée et se comporte comme un véritable membre de son espèce, si ce n'est qu'elle ne peut pas causer le moindre mal. Tant que vous vous trouvez dans un rayon de 36 mètres autour de la créature illusoire et que vous la voyez, vous pouvez utiliser une action pour la déplacer magiquement n'importe où dans un rayon de 9 mètres autour de sa carte. Toute interaction physique avec la créature révèle qu'elle n'est qu'une illusion, car les objets la traversent. Quelqu'un qui utilise une action pour inspecter visuellement la créature illusoire comprend qu'elle n'est pas réelle s'il réussit un test d'Intelligence (Investigation) DD 15. La créature lui paraît ensuite translucide.</p>\n<p>L'illusion persiste jusqu'à ce qu'on la dissipe ou que l'on déplace la carte. Quand l'illusion se termine, l'image de la carte s'efface et on ne peut plus s'en servir.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: left;\">Carte à jouer</th>\n<th style=\"text-align: left;\">Illusion</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: left;\"><strong>As de cœur</strong></td>\n<td style=\"text-align: left;\">Dragon rouge</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de cœur</strong></td>\n<td style=\"text-align: left;\">Chevalier et quatre gardes</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de cœur</strong></td>\n<td style=\"text-align: left;\">Succube ou incube</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de cœur</strong></td>\n<td style=\"text-align: left;\">Druide</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de cœur</strong></td>\n<td style=\"text-align: left;\">Géant des nuages</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de cœur</strong></td>\n<td style=\"text-align: left;\">Ettin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de cœur</strong></td>\n<td style=\"text-align: left;\">Gobelours</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de cœur</strong></td>\n<td style=\"text-align: left;\">Gobelin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>As de carreau</strong></td>\n<td style=\"text-align: left;\">Tyrannœil</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de carreau</strong></td>\n<td style=\"text-align: left;\">Archimage et apprenti mage</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de carreau</strong></td>\n<td style=\"text-align: left;\">Guenaude nocturne</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de carreau</strong></td>\n<td style=\"text-align: left;\">Assassin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de carreau</strong></td>\n<td style=\"text-align: left;\">Géant du feu</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de carreau</strong></td>\n<td style=\"text-align: left;\">Ogre mage</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de carreau</strong></td>\n<td style=\"text-align: left;\">Gnoll</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de carreau</strong></td>\n<td style=\"text-align: left;\">Kobold</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>As de pique</strong></td>\n<td style=\"text-align: left;\">Liche</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de pique</strong></td>\n<td style=\"text-align: left;\">Clerc et deux acolytes</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de pique</strong></td>\n<td style=\"text-align: left;\">Méduse</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de pique</strong></td>\n<td style=\"text-align: left;\">Vétéran</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de pique</strong></td>\n<td style=\"text-align: left;\">Géant du givre</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de pique</strong></td>\n<td style=\"text-align: left;\">Troll</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de pique</strong></td>\n<td style=\"text-align: left;\">Hobgobelin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de pique</strong></td>\n<td style=\"text-align: left;\">Gobelin</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>As de trèfle</strong></td>\n<td style=\"text-align: left;\">Golem de fer</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Roi de trèfle</strong></td>\n<td style=\"text-align: left;\">Capitaine des bandits et trois bandits</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Dame de trèfle</strong></td>\n<td style=\"text-align: left;\">Érinyes</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Valet de trèfle</strong></td>\n<td style=\"text-align: left;\">Berserker</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>10 de trèfle</strong></td>\n<td style=\"text-align: left;\">Géant des collines</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>9 de trèfle</strong></td>\n<td style=\"text-align: left;\">Ogre</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>8 de trèfle</strong></td>\n<td style=\"text-align: left;\">Orc</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>2 de trèfle</strong></td>\n<td style=\"text-align: left;\">Kobold</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Joker</strong></td>\n<td style=\"text-align: left;\">Vous (le propriétaire des cartes)</td>\n</tr>\n</tbody>\n</table></div></div>"
+      }
+    }
+  },
+  {
+    "id": "hat-of-disguise",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Chapeau de déguisement",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce chapeau, vous pouvez lancer <a href=\"/grimoire/deguisement\"><em>déguisement</em></a> sur vous par son intermédiaire, et ce à volonté. Le sort se termine si vous enlevez le chapeau.</p>"
+      }
+    }
+  },
+  {
+    "id": "slippers-of-spider-climbing",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Chaussons de l'araignée",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ces souliers légers aux pieds, vous pouvez vous déplacer vers le haut, le bas et le long de surfaces verticales, ou la tête en bas le long de plafonds, tout en gardant les mains libres. Vous disposez d'une vitesse d'escalade égale à votre vitesse au sol. Les chaussons ne permettent toutefois pas de se déplacer de cette façon sur des surfaces glissantes, si elles sont recouvertes de glace ou d'huile, par exemple.</p>"
+      }
+    }
+  },
+  {
+    "id": "necklace-of-adaptation",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Collier d'adaptation",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce collier, vous pouvez respirer normalement quel que soit l'environnement dans lequel vous vous trouvez, et vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des jets de sauvegarde contre les gaz et vapeurs toxiques (comme un <a href=\"/grimoire/nuage-mortel\"><em>nuage mortel</em></a> ou un <a href=\"/grimoire/nuage-puant\"><em>nuage puant</em></a>, un poison par inhalation ou le souffle de certains dragons).</p>"
+      }
+    }
+  },
+  {
+    "id": "rope-of-climbing",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Corde d'escalade",
+        "subtype": null,
+        "description": "<p>Cette corde en soie de 18 mètres de long pèse 1,5 kilo et peut soutenir un maximum de 1500 kilos. La corde s'anime si vous tenez en main une extrémité et utilisez une action pour prononcer le mot de commande. Pour une action bonus, vous pouvez ordonner à l'autre extrémité de se déplacer vers la destination de votre choix. Cette extrémité se déplace de 3 mètres lors du tour où vous lui avez donné l'ordre et de 3 mètres lors de chacun de vos tours, jusqu'à ce qu'elle atteigne sa destination, que sa longueur maximale soit atteinte ou que vous lui ordonniez de s'arrêter. Vous pouvez également ordonner à la corde de s'attacher fermement à un objet ou de s'en détacher, de se nouer ou se dénouer, ou de s'enrouler pour faciliter son transport.</p>\n<p>Si vous ordonnez à la corde de se nouer, des gros nœuds apparaissent sur sa longueur à 30 centimètres les uns des autres. Nouée de la sorte, la corde ne fait plus que 15 mètres de long et permet d'obtenir l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests effectués pour la grimper.</p>\n<p>La corde possède une CA de 20 et 20 points de vie. Elle récupère 1 point de vie toutes les 5 minutes tant qu'il lui reste au moins 1 point de vie. Elle est détruite si son nombre de points de vie tombe à 0.</p>"
+      }
+    }
+  },
+  {
+    "id": "circlet-of-blasting",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Diadème de destruction",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce diadème, vous pouvez utiliser votre action pour lancer le sort <a href=\"/grimoire/rayon-ardent\"><em>rayon ardent</em></a> par son intermédiaire. Quand vous effectuez l'attaque de sort, votre bonus d'attaque est de +5. Il faut attendre l'aube suivante avant d'utiliser de nouveau le diadème de cette manière.</p>"
+      }
+    }
+  },
+  {
+    "id": "wind-fan",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Éventail enchanté",
+        "subtype": null,
+        "description": "<p>Avec cet éventail en main, vous pouvez utiliser une action pour lancer le sort <a href=\"/grimoire/bourrasque\"><em>bourrasque</em></a> (DD des jets de sauvegarde contre le sort 13). Suite à cette première utilisation, l'éventail ne peut plus être utilisé sans risque de l'abîmer avant l'aube suivante. Chaque fois qu'il est utilisé une fois de plus avant l'aube prochaine, il y a 20% de chances cumulatives qu'il ne fonctionne pas et se casse pour devenir un éventail déchiré ordinaire et inutile.</p>"
+      }
+    }
+  },
+  {
+    "id": "figurine-of-wondrous-power-silver-raven",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Figurine merveilleuse de corbeau d'argent",
+        "subtype": null,
+        "description": "<p>Une <em>figurine merveilleuse</em> est une statuette représentant un animal et assez petite pour tenir dans une poche. Si vous utilisez une action pour prononcer le mot de commande et lancez la figurine au sol dans un rayon de 18 mètres autour de vous, elle se change en créature vivante. Si l'emplacement qu'elle devrait occuper accueille déjà d'autres créatures ou objets, ou s'il n'y a pas assez de place pour l'animal, la figurine ne se métamorphose pas.</p>\n<p>La créature issue de la figurine existe pendant une durée dépendant de sa statuette. Ensuite, elle se change de nouveau en bibelot. Elle reprend sa forme de figurine avant cela si elle tombe à 0 point de vie ou si vous utilisez une action pour prononcer de nouveau le mot de commande en la touchant. Une fois la créature redevenue bibelot, il faut attendre un certain temps avant qu'elle puisse se transformer de nouveau, comme indiqué dans sa description.</p>\n<p>Cette statuette de corbeau en argent peut se changer en véritable <a href=\"/bestiaire/corbeau\">corbeau</a> pendant un maximum de 12 heures. Ensuite, il faut attendre 2 jours avant de pouvoir s'en servir de nouveau. Sous forme de corbeau, la figurine vous permet de lancer le sort <a href=\"/grimoire/messager-animal\"><em>messager animal</em></a> sur elle à volonté.</p>"
+      }
+    }
+  },
+  {
+    "id": "pipes-of-the-sewers",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Flûte des égouts",
+        "subtype": null,
+        "description": "<p>Vous devez maîtriser les instruments à vent si vous voulez jouer de cette flûte. Tant que vous êtes harmonisé avec elle, les rats ordinaires et les rats géants sont indifférents envers vous et ne vous attaquent pas, à moins que vous ne les menaciez ou les blessiez.</p>\n<p>La flûte a trois charges. Si vous utilisez une action pour jouer de la flûte, vous pouvez dépenser une action bonus pour utiliser de 1 à 3 charges et appeler une <a href=\"/bestiaire/nuee-de-rats\">nuée de rats</a> par charge dépensée, à condition qu'il y ait assez de rats dans un rayon d'un kilomètre pour répondre ainsi à votre appel (c'est au MJ d'en décider). S'il n'y a pas assez de rats pour former une nuée, la charge est gaspillée. Une nuée ainsi appelée se précipite vers l'origine de la musique par le chemin le plus court, mais vous ne la contrôlez pas. Chaque jour à l'aube, la flûte récupère 1d3 charges dépensées.</p>\n<p>Quand une <a href=\"/bestiaire/nuee-de-rats\">nuée de rats</a> qui ne se trouve pas sous le contrôle d'une tierce personne arrive dans un rayon de 9 mètres autour de vous alors que vous jouez de la flûte, vous pouvez faire un test de Charisme opposé au test de Sagesse de la nuée. Si vous perdez, la nuée se comporte comme elle le ferait d'ordinaire et ne se laisse plus influencer par la musique de la flûte pendant les 24 heures qui suivent. Si vous l'emportez, la nuée est envoûtée par votre mélodie et se montre amicale envers vous et vos compagnons tant que vous continuez de jouer en dépensant une action à chaque round. Une nuée amicale obéit à vos ordres. Si vous n'en donnez pas, elle se défend mais, en dehors de cela, elle n'entreprend pas la moindre action. Si une nuée est amicale mais débute son tour dans l'incapacité d'entendre la flûte, vous en perdez le contrôle et elle se comporte comme le veut sa nature. La musique de la flûte ne l'influence plus pendant les 24 heures suivantes.</p>"
+      }
+    }
+  },
+  {
+    "id": "pipes-of-haunting",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Flûte terrifiante",
+        "subtype": null,
+        "description": "<p>Vous devez maîtriser les instruments à vent si vous voulez jouer de cette flûte dotée de 3 charges. Vous pouvez utiliser une action pour jouer et dépenser une charge pour créer une étrange mélodie envoûtante. Chaque créature qui se situe dans un rayon de 9 mètres autour de vous et vous entend jouer doit réussir un jet de sauvegarde de Sagesse DD 15, sans quoi vous la <em>terrorisez</em> pendant 1 minute. Si vous le désirez, toutes les créatures qui ne sont pas hostiles envers vous mais sont présentes dans la zone réussissent automatiquement leur jet de sauvegarde. Une créature qui a raté son jet de sauvegarde peut le refaire à la fin de chacun de ses tours. L'effet se termine pour elle dès qu'elle le réussit. Si une créature réussit son jet de sauvegarde contre la flûte, elle est immunisée contre ses effets pendant 24 heures. Chaque matin à l'aube, la flûte récupère 1d3 charges dépensées.</p>"
+      }
+    }
+  },
+  {
+    "id": "gauntlets-of-ogre-power",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Gantelets de puissance d'ogre",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ces gants, votre valeur de Force est de 19. Si elle est déjà de 19 ou plus, ils n'ont aucun effet sur vous.</p>"
+      }
+    }
+  },
+  {
+    "id": "gloves-of-swimming-and-climbing",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Gants de nage et d'escalade",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ces gants, la natation et l'escalade ne vous demandent pas de déplacement supplémentaire et vous gagnez un bonus de +5 aux tests de Force (Athlétisme) pour grimper ou nager.</p>"
+      }
+    }
+  },
+  {
+    "id": "gloves-of-missile-snaring",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Gants piégeurs de projectiles",
+        "subtype": null,
+        "description": "<p>Quand vous enfliez ces gants, ils semblent presque fusionner avec votre peau. Quand vous êtes touché par une attaque d'arme à distance alors que vous les portez, vous pouvez utiliser votre réaction pour réduire les dégâts subis de 1d10 + votre modificateur de Dextérité, à condition que vous ayez une main libre. Si vous réduisez les dégâts à 0, vous attrapez le projectile (s'il est de taille assez réduite pour que vous puissiez le tenir d'une main).</p>"
+      }
+    }
+  },
+  {
+    "id": "elemental-gem",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Gemme élémentaire",
+        "subtype": null,
+        "description": "<p>Cette gemme contient une particule d'énergie élémentaire. Quand vous brisez la gemme par une action, un élémentaire apparaît, comme si vous l'aviez invoqué avec un sort d'<a href=\"/grimoire/invoquer-un-elementaire\"><em>invoquer un élémentaire</em></a> et la gemme perd toute magie. Le type d'élémentaire invoqué dépend de la gemme utilisée.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: left;\">Gemme</th>\n<th style=\"text-align: left;\">Élémentaire invoqué</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: left;\"><strong>Saphir bleu</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-de-lair\">Élémentaire de l'air</a></td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Diamant jaune</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-de-la-terre\">Élémentaire de la terre</a></td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Corindon rouge</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-du-feu\">Élémentaire du feu</a></td>\n</tr>\n<tr>\n<td style=\"text-align: left;\"><strong>Émeraude</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elementaire-de-leau\">Élémentaire de l'eau</a></td>\n</tr>\n</tbody>\n</table></div></div>"
+      }
+    }
+  },
+  {
+    "id": "helm-of-comprehending-languages",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Heaume de compréhension des langages",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce heaume, vous pouvez utiliser une action pour lancer <a href=\"/grimoire/comprehension-des-langues\"><em>compréhension des langues</em></a> à volonté par son intermédiaire.</p>"
+      }
+    }
+  },
+  {
+    "id": "helm-of-telepathy",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Heaume de télépathie",
+        "subtype": null,
+        "description": "<p>Tant que vous portez ce heaume, vous pouvez utiliser une action pour lancer <a href=\"/grimoire/detection-des-pensees\"><em>détection des pensées</em></a> (DD 13) par son intermédiaire. Tant que vous restez concentré sur le sort, vous pouvez utiliser une action bonus pour envoyer un message télépathique à une créature sur laquelle vous vous concentrez. Elle peut vous répondre (en utilisant une action bonus) tant que vous restez concentré sur elle.</p>\n<p>Tant que vous vous concentrez sur une créature avec <a href=\"/grimoire/detection-des-pensees\"><em>détection des pensées</em></a>, vous pouvez utiliser une action pour lancer le sort <a href=\"/grimoire/suggestion\"><em>suggestion</em></a> (DD 13) sur elle par l'intermédiaire du heaume. Une fois que vous avez utilisé ce pouvoir, vous devez attendre l'aube suivante avant de pouvoir recommencer.</p>"
+      }
+    }
+  },
+  {
+    "id": "oil-of-slipperiness",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Huile glissante",
+        "subtype": null,
+        "description": "<p>Cet épais onguent noir est dense et lourd tant qu'il reste dans son récipient, mais il coule avec fluidité dès qu'on le verse. Il permet de recouvrir une créature de taille M ou inférieure (il faut verser une fiole de plus pour chaque catégorie de taille au-dessus de M). Il faut 10 minutes pour appliquer l'huile. La créature affectée bénéficie alors des effets du sort <a href=\"/grimoire/liberte-de-mouvement\"><em>liberté de mouvement</em></a> pendant 8 heures.</p>\n<p>Sinon, vous pouvez verser l'huile à terre par une action. Elle recouvre une zone de 3 mètres de côté et produit les mêmes effets que le sort <a href=\"/grimoire/graisse\"><em>graisse</em></a>.</p>"
+      }
+    }
+  },
+  {
+    "id": "javelin-of-lightning",
+    "source": "srd_5.1",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Javeline de foudre",
+        "subtype": "Javeline",
+        "description": "<p>Cette javeline est une arme magique. Quand vous la lancez et prononcez son mot de commande, elle se transforme en éclair, formant une ligne de 1,50 mètre de large qui s'étend de votre personne jusqu'à une cible située à une distance maximale de 36 mètres. Chaque créature présente sur cette ligne, à l'exception de vous et de votre cible, doit faire un jet de sauvegarde de Dextérité DD 13. Celles qui échouent subissent 4d6 points de dégâts de foudre, les autres la moitié seulement. L'éclair reprend sa forme de javeline quand il atteint sa cible. Faites une attaque d'arme à distance contre elle. Si vous touchez, la cible subit les dégâts habituels de la javeline plus 4d6 dégâts de foudre.</p>\n<p>Il faut attendre l'aube suivante pour se servir de nouveau de cette propriété de la javeline. En attendant, elle fonctionne tout de même comme une arme magique.</p>"
+      }
+    }
+  },
+  {
+    "id": "lantern-of-revealing",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Lanterne de révélation",
+        "subtype": null,
+        "description": "<p>Quand cette lanterne à capote est allumée, elle brûle pendant 6 heures en consommant 0,5 litre d'huile. Elle émet alors une vive lumière dans un rayon de 9 mètres et une faible lumière dans un rayon de 9 mètres de plus. Les créatures et les objets <a href=\"/gerer-la-sante-du-personnage#invisible\"><em>invisibles</em></a> situés dans la zone de vive lumière de la lanterne deviennent visibles. Vous pouvez utiliser une action pour baisser la capote et réduire la luminosité à une faible lumière dans un rayon de 1,50 mètre.</p>"
+      }
+    }
+  },
+  {
+    "id": "eyes-of-minute-seeing",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Lentilles de netteté",
+        "subtype": null,
+        "description": "<p>Ces lentilles de cristal se portent sur les yeux. Tant que vous les portez, votre vue est bien meilleure que d'habitude dans un rayon de 30 centimètres. Vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests d'Intelligence (Investigation) basés sur la vue quand vous fouillez une zone ou étudiez un objet situé dans ce rayon.</p>"
+      }
+    }
+  },
+  {
+    "id": "goggles-of-night",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Lunettes nocturnes",
+        "subtype": null,
+        "description": "<p>Quand vous portez ces verres sombres, vous bénéficiez de la vision dans le noir à 18 mètres. Si vous disposez déjà de ce pouvoir, son rayon augmente de 18 mètres.</p>"
+      }
+    }
+  },
+  {
+    "id": "medallion-of-thoughts",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Médaillon des pensées",
+        "subtype": null,
+        "description": "<p>Le médaillon a 3 charges. Tant que vous le portez, vous pouvez utiliser une action et dépenser une charge pour lancer <a href=\"/grimoire/detection-des-pensees\"><em>détection des pensées</em></a> (DD 13) par son intermédiaire. Chaque matin à l'aube, il récupère 1d3 charges dépensées.</p>"
+      }
+    }
+  },
+  {
+    "id": "ammunition-plus-1",
+    "source": "srd_5.1",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Munition +1",
+        "subtype": "N'importe quelle munition",
+        "description": "<p>Vous bénéficiez d'un bonus aux jets d'attaque et de dégâts de +1 effectués avec cette munition. Cette dernière perd toute magie dès qu'elle a touché une cible.</p>"
+      }
+    }
+  },
+  {
+    "id": "eyes-of-the-eagle",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Œil de lynx",
+        "subtype": null,
+        "description": "<p>Ces lentilles de cristal se portent sur les yeux. Tant que vous les portez, vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests de Sagesse (Perception) basés sur la vue. Si la visibilité est bien dégagée, vous percevez tous les détails des créatures et des objets, même très éloignés, à conditions que ces créatures et objets fassent au moins 60 centimètres de large.</p>"
+      }
+    }
+  },
+  {
+    "id": "spell-scroll-1st-level",
+    "source": "srd_5.1",
+    "type": "scroll",
+    "rarity": "common",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Parchemin magique (Niveau 1)",
+        "subtype": null,
+        "description": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 13<br>\n<strong>Bonus à l'attaque</strong> : +5</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>"
+      }
+    }
+  },
+  {
+    "id": "spell-scroll-2nd-level",
+    "source": "srd_5.1",
+    "type": "scroll",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Parchemin magique (Niveau 2)",
+        "subtype": null,
+        "description": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 13<br>\n<strong>Bonus à l'attaque</strong> : +5</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>"
+      }
+    }
+  },
+  {
+    "id": "spell-scroll-3rd-level",
+    "source": "srd_5.1",
+    "type": "scroll",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Parchemin magique (Niveau 3)",
+        "subtype": null,
+        "description": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 15<br>\n<strong>Bonus à l'attaque</strong> : +7</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>"
+      }
+    }
+  },
+  {
+    "id": "spell-scroll-cantrip",
+    "source": "srd_5.1",
+    "type": "scroll",
+    "rarity": "common",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Parchemin magique (Tour de magie)",
+        "subtype": null,
+        "description": "<p>Sur un <em>parchemin magique</em> est inscrite la formule d'un unique sort, rédigée tel un message mystique crypté. Si le sort est présent dans la liste de sorts de votre classe de personnage, vous pouvez utiliser une action pour lire le parchemin et lancer le sort qu'il contient sans devoir fournir aucune de ses composantes. Sinon, le sort est incompréhensible.</p>\n<p>Si le sort est présent dans la liste de sorts de votre classe de personnage mais d'un niveau supérieur à ceux que vous êtes normalement capable de lancer, vous devez effectuer un test de caractéristique en utilisant votre caractéristique d'incantation pour déterminer si vous parvenez à le lancer. Le DD est égal à 10 + le niveau du sort. En cas de test raté, le sort disparaît du parchemin sans produire d'effet.</p>\n<p>Une fois le sort lancé, la formule disparaît de la surface du parchemin qui tombe ensuite en poussière.</p>\n<p><strong>DD du jet de sauvegarde</strong> : 13<br>\n<strong>Bonus à l'attaque</strong> : +5</p>\n<p>Un sort de magicien inscrit sur un <em>parchemin magique</em> peut être recopié, tout comme on recopie les sorts dans un grimoire. Quand un sort est recopié depuis un <em>parchemin magique</em>, celui qui s'y adonne doit réussir un test d'Intelligence (Arcanes) contre un DD égal à 10 + le niveau du sort. En cas de réussite sur ce test, le sort est recopié avec succès. Le <em>parchemin magique</em> est détruit quel que la soit le résultat du test.</p>"
+      }
+    }
+  },
+  {
+    "id": "pearl-of-power",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Perle de puissance",
+        "subtype": null,
+        "description": "<p>Tant que vous portez cette perle sur vous, vous pouvez utiliser une action pour prononcer son mot de commande et récupérer un emplacement de sort dépensé. En revanche, si ce dernier est de niveau 4 ou supérieur, le nouvel emplacement est de niveau 3. Une fois que vous avez utilisé la perle, vous devez attendre l'aube suivante pour vous en servir à nouveau.</p>"
+      }
+    }
+  },
+  {
+    "id": "philter-of-love",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Philtre d'amour",
+        "subtype": null,
+        "description": "<p>Dans les 10 minutes qui suivent l'absorption de cette potion, vous êtes <a href=\"/gerer-la-sante-du-personnage#charmé\"><em>charmé</em></a> pendant 1 heure par la première créature que vous voyez. Si cette créature est d'une espèce et d'un sexe pour lesquels vous êtes susceptible de ressentir une attirance naturelle, vous considérez vos sentiments comme un amour véritable pendant toute la durée du charme. La potion est effervescente et de teinte rose et contient une bulle en forme de cœur, mais on peut facilement ne pas la voir parmi les autres.</p>"
+      }
+    }
+  },
+  {
+    "id": "stone-of-good-luck",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Pierre porte-bonheur",
+        "subtype": null,
+        "description": "<p>Tant que vous portez sur vous cette agate lustrée, vous bénéficiez d'un bonus de +1 aux tests de caractéristique et aux jets de sauvegarde.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-growth",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion d'agrandissement",
+        "subtype": null,
+        "description": "<p>Quand vous buvez cette potion, vous êtes affecté par la version « <em>agrandir</em> » du sort <a href=\"/grimoire/agrandir-retrecir\"><em>agrandir/rétrécir</em></a> pendant 1d4 heures (sans avoir besoin de vous concentrer). Une tache rouge dans le liquide s'étend jusqu'à colorer tout le liquide translucide et se rétracte pour former une petite bille. Ce cycle se répète sans cesse sans interruption, même si on secoue la bouteille.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-animal-friendship",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion d'amitié avec les animaux",
+        "subtype": null,
+        "description": "<p>Quand vous buvez cette potion, vous pouvez lancer le sort <a href=\"/grimoire/amitie-avec-les-animaux\"><em>amitié avec les animaux</em></a> (DD 13) à volonté pendant 1 heure. Si on agite ce liquide trouble, on distingue de petits morceaux : une écaille de poisson, une langue de colibri, une griffe de chat ou des poils d'écureuil.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-climbing",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "common",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion d'escalade",
+        "subtype": null,
+        "description": "<p>Quand vous buvez cette potion, vous gagnez une vitesse d'escalade égale à votre vitesse au sol pendant 1 heure. Pendant tout ce temps, vous obtenez l'<a href=\"/utiliser-les-caracteristiques#avantage-et-désasavantage\"><em>avantage</em></a> lors des tests de Force (Escalade) que vous effectuez pour grimper. La potion se divise en couches brunes, argent et grises qui rappellent des stries dans la roche. Les couleurs ne se mélangent pas, même quand on agite la bouteille.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-hill-giant-strength",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion de force de géant des collines",
+        "subtype": null,
+        "description": "<p>Quand vous buvez cette potion, votre valeur de Force est égale à 21 pendant 1 heure. La potion n'a aucun effet si votre Force est déjà égale ou supérieure à cette valeur.</p>\n<p>Une rognure d'ongle d'un géant du type approprié flotte dans cette potion transparente.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-poison",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion de poison",
+        "subtype": null,
+        "description": "<p>Cette concoction ressemble, tant au niveau du goût, de l'odeur et de l'aspect visuel, à une <a href=\"/liste-objets-magiques/potion-de-soins\"><em>potion de soins</em></a> ou autre potion bénéfique. C'est pourtant du poison dissimulé par une magie illusoire, et un sort d'<a href=\"/grimoire/identification\"><em>identification</em></a> révèle sa véritable nature.</p>\n<p>Vous subissez 3d6 dégâts de poison et devez réussir un jet de sauvegarde de Constitution DD 13 pour ne pas être <a href=\"/gerer-la-sante-du-personnage#empoisonné\"><em>empoisonné</em></a> si vous la buvez. Vous subissez 3d6 dégâts de poison au début de chacun de vos tours tant que vous êtes <a href=\"/gerer-la-sante-du-personnage#empoisonné\"><em>empoisonné</em></a> de cette façon. À la fin de chacun de vos tours, vous pouvez retenter le jet de sauvegarde. En cas de réussite, les dégâts de poison subis lors des tours suivants diminuent de 1d6, et le poison disparaît quand les dégâts sont réduits à 0.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-resistance",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion de résistance",
+        "subtype": null,
+        "description": "<p>Vous bénéficiez d'une résistance à un type spécifique de dégâts pendant 1 heure après avoir bu cette potion. Le MJ choisit le type ou le détermine au hasard parmi les potions suivantes.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D10</th>\n<th style=\"text-align: center;\">Type de dégâts</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: center;\">Acide</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: center;\">Froid</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: center;\">Feu</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: center;\">Force</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: center;\">Foudre</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: center;\">Nécrotique</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: center;\">Poison</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: center;\">Psychique</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>9</strong></td>\n<td style=\"text-align: center;\">Radiant</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>10</strong></td>\n<td style=\"text-align: center;\">Tonnerre</td>\n</tr>\n</tbody>\n</table></div></div>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-water-breathing",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion de respiration aquatique",
+        "subtype": null,
+        "description": "<p>Vous pouvez respirer sous l'eau pendant 1 heure après avoir bu cette potion. Le liquide vert et trouble qu'elle contient, dans lequel flotte une bulle à l'aspect de méduse, sent la mer.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-healing",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "common",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion de soins",
+        "subtype": null,
+        "description": "<p>Vous récupérez 2d4+2 points de vie quand vous buvez cette potion. Son liquide rouge scintille quand on l'agite.</p>"
+      }
+    }
+  },
+  {
+    "id": "potion-of-greater-healing",
+    "source": "srd_5.1",
+    "type": "potion",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Potion de soins supérieurs",
+        "subtype": null,
+        "description": "<p>Vous récupérez 4d4+4 points de vie quand vous buvez cette potion. Son liquide rouge scintille quand on l'agite.</p>"
+      }
+    }
+  },
+  {
+    "id": "dust-of-sneezing-and-choking",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Poussière à éternuer",
+        "subtype": null,
+        "description": "<p>Cette poudre se trouve dans un petit récipient et ressemble à du sable fin. On dirait de la <a href=\"/liste-objets-magiques/poussiere-de-disparition\"><em>poussière de disparition</em></a> et le sort d'<a href=\"/grimoire/identification\"><em>identification</em></a> confirme cette erreur. Il y en a assez pour une seule utilisation.</p>\n<p>Quand vous utilisez une action pour jeter une poignée de poussière dans les airs, vous et chaque créature qui a besoin de respirer et se trouve dans un rayon de 9 mètres autour de vous doit réussir un jet de sauvegarde de Constitution DD 15 ou se retrouver incapable de respirer tant elle tousse. Une créature ainsi affectée est <a href=\"/gerer-la-sante-du-personnage#neutralisé\"><em>neutralisée</em></a> et suffoque. Tant qu'elle est consciente, la créature peut refaire le jet de sauvegarde à la fin de chacun de ses tours, sachant que l'effet se termine pour elle si elle réussit. Le sort de <a href=\"/grimoire/restauration-inferieure\"><em>restauration inférieure</em></a> met aussi un terme à l'effet sur la créature qu'il touche.</p>"
+      }
+    }
+  },
+  {
+    "id": "dust-of-dryness",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Poussière d'assèchement",
+        "subtype": null,
+        "description": "<p>Ce petit paquet contient 1d6+4 pincées de poussière. Vous pouvez dépenser une action pour en saupoudrer une sur l'eau. La poussière transforme un cube d'eau de 4,50 mètres d'arête en une boulette de la taille d'une bille. Elle flotte ou repose près de l'endroit où vous avez saupoudré la poussière. Son poids est négligeable.</p>\n<p>Quelqu'un peut utiliser une action pour briser la boulette contre une surface solide : elle éclate alors et libère l'eau absorbée. La magie de la boulette disparaît alors.</p>\n<p>Un élémentaire majoritairement composé d'eau exposé à la poussière doit faire un jet de sauvegarde de Constitution. S'il échoue, il subit 10d6 dégâts nécrotiques, la moitié seulement sinon.</p>"
+      }
+    }
+  },
+  {
+    "id": "dust-of-disappearance",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Poussière de disparition",
+        "subtype": null,
+        "description": "<p>Cette poudre se trouve dans un petit paquet et ressemble à du sable fin. Il y en a assez pour une utilisation. Si vous utilisez une action pour lancer la poussière en l'air, vous et chaque créature et objet situé dans un rayon de 3 mètres autour de vous devenez <a href=\"/gerer-la-sante-du-personnage#invisible\"><em>invisible</em></a> pendant 2d4 minutes. La durée est la même pour toutes les cibles et la poussière est entièrement consumée dès que sa magie fait effet. Si une créature affectée par la poussière attaque ou lance un sort, l'invisibilité se termine pour elle.</p>"
+      }
+    }
+  },
+  {
+    "id": "eyes-of-charming",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Regard charmeur",
+        "subtype": null,
+        "description": "<p>Ces lentilles de cristal se portent sur les yeux et possèdent trois charges. Tant que vous les portez, vous pouvez dépenser une charge pour lancer le sort <a href=\"/grimoire/charme-personne\"><em>charme-personne</em></a> (DD 13) sur un humanoïde situé dans un rayon de 9 mètres, à condition que vous voyiez la cible et qu'elle vous voie. Chaque jour à l'aube, les lentilles régénèrent toutes les charges dépensées.</p>"
+      }
+    }
+  },
+  {
+    "id": "robe-of-useful-items",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Robe d'objets pratiques",
+        "subtype": null,
+        "description": "<p>Cette robe est couverte de pièces de tissu de formes et de couleurs diverses. Tant que vous portez ce vêtement, vous pouvez effectuer une action pour détacher une des pièces et provoquer sa transformation en l'objet ou la créature qu'elle représente. Dès que la dernière pièce est détachée, la robe devient un vêtement ordinaire.</p>\n<p>Deux pièces de chacun des éléments suivants sont cousues sur la robe :</p>\n<ul>\n<li>Dague</li>\n<li>Lanterne sourde (remplie et allumée)</li>\n<li>Miroir en acier</li>\n<li>Perche de 3 mètres</li>\n<li>Corde de chanvre (15 mètres, enroulée)</li>\n<li>Sac</li>\n</ul>\n<p>En outre, la robe se compose de 4d4 autres pièces. Le MJ choisit ces pièces ou les détermine au hasard.</p>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D100</th>\n<th style=\"text-align: left;\">Pièce</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>01-08</strong></td>\n<td style=\"text-align: left;\">100 po dans un sac</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>09-15</strong></td>\n<td style=\"text-align: left;\">Coffre en argent (30 centimètres de long, 15 centimètres de large et de profondeur) d'une valeur de 500 po</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>16-22</strong></td>\n<td style=\"text-align: left;\">Porte en fer (d'une largeur et d'une hauteur maximales de 3 mètres, barrée du côté de votre choix) que vous pouvez placer dans une ouverture à votre portée ; la taille s'adapte aux dimensions de l'ouverture et s'y fixe d'elle-même.</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>23-30</strong></td>\n<td style=\"text-align: left;\">10 pierres précieuses d'une valeur de 100 po chacune</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>34-44</strong></td>\n<td style=\"text-align: left;\">Échelle en bois de 7,30 mètres de long</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>45-51</strong></td>\n<td style=\"text-align: left;\">Cheval de selle avec fontes</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>52-59</strong></td>\n<td style=\"text-align: left;\">Fosse (cube de 3 mètres d'arête) que vous pouvez placer dans le sol à 3 mètres ou moins de vous</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>60-68</strong></td>\n<td style=\"text-align: left;\">4 potions de soins</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>69-75</strong></td>\n<td style=\"text-align: left;\">Barque (3,60 mètres de long)</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>76-83</strong></td>\n<td style=\"text-align: left;\">Parchemin magique contenant un sort de niveau 1 à 3</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>84-90</strong></td>\n<td style=\"text-align: left;\">2 <a href=\"/bestiaire/mastiff\">molosses</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>91-96</strong></td>\n<td style=\"text-align: left;\">Fenêtre (60 centimètres sur 1,20 mètre et jusqu'à 60 centimètres d'épaisseur) que vous pouvez placer sur une surface verticale à votre portée</td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>97-00</strong></td>\n<td style=\"text-align: left;\">Bélier portable</td>\n</tr>\n</tbody>\n</table></div></div>"
+      }
+    }
+  },
+  {
+    "id": "bag-of-tricks",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Sac à malice",
+        "subtype": null,
+        "description": "<p>Ce banal sac gris, rouille ou brun semble vide. Cependant, si l'on plonge la main à l'intérieur, on sent un petit objet duveteux. Le sac pèse 250 grammes.</p>\n<p>Vous pouvez dépenser une action pour sortir l'objet duveteux du sac et le lancer à une distance maximale de 6 mètres. Quand il atterrit, il se transforme en une créature que vous déterminez en lançant un d8 dans la table correspondant à la couleur du sac.</p>\n<p>La créature se montre amicale envers vous et vos compagnons et agit à votre tour. Vous pouvez utiliser une action bonus pour gérer ses déplacements et son action lors de son prochain tour ou pour lui donner des ordres génériques, comme d'attaquer vos ennemis. En l'absence d'ordre, la créature se comporte en accord avec sa nature.</p>\n<p>Une fois que vous avez sorti trois objets duveteux du sac, il devient inutile jusqu'à l'aube suivante.</p>\n<div  class=\"table-container\">\n<h2 id=\"sac-a-malice-gris\">Sac à malice gris</h2>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D8</th>\n<th style=\"text-align: left;\">Créature</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/belette\">Belette</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/rat-geant\">Rat géant</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/blaireau\">Blaireau</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/sanglier\">Sanglier</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/panthere\">Panthère</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/blaireau-geant\">Blaireau géant</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/loup-sanguinaire\">Loup sanguinaire</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/elan-geant\">Élan géant</a></td>\n</tr>\n</tbody>\n</table></div></div>\n</div>\n<div  class=\"table-container\">\n<h2 id=\"sac-a-malice-rouille\">Sac à malice rouille</h2>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D8</th>\n<th style=\"text-align: left;\">Créature</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/rat\">Rat</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chouette\">Chouette</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/mastiff\">Mastiff</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chevre\">Chèvre</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chevre-geante\">Chèvre géante</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/sanglier-geant\">Sanglier géant</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/lion\">Lion</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/ours-brun\">Ours brun</a></td>\n</tr>\n</tbody>\n</table></div></div>\n</div>\n<div  class=\"table-container\">\n<h2 id=\"sac-a-malice-brun\">Sac à malice brun</h2>\n<div class='simple-responsive-table'><div><table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">D8</th>\n<th style=\"text-align: left;\">Créature</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\"><strong>1</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/chacal\">Chacal</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>2</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/grand-singe\">Grand singe</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>3</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/babouin\">Babouin</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>4</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/bec-de-hache\">Bec de hache</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>5</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/ours-noir\">Ours noir</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>6</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/belette-geante\">Belette géante</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>7</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/hyene-geante\">Hyène géante</a></td>\n</tr>\n<tr>\n<td style=\"text-align: center;\"><strong>8</strong></td>\n<td style=\"text-align: left;\"><a href=\"/bestiaire/tigre\">Tigre</a></td>\n</tr>\n</tbody>\n</table></div></div>\n</div>"
+      }
+    }
+  },
+  {
+    "id": "bag-of-holding",
+    "source": "srd_5.1",
+    "type": "wondrous_item",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Sac sans fond",
+        "subtype": null,
+        "description": "<p>Ce sac abrite un espace intérieur bien plus grand que ce que ses dimensions extérieures laissent présager. Visuellement, il fait une soixantaine de centimètres de diamètre au niveau de l'ouverture pour 1,20 mètre de profondeur. En revanche, il peut contenir jusqu'à 250 kilos de matière, sans dépasser un volume de 2000 litres. Le sac pèse 7,5 kilos, quel que soit son contenu. Il faut dépenser une action pour récupérer un objet dans le sac.</p>\n<p>Si le sac est surchargé, percé ou déchiré, il se découd complètement. Il est alors détruit et son contenu s'éparpille sur le plan Astral. Si on retourne le sac sur l'envers, son contenu se répand à terre, sans dommage, mais il faut le remettre sur l'endroit avant de pouvoir s'en servir de nouveau. Si l'on place une créature ayant besoin de respirer dans le sac, sa survie est limitée : elle peut y rester un nombre de minutes égal à 10 divisé par le nombre de créatures présentes dans le sac (une minute au minimum), ensuite, elle commence à suffoquer.</p>\n<p>Si l'on place un sac sans fond dans l'espace extradimensionnel né d'un <a href=\"/liste-objets-magiques/havresac-magique\"><em>havresac magique</em></a>, d'un <a href=\"/liste-objets-magiques/puits-portatif\"><em>puits portatif</em></a> ou d'un objet similaire, les deux objets sont instantanément détruits et un portail s'ouvre vers le plan Astral. Il apparaît là où l'on a placé le premier objet dans le second et toutes les créatures situées dans un rayon de 3 mètres autour de ce portail sont emportées vers un endroit aléatoire du plan Astral. Le portail se referme ensuite, sachant qu'il est à sens unique et qu'il est impossible de le rouvrir.</p>"
+      }
+    }
+  },
+  {
+    "id": "immovable-rod",
+    "source": "srd_5.1",
+    "type": "rod",
+    "rarity": "uncommon",
+    "attunement": false,
+    "translations": {
+      "fr": {
+        "name": "Sceptre inamovible",
+        "subtype": null,
+        "description": "<p>Ce sceptre plat en fer est équipé d'un bouton sur une extrémité. Vous pouvez utiliser une action pour appuyer dessus : il se fixe alors par magie à l'endroit où il se trouve. Il ne bouge plus tant que vous ou une tierce personne n'utilisez pas une action pour appuyer de nouveau sur le bouton, même s'il doit pour cela défier les lois de la gravité. Le sceptre peut soutenir jusqu'à 4 tonnes. Il se désactive et tombe si on lui fait porter plus de poids. Une créature peut utiliser une action pour faire un test de Force DD 30 afin de déplacer le sceptre. Si elle réussit, il bouge d'au maximum 3 mètres.</p>"
+      }
+    }
+  },
+  {
+    "id": "trident-of-fish-command",
+    "source": "srd_5.1",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "attunement": true,
+    "translations": {
+      "fr": {
+        "name": "Trident de domination aquatique",
+        "subtype": "Trident",
+        "description": "<p>Ce trident est une arme magique. Il contient 3 charges. Tant que vous le portez sur vous, vous pouvez utiliser une action et dépenser 1 charge pour lancer <a href=\"/grimoire/dominer-une-bete\"><em>dominer une bête</em></a> (DD du jet de sauvegarde 15) par son biais sur une créature qui sait nager de manière innée et possède une vitesse à la nage. Le trident récupère 1d3 charges dépensées chaque jour, à l'aube.</p>"
+      }
+    }
+  }
+]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ For detailed feature specifications, see the [PRDs](prd/).
 > Bring current implementations to a production-ready state. - [PRD-001](prd/PRD-001-REFERENCE-DATA.md)
 
 - [x] Complete Spellbook filters (school, class) - [PRD-001a](prd/PRD-001a-SPELLBOOK.md)
-- [x] Complete Inventory filters (type, rarity) - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
+- [x] Complete Magical item filters (type, rarity) - [PRD-001b](prd/PRD-001b-ITEM-LIST.md)
 - [x] Complete Bestiary filters (type, CR) - [PRD-001c](prd/PRD-001c-BESTIARY.md)
 
 ## Phase 3 - Local Lists

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,8 +35,8 @@ For detailed feature specifications, see the [PRDs](prd/).
 - [x] Setup backend service with a simple API
 - [ ] Data quality & coherence — DB-ready models, i18n, source tracking
   - [x] Architecture decisions & SRD translation map ([ADR-001](adr/ADR-001-data-model.md), [i18n](i18n/srd-fr-en.md))
-  - [ ] Spells: structured components, concentration/ritual flags, complete class list
-  - [ ] Magical items: typed fields normalized
+  - [x] Spells: structured components, concentration/ritual flags, complete class list
+  - [x] Magical items: typed fields normalized
   - [ ] Creatures: full stat block (speed, senses, skills, saving throws, damage affinities); character model coherence
 - [ ] Fetch public reference data from backend (spells, items, creatures)
 - [ ] Develop the sync engine on which will rely all sync logic and conflict resolution

--- a/docs/i18n/data-ingestion.md
+++ b/docs/i18n/data-ingestion.md
@@ -70,14 +70,15 @@ For the data model decisions behind these formats, see [`docs/adr/ADR-001-data-m
 
 ```json
 {
-  "id": "amulet-of-health",
+  "id": "shield-plus-1",
   "source": "srd_5.1",
-  "type": "wondrous_item",
+  "type": "armor",
   "rarity": "uncommon",
-  "attunement": true,
+  "attunement": false,
   "translations": {
     "fr": {
-      "name": "Amulette de cicatrisation",
+      "name": "Bouclier +1",
+      "subtype": "Bouclier",
       "description": "<p>...</p>"
     }
   }
@@ -95,6 +96,7 @@ For the data model decisions behind these formats, see [`docs/adr/ADR-001-data-m
 - [ ] `rarity` — see [Magical Item Rarities](srd-fr-en.md#magical-item-rarities)
 - [ ] `attunement` — boolean
 - [ ] `translations.fr.name`
+- [ ] `translations.fr.subtype` — optional; weapon/armor sub-category (locale-specific)
 - [ ] `translations.fr.description` — HTML
 
 ---

--- a/server-go/internal/model/magical_item.go
+++ b/server-go/internal/model/magical_item.go
@@ -2,19 +2,34 @@ package model
 
 // MagicalItem is the API response model for a compendium magical item.
 type MagicalItem struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Type        string `json:"type"`
-	Rarity      string `json:"rarity"`
-	Attunement  bool   `json:"attunement"`
+	ID           string                            `json:"id"`
+	Source       string                            `json:"source"`
+	Type         string                            `json:"type"`
+	Rarity       string                            `json:"rarity"`
+	Attunement   bool                              `json:"attunement"`
+	Translations map[string]MagicalItemTranslation `json:"translations"`
+}
+
+// MagicalItemTranslation holds locale-specific fields for a magical item.
+type MagicalItemTranslation struct {
+	Name        string  `json:"name"`
+	Subtype     *string `json:"subtype"`
+	Description string  `json:"description"`
 }
 
 // MagicalItemJson mirrors the raw JSON structure of magical-items.json.
 type MagicalItemJson struct {
-	Title      *string `json:"title"`
-	Content    *string `json:"content"`
-	Type       *string `json:"type"`
-	Rarity     *string `json:"rarity"`
-	Attunement *string `json:"attunement"`
+	ID           *string                                `json:"id"`
+	Source       *string                                `json:"source"`
+	Type         *string                                `json:"type"`
+	Rarity       *string                                `json:"rarity"`
+	Attunement   *bool                                  `json:"attunement"`
+	Translations map[string]MagicalItemTranslationJson  `json:"translations"`
+}
+
+// MagicalItemTranslationJson mirrors the raw JSON translation entry.
+type MagicalItemTranslationJson struct {
+	Name        *string `json:"name"`
+	Subtype     *string `json:"subtype"`
+	Description *string `json:"description"`
 }

--- a/server-go/internal/store/json_store.go
+++ b/server-go/internal/store/json_store.go
@@ -209,17 +209,58 @@ func creatureFromJson(r model.CreatureJson) (model.Creature, bool) {
 }
 
 func magicalItemFromJson(r model.MagicalItemJson) (model.MagicalItem, bool) {
-	if r.Title == nil || *r.Title == "" {
+	if r.ID == nil || *r.ID == "" {
+		fmt.Println("WARNING: skipping magical item with missing id")
+		return model.MagicalItem{}, false
+	}
+	id := *r.ID
+	if r.Source == nil {
+		fmt.Printf("WARNING: skipping magical item '%s': missing source\n", id)
+		return model.MagicalItem{}, false
+	}
+	if r.Type == nil {
+		fmt.Printf("WARNING: skipping magical item '%s': missing type\n", id)
+		return model.MagicalItem{}, false
+	}
+	if r.Rarity == nil {
+		fmt.Printf("WARNING: skipping magical item '%s': missing rarity\n", id)
+		return model.MagicalItem{}, false
+	}
+	if len(r.Translations) == 0 {
+		fmt.Printf("WARNING: skipping magical item '%s': missing translations\n", id)
 		return model.MagicalItem{}, false
 	}
 
+	translations := make(map[string]model.MagicalItemTranslation, len(r.Translations))
+	for locale, t := range r.Translations {
+		if t.Name == nil {
+			fmt.Printf("WARNING: magical item '%s' locale '%s': missing name\n", id, locale)
+			continue
+		}
+		if t.Description == nil {
+			fmt.Printf("WARNING: magical item '%s' locale '%s': missing description\n", id, locale)
+			continue
+		}
+		translations[locale] = model.MagicalItemTranslation{
+			Name:        *t.Name,
+			Subtype:     t.Subtype,
+			Description: *t.Description,
+		}
+	}
+	if len(translations) == 0 {
+		fmt.Printf("WARNING: skipping magical item '%s': no valid translations\n", id)
+		return model.MagicalItem{}, false
+	}
+
+	attunement := r.Attunement != nil && *r.Attunement
+
 	return model.MagicalItem{
-		ID:          *r.Title,
-		Title:       *r.Title,
-		Description: derefString(r.Content),
-		Type:        derefString(r.Type),
-		Rarity:      derefString(r.Rarity),
-		Attunement:  r.Attunement != nil && *r.Attunement != "",
+		ID:           id,
+		Source:       *r.Source,
+		Type:         *r.Type,
+		Rarity:       *r.Rarity,
+		Attunement:   attunement,
+		Translations: translations,
 	}, true
 }
 

--- a/server-go/internal/store/json_store_test.go
+++ b/server-go/internal/store/json_store_test.go
@@ -165,23 +165,52 @@ func TestSpellFromJson_nilId(t *testing.T) {
 
 // ── magicalItemFromJson ───────────────────────────────────────────────────────
 
-func TestMagicalItemFromJson_attunementPresent(t *testing.T) {
-	title := "Anneau de protection"
-	att := "Oui"
-	r := model.MagicalItemJson{Title: &title, Attunement: &att}
-	item, ok := magicalItemFromJson(r)
-	if !ok || !item.Attunement {
-		t.Errorf("expected attunement=true, got %+v", item)
+func makeMagicalItemJson(id, source, itemType, rarity string, attunement bool, translations map[string]model.MagicalItemTranslationJson) model.MagicalItemJson {
+	att := attunement
+	return model.MagicalItemJson{
+		ID:           &id,
+		Source:       &source,
+		Type:         &itemType,
+		Rarity:       &rarity,
+		Attunement:   &att,
+		Translations: translations,
 	}
 }
 
-func TestMagicalItemFromJson_attunementEmpty(t *testing.T) {
-	title := "Épée longue +1"
-	empty := ""
-	r := model.MagicalItemJson{Title: &title, Attunement: &empty}
+func TestMagicalItemFromJson_valid(t *testing.T) {
+	name := "Ring of Protection"
+	desc := "<p>...</p>"
+	r := makeMagicalItemJson("ring-of-protection", "srd_5.1", "ring", "rare", true, map[string]model.MagicalItemTranslationJson{
+		"en": {Name: &name, Description: &desc},
+	})
+	item, ok := magicalItemFromJson(r)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if item.ID != "ring-of-protection" || item.Type != "ring" || item.Rarity != "rare" || !item.Attunement {
+		t.Errorf("got %+v", item)
+	}
+	if _, hasEn := item.Translations["en"]; !hasEn {
+		t.Error("expected 'en' translation")
+	}
+}
+
+func TestMagicalItemFromJson_attunementFalse(t *testing.T) {
+	name := "Long Sword +1"
+	desc := "<p>...</p>"
+	r := makeMagicalItemJson("long-sword-plus-1", "srd_5.1", "weapon", "uncommon", false, map[string]model.MagicalItemTranslationJson{
+		"en": {Name: &name, Description: &desc},
+	})
 	item, ok := magicalItemFromJson(r)
 	if !ok || item.Attunement {
 		t.Errorf("expected attunement=false, got %+v", item)
+	}
+}
+
+func TestMagicalItemFromJson_missingId(t *testing.T) {
+	_, ok := magicalItemFromJson(model.MagicalItemJson{})
+	if ok {
+		t.Fatal("expected !ok for missing id")
 	}
 }
 

--- a/server-rust/src/models/magical_item.rs
+++ b/server-rust/src/models/magical_item.rs
@@ -1,13 +1,22 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MagicalItem {
     pub id: String,
-    pub title: String,
-    pub description: String,
+    pub source: String,
     #[serde(rename = "type")]
     pub item_type: String,
     pub rarity: String,
     pub attunement: bool,
+    pub translations: HashMap<String, MagicalItemTranslation>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct MagicalItemTranslation {
+    pub name: String,
+    pub subtype: Option<String>,
+    pub description: String,
 }

--- a/server-rust/src/store/json_store.rs
+++ b/server-rust/src/store/json_store.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::models::{
     creature::{Abilities, Creature},
-    magical_item::MagicalItem,
+    magical_item::{MagicalItem, MagicalItemTranslation},
     spell::{Spell, SpellComponents, SpellTranslation},
 };
 use crate::store::CompendiumStore;
@@ -105,12 +105,20 @@ struct MonsterJson {
 
 #[derive(Deserialize)]
 struct MagicalItemJson {
-    title: Option<String>,
-    content: Option<String>,
+    id: Option<String>,
+    source: Option<String>,
     #[serde(rename = "type")]
     item_type: Option<String>,
     rarity: Option<String>,
-    attunement: Option<String>,
+    attunement: Option<bool>,
+    translations: Option<std::collections::HashMap<String, MagicalItemTranslationJson>>,
+}
+
+#[derive(Deserialize)]
+struct MagicalItemTranslationJson {
+    name: Option<String>,
+    subtype: Option<String>,
+    description: Option<String>,
 }
 
 // ── Parsing helpers ───────────────────────────────────────────────────────────
@@ -306,15 +314,54 @@ fn parse_magical_items(json: &str) -> Result<Vec<MagicalItem>, Box<dyn std::erro
 }
 
 fn magical_item_from_json(raw: MagicalItemJson) -> Option<MagicalItem> {
-    let title = raw.title.filter(|t| !t.is_empty())?;
+    let id = raw.id.filter(|s| !s.is_empty()).or_else(|| {
+        eprintln!("WARNING: skipping magical item with missing id");
+        None
+    })?;
+    let source = raw.source.or_else(|| {
+        eprintln!("WARNING: skipping magical item '{id}': missing source");
+        None
+    })?;
+    let item_type = raw.item_type.or_else(|| {
+        eprintln!("WARNING: skipping magical item '{id}': missing type");
+        None
+    })?;
+    let rarity = raw.rarity.or_else(|| {
+        eprintln!("WARNING: skipping magical item '{id}': missing rarity");
+        None
+    })?;
+    let raw_translations = raw.translations.filter(|t| !t.is_empty()).or_else(|| {
+        eprintln!("WARNING: skipping magical item '{id}': missing translations");
+        None
+    })?;
+
+    let translations = raw_translations
+        .into_iter()
+        .filter_map(|(locale, t)| {
+            let name = t.name.or_else(|| {
+                eprintln!("WARNING: magical item '{id}' locale '{locale}': missing name");
+                None
+            })?;
+            let description = t.description.or_else(|| {
+                eprintln!("WARNING: magical item '{id}' locale '{locale}': missing description");
+                None
+            })?;
+            Some((locale, MagicalItemTranslation { name, subtype: t.subtype, description }))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+
+    if translations.is_empty() {
+        eprintln!("WARNING: skipping magical item '{id}': no valid translations");
+        return None;
+    }
 
     Some(MagicalItem {
-        id: title.clone(),
-        title,
-        description: raw.content.unwrap_or_default(),
-        item_type: raw.item_type.unwrap_or_default(),
-        rarity: raw.rarity.unwrap_or_default(),
-        attunement: raw.attunement.is_some_and(|a| !a.is_empty()),
+        id,
+        source,
+        item_type,
+        rarity,
+        attunement: raw.attunement.unwrap_or(false),
+        translations,
     })
 }
 


### PR DESCRIPTION
## 📝 Description

Sub-step 2 of the data quality & coherence phase (see ADR-001). Brings the magical item layer in line with the spell layer delivered in #78.

**Data (`data/compendium/magical-items.json`)**
- Migrated 82 items to normalized format: slugified English IDs, lowercase English enum values for `type` and `rarity`, `translations` map keyed by locale
- Added optional `subtype` field in each translation (locale-specific weapon/armor sub-category)

**KMP domain & data layer**
- `MagicalItem` domain model: typed `Type` / `Rarity` enums, `translations: Map<String, Translation>`, `resolveTranslation(locale)` with EN fallback
- `MagicalItemImportError` sealed interface — no silent failures, every skip is a typed error
- `JsonMagicalItemRepository` rewritten with `Result`-based parsing, `api`-prefixed variables to avoid shadowing, `entries.find { … }` enum lookup
- `ApiInventoryItem` renamed to `ApiMagicalItem`
- Search queries across all available translations

**Presentation layer**
- `resolveTranslation` called at display time (list + detail)
- ViewModel tests aligned with spell test patterns (`requireNotNull(translations["en"])`)

**Rust server**
- `MagicalItem` + `MagicalItemTranslation` structs; `MagicalItemJson` parser updated for new format

**Go server**
- `MagicalItem` + `MagicalItemTranslation` + `MagicalItemJson` models updated; `magicalItemFromJson` rewritten with explicit warnings; store tests updated

**Cleanup**
- `btn_inventory` string resource renamed to `btn_magical_items`
- ROADMAP.md: "Inventory filters" → "Magical item filters"

## 🖼️ Media

Rust endpoint:
```json
{
  "id": "amulet-of-proof-against-detection-and-location",
  "source": "srd_5.1",
  "type": "wondrous_item",
  "rarity": "uncommon",
  "attunement": true,
  "translations": {
    "fr": {
      "name": "Amulette d'antidétection",
      "subtype": null,
      "description": "<p>...</p>"
    }
  }
}
```

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed