### PR TITLE
feat(magicalitem): add getSubtitle() and unify type/rarity/attunement display

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -62,33 +62,10 @@
     <string name="school_necromancy">Nécromancie</string>
     <string name="school_transmutation">Transmutation</string>
 
-    <!-- Magical Item Type -->
-    <string name="item_type_armor">Armure</string>
-    <string name="item_type_potion">Potion</string>
-    <string name="item_type_ring">Anneau</string>
-    <string name="item_type_rod">Sceptre</string>
-    <string name="item_type_scroll">Parchemin</string>
-    <string name="item_type_staff">Bâton</string>
-    <string name="item_type_wand">Baguette</string>
-    <string name="item_type_weapon">Arme</string>
-    <string name="item_type_wondrous_item">Objet merveilleux</string>
-
-    <!-- Magical Item Rarity -->
-    <string name="item_rarity_common">Commun</string>
-    <string name="item_rarity_uncommon">Peu commun</string>
-    <string name="item_rarity_rare">Rare</string>
-    <string name="item_rarity_very_rare">Très rare</string>
-    <string name="item_rarity_legendary">Légendaire</string>
-    <string name="item_rarity_artifact">Artéfact</string>
-
     <!-- Spell Filter -->
     <string name="title_filter_spells">Filtrer les sorts</string>
     <string name="label_filter_level">Niveau</string>
     <string name="label_filter_class">Classe</string>
     <string name="label_filter_school">Ecole</string>
 
-    <!-- Magical Item Filter -->
-    <string name="title_filter_items">Filtrer les objets</string>
-    <string name="label_filter_type">Type</string>
-    <string name="label_filter_rarity">Rareté</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_magical_items.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_magical_items.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!-- Magical Item Type -->
+    <string name="item_type_armor">Armure</string>
+    <string name="item_type_potion">Potion</string>
+    <string name="item_type_ring">Anneau</string>
+    <string name="item_type_rod">Sceptre</string>
+    <string name="item_type_scroll">Parchemin</string>
+    <string name="item_type_staff">Bâton</string>
+    <string name="item_type_wand">Baguette</string>
+    <string name="item_type_weapon">Arme</string>
+    <string name="item_type_wondrous_item">Objet merveilleux</string>
+
+    <!-- Magical Item Rarity -->
+    <string name="item_rarity_common">Commun</string>
+    <string name="item_rarity_uncommon">Peu commun</string>
+    <string name="item_rarity_rare">Rare</string>
+    <string name="item_rarity_very_rare">Très rare</string>
+    <string name="item_rarity_legendary">Légendaire</string>
+    <string name="item_rarity_artifact">Artéfact</string>
+    <string name="item_requires_attunement">Nécessite une harmonisation</string>
+
+    <!-- Magical Item Filter -->
+    <string name="title_filter_items">Filtrer les objets</string>
+    <string name="label_filter_type">Type</string>
+    <string name="label_filter_rarity">Rareté</string>
+</resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -62,34 +62,10 @@
     <string name="school_necromancy">Necromancy</string>
     <string name="school_transmutation">Transmutation</string>
 
-    <!-- Magical Item Type -->
-    <string name="item_type_armor">Armor</string>
-    <string name="item_type_potion">Potion</string>
-    <string name="item_type_ring">Ring</string>
-    <string name="item_type_rod">Rod</string>
-    <string name="item_type_scroll">Scroll</string>
-    <string name="item_type_staff">Staff</string>
-    <string name="item_type_wand">Wand</string>
-    <string name="item_type_weapon">Weapon</string>
-    <string name="item_type_wondrous_item">Wondrous item</string>
-
-    <!-- Magical Item Rarity -->
-    <string name="item_rarity_common">Common</string>
-    <string name="item_rarity_uncommon">Uncommon</string>
-    <string name="item_rarity_rare">Rare</string>
-    <string name="item_rarity_very_rare">Very rare</string>
-    <string name="item_rarity_legendary">Legendary</string>
-    <string name="item_rarity_artifact">Artifact</string>
-
     <!-- Spell Filter -->
     <string name="title_filter_spells">Filter Spells</string>
     <string name="label_filter_level">Level</string>
     <string name="label_filter_class">Class</string>
     <string name="label_filter_school">School</string>
-
-    <!-- Magical Item Filter -->
-    <string name="title_filter_items">Filter Items</string>
-    <string name="label_filter_type">Type</string>
-    <string name="label_filter_rarity">Rarity</string>
 
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_magical_items.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_magical_items.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!-- Magical Item Type -->
+    <string name="item_type_armor">Armor</string>
+    <string name="item_type_potion">Potion</string>
+    <string name="item_type_ring">Ring</string>
+    <string name="item_type_rod">Rod</string>
+    <string name="item_type_scroll">Scroll</string>
+    <string name="item_type_staff">Staff</string>
+    <string name="item_type_wand">Wand</string>
+    <string name="item_type_weapon">Weapon</string>
+    <string name="item_type_wondrous_item">Wondrous item</string>
+
+    <!-- Magical Item Rarity -->
+    <string name="item_rarity_common">Common</string>
+    <string name="item_rarity_uncommon">Uncommon</string>
+    <string name="item_rarity_rare">Rare</string>
+    <string name="item_rarity_very_rare">Very rare</string>
+    <string name="item_rarity_legendary">Legendary</string>
+    <string name="item_rarity_artifact">Artifact</string>
+    <string name="item_requires_attunement">Requires attunement</string>
+
+    <!-- Magical Item Filter -->
+    <string name="title_filter_items">Filter Items</string>
+    <string name="label_filter_type">Type</string>
+    <string name="label_filter_rarity">Rarity</string>
+</resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MagicalItemFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MagicalItemFormatExt.kt
@@ -11,6 +11,7 @@ import rpg_companion.composeapp.generated.resources.item_rarity_legendary
 import rpg_companion.composeapp.generated.resources.item_rarity_rare
 import rpg_companion.composeapp.generated.resources.item_rarity_uncommon
 import rpg_companion.composeapp.generated.resources.item_rarity_very_rare
+import rpg_companion.composeapp.generated.resources.item_requires_attunement
 import rpg_companion.composeapp.generated.resources.item_type_armor
 import rpg_companion.composeapp.generated.resources.item_type_potion
 import rpg_companion.composeapp.generated.resources.item_type_ring
@@ -48,6 +49,13 @@ fun MagicalItem.Rarity.toFormattedString(): String {
         MagicalItem.Rarity.ARTIFACT -> Res.string.item_rarity_artifact
     }
     return stringResource(stringRes)
+}
+
+@Composable
+fun MagicalItem.getSubtitle(translation: MagicalItem.Translation): String {
+    val subtypeStr = translation.subtype?.let { " ($it)" } ?: ""
+    val attunementStr = if (attunement) " - ${stringResource(Res.string.item_requires_attunement)}" else ""
+    return "${type.toFormattedString()}$subtypeStr - ${rarity.toFormattedString()}$attunementStr"
 }
 
 private val weaponColor = Color(155, 11, 78)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemAddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/MagicalItemAddToListProvider.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.cyrillrx.rpg.app.currentLocale
-import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.component.dnd.getSubtitle
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
@@ -53,7 +53,7 @@ class MagicalItemAddToListProvider(
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = "${entity.type.toFormattedString()} · ${entity.rarity.toFormattedString()}",
+                text = entity.getSubtitle(translation),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.HtmlText
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
+import com.cyrillrx.rpg.core.presentation.component.dnd.getSubtitle
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
@@ -58,20 +59,18 @@ fun MagicalItemCard(
                         bottom = textPadding / 2,
                     ),
             )
-            translation.subtype?.let { subtype ->
-                Text(
-                    text = subtype,
-                    fontSize = 14.sp,
-                    fontStyle = FontStyle.Italic,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            start = textPadding,
-                            end = textPadding,
-                            top = textPadding,
-                        ),
-                )
-            }
+            Text(
+                text = magicalItem.getSubtitle(translation),
+                fontSize = 14.sp,
+                fontStyle = FontStyle.Italic,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = textPadding,
+                        end = textPadding,
+                        top = textPadding,
+                    ),
+            )
             HtmlText(
                 text = translation.description,
                 fontSize = 16.sp,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
+import com.cyrillrx.rpg.core.presentation.component.dnd.getSubtitle
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
@@ -58,15 +59,13 @@ fun MagicalItemListItem(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 
-                translation.subtype?.let { subtype ->
-                    Text(
-                        text = subtype,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
+                Text(
+                    text = magicalItem.getSubtitle(translation),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
 
             Spacer(modifier = Modifier.width(spacingMedium))


### PR DESCRIPTION
## 📝 Description

Unifies the display of magical item metadata (type, subtype, rarity, attunement) across all three UI components via a shared `getSubtitle()` extension function.

Previously, each component displayed these fields differently - `MagicalItemListItem` showed type + optional subtype, `MagicalItemCard` showed only optional subtype, `MagicalItemAddToListProvider` showed type + rarity with no subtype or attunement. This PR normalises the display to `Type (subtype) - Rarity [- Requires attunement]` everywhere.

Commits:
1. Extract magical item string resources into a dedicated `strings_magical_items.xml` (EN + FR), following the `strings_creature.xml` pattern. Adds `item_requires_attunement` string.
2. Add `MagicalItem.getSubtitle(translation)` to `MagicalItemFormatExt`.
3. Use `getSubtitle()` in `MagicalItemListItem`, `MagicalItemCard` and `MagicalItemAddToListProvider`.

## 🖼️ Media

<img width="574" height="1254" alt="image" src="https://github.com/user-attachments/assets/862c93a5-f9e2-4b40-8f24-ceb0a25f0eb6" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed