### PR TITLE
feat(compendium): migrate source format to one YAML file per entity

### DIFF
--- a/.github/workflows/ci-compendium.yml
+++ b/.github/workflows/ci-compendium.yml
@@ -1,0 +1,34 @@
+name: Compendium CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'data/compendium/**/*.yaml'
+      - 'scripts/build_compendium.py'
+  push:
+    branches: [main]
+    paths:
+      - 'data/compendium/**/*.yaml'
+      - 'scripts/build_compendium.py'
+  workflow_dispatch:
+
+jobs:
+  check-compendium:
+    name: Verify generated JSON is up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml markdown
+
+      - name: Check compendium JSON is up to date
+        run: python scripts/build_compendium.py --check

--- a/.github/workflows/ci-compendium.yml
+++ b/.github/workflows/ci-compendium.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install pyyaml markdown
+        run: pip install pyyaml
 
       - name: Check compendium JSON is up to date
         run: python scripts/build_compendium.py --check

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/README.md
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/README.md
@@ -1,0 +1,19 @@
+# Compendium JSON files — do not edit
+
+The JSON files in this directory are **symlinks** to `data/compendium/*.json` in the repository root:
+
+```
+spells.json        → ../../../../../../../../data/compendium/spells.json
+monsters.json      → ../../../../../../../../data/compendium/monsters.json
+magical-items.json → ../../../../../../../../data/compendium/magical-items.json
+```
+
+**Do not copy, replace, or edit these files directly.**  
+They are generated artifacts. The source of truth is `data/compendium/{type}/*.yaml`.
+
+To update the compendium data:
+1. Edit (or add) YAML files in `data/compendium/{spells,monsters,magical-items}/`
+2. Run `python scripts/build_compendium.py` from the repository root
+3. Commit both the YAML changes and the regenerated JSON
+
+See [`docs/adr/adr-002-compendium-source-format.md`](../../../../../../../../docs/adr/adr-002-compendium-source-format.md) for the full rationale.

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/README.md
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/README.md
@@ -16,4 +16,4 @@ To update the compendium data:
 2. Run `python scripts/build_compendium.py` from the repository root
 3. Commit both the YAML changes and the regenerated JSON
 
-See [`docs/adr/adr-002-compendium-source-format.md`](../../../../../../../../docs/adr/adr-002-compendium-source-format.md) for the full rationale.
+See [`docs/adr/adr-002-compendium-source-format.md`](../../../../../../docs/adr/adr-002-compendium-source-format.md) for the full rationale.

--- a/docs/adr/adr-002-compendium-source-format.md
+++ b/docs/adr/adr-002-compendium-source-format.md
@@ -39,19 +39,21 @@ YAML keys use **camelCase**, identical to the JSON output, to keep a 1:1 mapping
 
 ---
 
-## 2. Markdown Descriptions
+## 2. Description Format — Phase 1: HTML, Phase 2: Markdown
 
-### Decision
+### Phase 1 Decision (current)
 
-The `description` field (and any other prose field) in source YAML files uses **GitHub Flavored Markdown (GFM)**. Tables use the GFM pipe syntax.
+Description fields are kept as **HTML** in the YAML source files, identical to the current JSON format. The build script aggregates them unchanged. No conversion is performed.
 
-The build script converts Markdown to HTML for the distributed JSON files (backward compatible with the existing `HtmlText` renderer). In Phase 2 (tracked separately), the Compose renderer will be updated to consume Markdown directly so that tables render natively.
+### Phase 2 Decision (future — tracked separately)
+
+Description fields will be migrated to **GitHub Flavored Markdown (GFM)** when the Compose renderer is updated to consume Markdown directly. At that point, the build script will convert Markdown → HTML for backward compatibility until all clients are updated.
 
 ### Rationale
 
-- HTML tables are painful to write and read by hand. GFM tables are significantly easier to edit, especially before a dedicated editing tool exists.
-- Markdown is renderable as-is in most editors (VS Code, Obsidian, GitHub) — contributors get a live preview for free.
-- Converting Markdown → HTML at build time is trivial and reversible. Converting HTML → Markdown at migration time is a one-off cost.
+- Automated HTML → Markdown conversion produces artifacts on complex content (notably `<strong><em>` combinations in stat blocks). 507 of 513 monster descriptions are affected, making automated migration unsafe for Phase 1.
+- Deferring to Phase 2 keeps the data migration risk-free: round-trip fidelity (YAML → JSON) is exact.
+- Markdown descriptions remain a firm goal: GFM tables are significantly easier to edit than HTML tables, especially before a dedicated editing tool exists.
 
 ---
 

--- a/docs/adr/adr-002-compendium-source-format.md
+++ b/docs/adr/adr-002-compendium-source-format.md
@@ -1,0 +1,100 @@
+# ADR-002: Compendium Source Format — YAML per Entity with Markdown Descriptions
+
+**Status**: Accepted  
+**Date**: 2026-05-04  
+**Context**: Improving contributor ergonomics before the compendium editing tool is built.
+
+---
+
+## 1. One YAML File per Entity
+
+### Decision
+
+The compendium source switches from three monolithic JSON files to **one YAML file per entity**, organized in typed subdirectories:
+
+```
+data/compendium/
+  spells/
+    fireball.yaml
+    acid-splash.yaml
+  monsters/
+    goblin.yaml
+    aarakocra-aeromancer.yaml
+  magical-items/
+    adamantine-armor.yaml
+```
+
+A **build script** (`scripts/build_compendium.py`) aggregates these files back into the three JSON files consumed by the KMP app and the Rust server. The JSON files remain in the repository as generated artifacts so that the app and server require no changes.
+
+### Field naming
+
+YAML keys use **camelCase**, identical to the JSON output, to keep a 1:1 mapping and avoid translation errors in the build script.
+
+### Rationale
+
+- **Git ergonomics**: adding or editing an entity produces a diff scoped to a single file. Merge conflicts on the monolithic JSON files were a persistent friction point.
+- **Discoverability**: `find data/compendium/spells/ -name "*.yaml"` lists every spell. Searching within a 3 MB JSON file is not.
+- **Tool-readiness**: one file per entity is the natural unit for a future CRUD editing tool.
+- **YAML over JSON**: YAML supports multiline strings natively (via `|` block scalar), which is essential for readable Markdown descriptions. Comments are also supported for contributor notes.
+
+---
+
+## 2. Markdown Descriptions
+
+### Decision
+
+The `description` field (and any other prose field) in source YAML files uses **GitHub Flavored Markdown (GFM)**. Tables use the GFM pipe syntax.
+
+The build script converts Markdown to HTML for the distributed JSON files (backward compatible with the existing `HtmlText` renderer). In Phase 2 (tracked separately), the Compose renderer will be updated to consume Markdown directly so that tables render natively.
+
+### Rationale
+
+- HTML tables are painful to write and read by hand. GFM tables are significantly easier to edit, especially before a dedicated editing tool exists.
+- Markdown is renderable as-is in most editors (VS Code, Obsidian, GitHub) — contributors get a live preview for free.
+- Converting Markdown → HTML at build time is trivial and reversible. Converting HTML → Markdown at migration time is a one-off cost.
+
+---
+
+## 3. Build Pipeline
+
+### Decision
+
+```
+data/compendium/{type}/*.yaml
+    ↓  scripts/build_compendium.py
+data/compendium/{spells,monsters,magical-items}.json   ← generated, do not edit
+    ↓  copied automatically
+cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/
+```
+
+A CI workflow (`.github/workflows/ci-compendium.yml`) runs the build script on every PR that touches `data/compendium/**/*.yaml` and verifies that the committed JSON files are up to date.
+
+A migration script (`scripts/migrate_json_to_yaml.py`) handles the one-time conversion from the current JSON format to the new YAML source files (HTML → Markdown via `html2text`).
+
+### Rationale
+
+- Keeping the generated JSON in the repo means zero changes to consumers (KMP app, Rust server).
+- CI enforcement prevents contributors from forgetting to run the build step.
+- The migration script is retained in the repository for traceability, even after it has been run.
+
+---
+
+## 4. Consequences
+
+### Positive
+
+- Editing a single entity no longer requires locating it inside a large file.
+- Tables in descriptions are human-readable and editable.
+- The future editing tool can read/write individual YAML files without loading the entire compendium.
+
+### Negative / Trade-offs
+
+- A build step is now required before the app or server can pick up data changes. CI enforces this.
+- The HTML → Markdown migration is automated but not perfect; manual review of a sample set is required after running the migration script.
+- The Compose renderer does not yet render GFM tables. This is addressed in Phase 2 (separate feature branch `feat/compose-markdown-renderer`).
+
+### Out of Scope
+
+- Cross-entity linking — tracked in a future ADR.
+- User-authored notes (lore, session logs, character annotations) — separate feature (PRD-004).
+- The Compose Markdown renderer update — separate feature branch (`feat/compose-markdown-renderer`).

--- a/docs/adr/adr-002-compendium-source-format.md
+++ b/docs/adr/adr-002-compendium-source-format.md
@@ -71,6 +71,8 @@ cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/
 
 A CI workflow (`.github/workflows/ci-compendium.yml`) runs the build script on every PR that touches `data/compendium/**/*.yaml` and verifies that the committed JSON files are up to date.
 
+The JSON files in `cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/` are **symlinks** to `data/compendium/*.json`. Writing to `data/compendium/spells.json` automatically updates the app resources — no copy step is needed. Do not replace these symlinks with regular files.
+
 A migration script (`scripts/migrate_json_to_yaml.py`) handles the one-time conversion from the current JSON format to the new YAML source files (HTML → Markdown via `html2text`).
 
 ### Rationale

--- a/docs/adr/adr-002-compendium-source-format.md
+++ b/docs/adr/adr-002-compendium-source-format.md
@@ -73,7 +73,7 @@ A CI workflow (`.github/workflows/ci-compendium.yml`) runs the build script on e
 
 The JSON files in `cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/` are **symlinks** to `data/compendium/*.json`. Writing to `data/compendium/spells.json` automatically updates the app resources — no copy step is needed. Do not replace these symlinks with regular files.
 
-A migration script (`scripts/migrate_json_to_yaml.py`) handles the one-time conversion from the current JSON format to the new YAML source files (HTML → Markdown via `html2text`).
+A migration script (`scripts/migrate_json_to_yaml.py`) handles the one-time conversion from the current JSON format to the new YAML source files. Descriptions are carried over as-is (HTML) — see §2.
 
 ### Rationale
 
@@ -88,8 +88,8 @@ A migration script (`scripts/migrate_json_to_yaml.py`) handles the one-time conv
 ### Positive
 
 - Editing a single entity no longer requires locating it inside a large file.
-- Tables in descriptions are human-readable and editable.
 - The future editing tool can read/write individual YAML files without loading the entire compendium.
+- Phase 2: descriptions in GFM Markdown will make tables human-readable and editable directly in source.
 
 ### Negative / Trade-offs
 

--- a/docs/conventions/git-and-collaboration.md
+++ b/docs/conventions/git-and-collaboration.md
@@ -87,3 +87,15 @@ feat(spell): redesign spell list screen with new item, samples, and strings
 - **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline. The CI pipeline (`.github/workflows/ci.yml`) runs `KMP Client - JVM Tests` (`./gradlew jvmTest` in `cmp-ttrpg-companion/`) on every PR targeting the default branch. It must pass for a PR to be mergeable.
 - **Warnings as Errors**: Treat compiler warnings seriously. Fix them proactively.
 - **Security Scans**: Integrate automated security scanning where applicable.
+
+## 7. Architecture Decision Records (ADRs)
+
+For any change that significantly affects the data model, source format, or technical architecture, an **ADR must be created or updated before starting the implementation**.
+
+ADRs live in [`docs/adr/`](../adr/) and follow the naming convention `adr-###-kebab-case-title.md`. Creating the ADR in a dedicated commit (or early in the implementation PR) before the bulk of the implementation is strongly encouraged — it gives reviewers context and prevents costly rework.
+
+Changes that require an ADR include, but are not limited to:
+- Compendium source format or schema changes
+- Data distribution format changes (JSON structure, API contracts)
+- New cross-cutting architectural patterns (deeplink conventions, navigation model, etc.)
+- Database schema changes with migration implications

--- a/docs/data/srd-magical-item-ingestion.md
+++ b/docs/data/srd-magical-item-ingestion.md
@@ -17,7 +17,7 @@ For the source format decision, see [`docs/adr/adr-002-compendium-source-format.
 - All keys are in English. French content belongs only inside `translations.fr`.
 - The `source` field identifies the origin of the entry — see [known source values](../adr/adr-001-data-model.md#2-source-field).
 - An entity with an empty `translations` map is considered malformed.
-- Descriptions use **GitHub Flavored Markdown** (GFM). The build script converts them to HTML for distribution.
+- Descriptions are currently **HTML** (Phase 1). Migration to GFM Markdown is deferred to Phase 2, alongside the Compose renderer update.
 
 ---
 
@@ -49,7 +49,7 @@ translations:
 - `attunement` — boolean; any non-null French source string (e.g., `"harmonisation requise"`) maps to `true`
 - `translations.{locale}.subtype` — optional locale-specific weapon/armor sub-category; always present, set to `null` if absent
 - `translations.{locale}.name` — when multiple official names exist, separate with ` / ` (e.g. `"Selle du cavalier / du hussard"`). Never use `|` as a separator.
-- `translations.{locale}.description` — GFM Markdown
+- `translations.{locale}.description` — HTML (Phase 1)
 - The display subtitle (`"Objet merveilleux · Peu courant · Harmonisation"`) is computed by the client from typed fields — not stored
 
 ### Item Checklist

--- a/docs/data/srd-magical-item-ingestion.md
+++ b/docs/data/srd-magical-item-ingestion.md
@@ -61,7 +61,7 @@ translations:
 - [ ] `attunement` — boolean
 - [ ] `translations.{locale}.name`
 - [ ] `translations.{locale}.subtype` — locale-specific string or `null`
-- [ ] `translations.{locale}.description` — GFM Markdown
+- [ ] `translations.{locale}.description` — HTML (Phase 1)
 
 ---
 

--- a/docs/data/srd-magical-item-ingestion.md
+++ b/docs/data/srd-magical-item-ingestion.md
@@ -1,9 +1,13 @@
 # SRD Magical Item Ingestion Guide
 
-Guide for contributors adding or migrating magical item data into the normalized JSON format.
+Guide for contributors adding or migrating magical item data into the normalized YAML source format.
 
 For the complete FR↔EN term mapping, see [`docs/data/srd-fr-en.md`](srd-fr-en.md).  
-For the data model decisions behind these formats, see [`docs/adr/adr-001-data-model.md`](../adr/adr-001-data-model.md).
+For the data model decisions behind these formats, see [`docs/adr/adr-001-data-model.md`](../adr/adr-001-data-model.md).  
+For the source format decision, see [`docs/adr/adr-002-compendium-source-format.md`](../adr/adr-002-compendium-source-format.md).
+
+> **Source files are in `data/compendium/magical-items/*.yaml`.**  
+> The JSON files (`data/compendium/magical-items.json`, `composeResources/files/magical-items.json`) are **generated** — run `scripts/build_compendium.py` after editing. Do not edit the JSON files directly.
 
 ---
 
@@ -13,38 +17,39 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 - All keys are in English. French content belongs only inside `translations.fr`.
 - The `source` field identifies the origin of the entry — see [known source values](../adr/adr-001-data-model.md#2-source-field).
 - An entity with an empty `translations` map is considered malformed.
+- Descriptions use **GitHub Flavored Markdown** (GFM). The build script converts them to HTML for distribution.
 
 ---
 
 ## Magical Item Entry Format
 
-```json
-{
-  "id": "shield-plus-1",
-  "source": "srd_5.1",
-  "type": "armor",
-  "rarity": "uncommon",
-  "attunement": false,
-  "translations": {
-    "en": {
-      "name": "Shield, +1",
-      "subtype": "Shield",
-      "description": "<p>...</p>"
-    },
-    "fr": {
-      "name": "Bouclier +1",
-      "subtype": "Bouclier",
-      "description": "<p>...</p>"
-    }
-  }
-}
+```yaml
+id: shield-plus-1
+source: srd_5.1
+type: armor
+rarity: uncommon
+attunement: false
+translations:
+  en:
+    name: "Shield, +1"
+    subtype: Shield
+    description: |
+      While holding this shield, you have a +1 bonus to AC.
+      This bonus is in addition to the shield's normal bonus to AC.
+  fr:
+    name: Bouclier +1
+    subtype: Bouclier
+    description: |
+      Lorsque vous tenez ce bouclier, vous bénéficiez d'un bonus de +1 à la CA.
+      Ce bonus s'ajoute au bonus normal du bouclier à la CA.
 ```
 
 ### Notes
 
-- `attunement`: any non-null French source string (e.g., `"harmonisation requise"`) maps to `true`
-- `translations.{locale}.subtype` — optional locale-specific weapon/armor sub-category
-- `translations.{locale}.name` — when multiple official names exist (e.g. old and new edition), separate them with ` / ` (e.g. `"Selle du cavalier / du hussard"`). Never use `|` as a separator.
+- `attunement` — boolean; any non-null French source string (e.g., `"harmonisation requise"`) maps to `true`
+- `translations.{locale}.subtype` — optional locale-specific weapon/armor sub-category; always present, set to `null` if absent
+- `translations.{locale}.name` — when multiple official names exist, separate with ` / ` (e.g. `"Selle du cavalier / du hussard"`). Never use `|` as a separator.
+- `translations.{locale}.description` — GFM Markdown
 - The display subtitle (`"Objet merveilleux · Peu courant · Harmonisation"`) is computed by the client from typed fields — not stored
 
 ### Item Checklist
@@ -55,11 +60,12 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 - [ ] `rarity` — see [Magical Item Rarities](srd-fr-en.md#magical-item-rarities)
 - [ ] `attunement` — boolean
 - [ ] `translations.{locale}.name`
-- [ ] `translations.{locale}.subtype` — optional
-- [ ] `translations.{locale}.description` — HTML
+- [ ] `translations.{locale}.subtype` — locale-specific string or `null`
+- [ ] `translations.{locale}.description` — GFM Markdown
 
 ---
 
 ## Validation Rules
 
 - **No unknown fallback without documentation**: if a source value has no matching entry in the translation map, document it in [`srd-fr-en.md`](srd-fr-en.md) before adding it to the data file.
+- **Run the build script** after any change: `python scripts/build_compendium.py`

--- a/docs/data/srd-monster-ingestion.md
+++ b/docs/data/srd-monster-ingestion.md
@@ -17,7 +17,7 @@ For the source format decision, see [`docs/adr/adr-002-compendium-source-format.
 - All keys are in English. French content belongs only inside `translations.fr`.
 - The `source` field identifies the origin of the entry — see [known source values](../adr/adr-001-data-model.md#2-source-field).
 - An entity with an empty `translations` map is considered malformed.
-- Descriptions use **GitHub Flavored Markdown** (GFM). The build script converts them to HTML for distribution.
+- Descriptions are currently **HTML** (Phase 1). Migration to GFM Markdown is deferred to Phase 2, alongside the Compose renderer update.
 
 ---
 
@@ -149,7 +149,7 @@ translations:
 - `translations.{locale}.subtype` — locale-specific string or `null`; always present, never omitted
 - `translations.{locale}.senses` — raw locale text; EN uses feet, FR uses rounded metres
 - `translations.{locale}.languages` — array of strings (locale-specific names)
-- `translations.{locale}.description` — GFM Markdown containing traits, actions, reactions, and legendary actions; use `|` block scalar for multiline content
+- `translations.{locale}.description` — HTML containing traits, actions, reactions, and legendary actions; use `|` block scalar for multiline content
 
 ### Monster Checklist
 
@@ -169,7 +169,7 @@ translations:
 - [ ] `conditionImmunities` — all 14 keys present
 - [ ] `translations.{locale}.name`
 - [ ] `translations.{locale}.subtype` — locale-specific string or `null`
-- [ ] `translations.{locale}.description` — GFM Markdown (traits, actions, reactions, legendary actions)
+- [ ] `translations.{locale}.description` — HTML (traits, actions, reactions, legendary actions)
 - [ ] `translations.{locale}.senses` — raw text
 - [ ] `translations.{locale}.languages` — array of strings
 

--- a/docs/data/srd-monster-ingestion.md
+++ b/docs/data/srd-monster-ingestion.md
@@ -163,7 +163,7 @@ translations:
 - [ ] `maxHitPoints` — integer (average)
 - [ ] `hitDice` — string (e.g., `2d6`, `23d8+92`)
 - [ ] `abilities` — all 6 keys, each with integer `value` and `savingThrowProficiency`
-- [ ] `speeds` — all 5 movement keys + `hover`; values in feet or `null`
+- [ ] `speeds` — all 6 keys (`walk`, `fly`, `swim`, `climb`, `burrow`, `hover`); values in feet or `null`
 - [ ] `skills` — all 18 keys present
 - [ ] `damageAffinities` — all 16 keys present
 - [ ] `conditionImmunities` — all 14 keys present

--- a/docs/data/srd-monster-ingestion.md
+++ b/docs/data/srd-monster-ingestion.md
@@ -1,9 +1,13 @@
 # SRD Monster Ingestion Guide
 
-Guide for contributors adding or migrating monster data into the normalized JSON format.
+Guide for contributors adding or migrating monster data into the normalized YAML source format.
 
 For the complete FR↔EN term mapping, see [`docs/data/srd-fr-en.md`](srd-fr-en.md).  
-For the data model decisions behind these formats, see [`docs/adr/adr-001-data-model.md`](../adr/adr-001-data-model.md).
+For the data model decisions behind these formats, see [`docs/adr/adr-001-data-model.md`](../adr/adr-001-data-model.md).  
+For the source format decision, see [`docs/adr/adr-002-compendium-source-format.md`](../adr/adr-002-compendium-source-format.md).
+
+> **Source files are in `data/compendium/monsters/*.yaml`.**  
+> The JSON files (`data/compendium/monsters.json`, `composeResources/files/monsters.json`) are **generated** — run `scripts/build_compendium.py` after editing. Do not edit the JSON files directly.
 
 ---
 
@@ -13,93 +17,139 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 - All keys are in English. French content belongs only inside `translations.fr`.
 - The `source` field identifies the origin of the entry — see [known source values](../adr/adr-001-data-model.md#2-source-field).
 - An entity with an empty `translations` map is considered malformed.
+- Descriptions use **GitHub Flavored Markdown** (GFM). The build script converts them to HTML for distribution.
 
 ---
 
 ## Monster Entry Format
 
-```json
-{
-  "id": "goblin",
-  "source": "monster_manual_2024",
-  "type": "humanoid",
-  "size": "small",
-  "alignment": "neutral_evil",
-  "challengeRating": 0.25,
-  "armorClass": 15,
-  "maxHitPoints": 7,
-  "hitDice": "2d6",
-  "abilities": {
-    "str": { "value": 8,  "savingThrowProficiency": "none" },
-    "dex": { "value": 14, "savingThrowProficiency": "none" },
-    "con": { "value": 10, "savingThrowProficiency": "none" },
-    "int": { "value": 10, "savingThrowProficiency": "none" },
-    "wis": { "value": 8,  "savingThrowProficiency": "none" },
-    "cha": { "value": 8,  "savingThrowProficiency": "none" }
-  },
-  "speeds": {
-    "walk": 30,
-    "fly": null,
-    "swim": null,
-    "climb": null,
-    "burrow": null,
-    "hover": false
-  },
-  "skills": {
-    "acrobatics": "none", "animalHandling": "none", "arcana": "none",
-    "athletics": "none", "deception": "none", "history": "none",
-    "insight": "none", "intimidation": "none", "investigation": "none",
-    "medicine": "none", "nature": "none", "perception": "none",
-    "performance": "none", "persuasion": "none", "religion": "none",
-    "sleightOfHand": "none", "stealth": "proficient", "survival": "none"
-  },
-  "damageAffinities": {
-    "acid": "none", "bludgeoning": "none", "cold": "none",
-    "fire": "none", "force": "none", "lightning": "none",
-    "necrotic": "none", "piercing": "none", "poison": "none",
-    "psychic": "none", "radiant": "none", "slashing": "none",
-    "thunder": "none", "bludgeoningNonMagical": "none",
-    "piercingNonMagical": "none", "slashingNonMagical": "none"
-  },
-  "conditionImmunities": {
-    "blinded": false, "charmed": false, "deafened": false,
-    "exhaustion": false, "frightened": false, "grappled": false,
-    "incapacitated": false, "paralyzed": false, "petrified": false,
-    "poisoned": false, "prone": false, "restrained": false,
-    "stunned": false, "unconscious": false
-  },
-  "translations": {
-    "en": {
-      "name": "Goblin",
-      "subtype": "Goblinoid",
-      "description": "<h2>Actions</h2><p>...</p>",
-      "senses": "Darkvision 60 ft., Passive Perception 9",
-      "languages": ["Common", "Goblin"]
-    },
-    "fr": {
-      "name": "Gobelin",
-      "subtype": "Gobelinoïde",
-      "description": "<h2>Actions</h2><p>...</p>",
-      "senses": "Vision dans le noir 18 m, Perception passive 9",
-      "languages": ["commun", "gobelin"]
-    }
-  }
-}
+```yaml
+id: goblin
+source: monster_manual_2024
+type: humanoid
+size: small
+alignment: neutral_evil
+challengeRating: 0.25
+armorClass: 15
+maxHitPoints: 7
+hitDice: 2d6
+abilities:
+  str:
+    value: 8
+    savingThrowProficiency: none
+  dex:
+    value: 14
+    savingThrowProficiency: none
+  con:
+    value: 10
+    savingThrowProficiency: none
+  int:
+    value: 10
+    savingThrowProficiency: none
+  wis:
+    value: 8
+    savingThrowProficiency: none
+  cha:
+    value: 8
+    savingThrowProficiency: none
+speeds:
+  walk: 30
+  fly: null
+  swim: null
+  climb: null
+  burrow: null
+  hover: false
+skills:
+  acrobatics: none
+  animalHandling: none
+  arcana: none
+  athletics: none
+  deception: none
+  history: none
+  insight: none
+  intimidation: none
+  investigation: none
+  medicine: none
+  nature: none
+  perception: none
+  performance: none
+  persuasion: none
+  religion: none
+  sleightOfHand: none
+  stealth: proficient
+  survival: none
+damageAffinities:
+  acid: none
+  bludgeoning: none
+  cold: none
+  fire: none
+  force: none
+  lightning: none
+  necrotic: none
+  piercing: none
+  poison: none
+  psychic: none
+  radiant: none
+  slashing: none
+  thunder: none
+  bludgeoningNonMagical: none
+  piercingNonMagical: none
+  slashingNonMagical: none
+conditionImmunities:
+  blinded: false
+  charmed: false
+  deafened: false
+  exhaustion: false
+  frightened: false
+  grappled: false
+  incapacitated: false
+  paralyzed: false
+  petrified: false
+  poisoned: false
+  prone: false
+  restrained: false
+  stunned: false
+  unconscious: false
+translations:
+  en:
+    name: Goblin
+    subtype: Goblinoid
+    description: |
+      ## Actions
+
+      **Scimitar.** *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target.
+      *Hit:* 5 (1d6 + 2) slashing damage.
+    senses: Darkvision 60 ft., Passive Perception 9
+    languages:
+      - Common
+      - Goblin
+  fr:
+    name: Gobelin
+    subtype: Gobelinoïde
+    description: |
+      ## Actions
+
+      **Cimeterre.** *Attaque d'arme au corps à corps :* +4 pour toucher, allonge 1,50 m, une cible.
+      *Touché :* 5 (1d6 + 2) dégâts tranchants.
+    senses: Vision dans le noir 18 m, Perception passive 9
+    languages:
+      - commun
+      - gobelin
 ```
 
 ### Notes
 
-- `abilities.{key}.savingThrowProficiency` — `"none"`, `"proficient"`, or `"expert"` (ADR-001 §5)
-- `skills` — all 18 keys required; set to `"none"` when not proficient (ADR-001 §6)
-- `damageAffinities` — all 16 keys required; `"none"` / `"resistant"` / `"immune"` / `"vulnerable"` (ADR-001 §7)
+- `abilities.{key}.savingThrowProficiency` — `none`, `proficient`, or `expert` (ADR-001 §5)
+- `skills` — all 18 keys required; set to `none` when not proficient (ADR-001 §6)
+- `damageAffinities` — all 16 keys required; `none` / `resistant` / `immune` / `vulnerable` (ADR-001 §7)
 - `conditionImmunities` — all 14 keys required; `false` when not immune (ADR-001 §7)
-- `hitDice` — format `"NdX"` or `"NdX+Y"` (e.g., `"2d6"`, `"23d8+92"`) (ADR-001 §9)
-- `speeds` — all speed values in **feet** (integers); `null` when the movement type does not apply; `hover: true` when the creature hovers; the app converts to metres for FR display (× 0.3, i.e. `feet * 3 / 5` half-metres)
-- `translations.{locale}.name` — when multiple official names exist (e.g. old and new edition), separate them with ` / ` (e.g. `"Ours-hibou / Hibours"`). Never use `|` as a separator.
-- `translations.{locale}.subtype` — locale-specific subtype string (e.g. EN `"Goblinoid"`, FR `"Gobelinoïde"`), or `null` if the monster has no subtype
+- `hitDice` — format `NdX` or `NdX+Y` (e.g., `2d6`, `23d8+92`) (ADR-001 §9)
+- `speeds` — all values in **feet** (integers); `null` when the movement type does not apply; always present, never omitted
+- `translations.{locale}.name` — when multiple official names exist, separate with ` / `. Never use `|` as a separator.
+- `translations.{locale}.subtype` — locale-specific string or `null`; always present, never omitted
 - `translations.{locale}.senses` — raw locale text; EN uses feet, FR uses rounded metres
 - `translations.{locale}.languages` — array of strings (locale-specific names)
-- `translations.{locale}.description` — HTML containing traits, actions, reactions, legendary actions
+- `translations.{locale}.description` — GFM Markdown containing traits, actions, reactions, and legendary actions; use `|` block scalar for multiline content
 
 ### Monster Checklist
 
@@ -111,15 +161,15 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 - [ ] `challengeRating` — float (e.g., `0.25`, `0.5`, `1.0`, `20.0`)
 - [ ] `armorClass` — integer only (no armor type string)
 - [ ] `maxHitPoints` — integer (average)
-- [ ] `hitDice` — string (e.g., `"2d6"`, `"23d8+92"`)
+- [ ] `hitDice` — string (e.g., `2d6`, `23d8+92`)
 - [ ] `abilities` — all 6 keys, each with integer `value` and `savingThrowProficiency`
-- [ ] `speeds` — all 5 movement keys (`walk`, `fly`, `swim`, `climb`, `burrow`) + `hover`; values in feet or `null`
+- [ ] `speeds` — all 5 movement keys + `hover`; values in feet or `null`
 - [ ] `skills` — all 18 keys present
 - [ ] `damageAffinities` — all 16 keys present
 - [ ] `conditionImmunities` — all 14 keys present
 - [ ] `translations.{locale}.name`
 - [ ] `translations.{locale}.subtype` — locale-specific string or `null`
-- [ ] `translations.{locale}.description` — HTML
+- [ ] `translations.{locale}.description` — GFM Markdown (traits, actions, reactions, legendary actions)
 - [ ] `translations.{locale}.senses` — raw text
 - [ ] `translations.{locale}.languages` — array of strings
 
@@ -129,10 +179,10 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 
 | Key            | Meaning             |
 |----------------|---------------------|
-| `"none"`       | No special affinity |
-| `"resistant"`  | Takes half damage   |
-| `"immune"`     | Takes no damage     |
-| `"vulnerable"` | Takes double damage |
+| `none`         | No special affinity |
+| `resistant`    | Takes half damage   |
+| `immune`       | Takes no damage     |
+| `vulnerable`   | Takes double damage |
 
 The 16 damage type keys: `acid`, `bludgeoning`, `cold`, `fire`, `force`, `lightning`,
 `necrotic`, `piercing`, `poison`, `psychic`, `radiant`, `slashing`, `thunder`,
@@ -145,7 +195,8 @@ The 16 damage type keys: `acid`, `bludgeoning`, `cold`, `fire`, `force`, `lightn
 - **No unknown fallback without documentation**: if a source value has no matching entry in the translation map, document it in [`srd-fr-en.md`](srd-fr-en.md) before adding it to the data file.
 - **Ability scores must be integers**: reject `"15 (+2)"` — store `15` only.
 - **AC must be an integer**: reject `"11 (armure de cuir)"` — store `11` only.
-- **Senses belong in `translations`**: never store them as locale-independent data. Speeds are stored as integers at the root level (e.g. `"walk": 30`) for automatic unit conversion.
+- **Senses belong in `translations`**: never store them as locale-independent data.
 - **Languages belong in `translations`**: never store language names as locale-independent data.
 - **No pre-computed modifiers**: store scores and proficiency levels; let the app compute bonuses.
 - **All bounded objects must be exhaustive**: `skills` (18 keys), `damageAffinities` (16 keys), `conditionImmunities` (14 keys) — all keys always present.
+- **Run the build script** after any change: `python scripts/build_compendium.py`

--- a/docs/data/srd-spell-ingestion.md
+++ b/docs/data/srd-spell-ingestion.md
@@ -1,9 +1,13 @@
 # SRD Spell Ingestion Guide
 
-Guide for contributors adding or migrating spell data into the normalized JSON format.
+Guide for contributors adding or migrating spell data into the normalized YAML source format.
 
 For the complete FR↔EN term mapping, see [`docs/data/srd-fr-en.md`](srd-fr-en.md).  
-For the data model decisions behind these formats, see [`docs/adr/adr-001-data-model.md`](../adr/adr-001-data-model.md).
+For the data model decisions behind these formats, see [`docs/adr/adr-001-data-model.md`](../adr/adr-001-data-model.md).  
+For the source format decision, see [`docs/adr/adr-002-compendium-source-format.md`](../adr/adr-002-compendium-source-format.md).
+
+> **Source files are in `data/compendium/spells/*.yaml`.**  
+> The JSON files (`data/compendium/spells.json`, `composeResources/files/spells.json`) are **generated** — run `scripts/build_compendium.py` after editing. Do not edit the JSON files directly.
 
 ---
 
@@ -13,44 +17,46 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 - All keys are in English. French content belongs only inside `translations.fr`.
 - The `source` field identifies the origin of the entry — see [known source values](../adr/adr-001-data-model.md#2-source-field).
 - An entity with an empty `translations` map is considered malformed.
+- Descriptions use **GitHub Flavored Markdown** (GFM). The build script converts them to HTML for distribution.
 
 ---
 
 ## Spell Entry Format
 
-```json
-{
-  "id": "acid-splash",
-  "source": "srd_5.1",
-  "level": 0,
-  "school": "conjuration",
-  "concentration": false,
-  "ritual": false,
-  "components": {
-    "verbal": true,
-    "somatic": true,
-    "material": false
-  },
-  "availableClasses": ["sorcerer", "wizard"],
-  "translations": {
-    "en": {
-      "name": "Acid Splash",
-      "castingTime": "1 action",
-      "range": "60 feet",
-      "duration": "Instantaneous",
-      "materialDescription": null,
-      "description": "<p>...</p>"
-    },
-    "fr": {
-      "name": "Aspersion acide",
-      "castingTime": "1 action",
-      "range": "18 mètres",
-      "duration": "instantanée",
-      "materialDescription": null,
-      "description": "<p>...</p>"
-    }
-  }
-}
+```yaml
+id: acid-splash
+source: srd_5.1
+level: 0
+school: conjuration
+concentration: false
+ritual: false
+components:
+  verbal: true
+  somatic: true
+  material: false
+availableClasses:
+  - sorcerer
+  - wizard
+translations:
+  en:
+    name: Acid Splash
+    castingTime: 1 action
+    range: 60 feet
+    duration: Instantaneous
+    materialDescription: null
+    description: |
+      You hurl a bubble of acid. Choose one or two creatures you can see within range.
+      If you choose two, they must be within 5 feet of each other.
+      A target must succeed on a Dexterity saving throw or take **1d6 acid damage**.
+  fr:
+    name: Aspersion acide
+    castingTime: 1 action
+    range: 18 mètres
+    duration: instantanée
+    materialDescription: null
+    description: |
+      Vous lancez une bulle d'acide. Choisissez une ou deux créatures visibles dans la portée.
+      Si vous en choisissez deux, elles doivent se trouver à 1,50 mètre l'une de l'autre.
 ```
 
 ### Notes
@@ -59,7 +65,8 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 - `availableClasses` — see [Character Classes](srd-fr-en.md#character-classes)
 - `translations.{locale}.name` — when multiple official names exist (e.g. old and new edition), separate them with ` / ` (e.g. `"Immobilisation une personne / un humanoïde"`). Never use `|` as a separator.
 - `translations.{locale}.range` — locale-specific raw text (English uses feet, French uses metres)
-- `translations.{locale}.materialDescription` — string or `null`
+- `translations.{locale}.materialDescription` — string or `null`; always present, never omitted
+- `translations.{locale}.description` — GFM Markdown; use `|` block scalar for multiline content
 
 ### Spell Checklist
 
@@ -76,7 +83,7 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 - [ ] `translations.{locale}.range`
 - [ ] `translations.{locale}.duration`
 - [ ] `translations.{locale}.materialDescription` — string or `null`
-- [ ] `translations.{locale}.description` — HTML
+- [ ] `translations.{locale}.description` — GFM Markdown
 
 ---
 
@@ -84,3 +91,4 @@ For the data model decisions behind these formats, see [`docs/adr/adr-001-data-m
 
 - **No unknown fallback without documentation**: if a source value has no matching entry in the translation map, document it in [`srd-fr-en.md`](srd-fr-en.md) before adding it to the data file.
 - **No pre-computed modifiers**: store levels and flags; let the app compute display strings.
+- **Run the build script** after any change: `python scripts/build_compendium.py`

--- a/docs/data/srd-spell-ingestion.md
+++ b/docs/data/srd-spell-ingestion.md
@@ -17,7 +17,7 @@ For the source format decision, see [`docs/adr/adr-002-compendium-source-format.
 - All keys are in English. French content belongs only inside `translations.fr`.
 - The `source` field identifies the origin of the entry — see [known source values](../adr/adr-001-data-model.md#2-source-field).
 - An entity with an empty `translations` map is considered malformed.
-- Descriptions use **GitHub Flavored Markdown** (GFM). The build script converts them to HTML for distribution.
+- Descriptions are currently **HTML** (Phase 1). Migration to GFM Markdown is deferred to Phase 2, alongside the Compose renderer update.
 
 ---
 
@@ -66,7 +66,7 @@ translations:
 - `translations.{locale}.name` — when multiple official names exist (e.g. old and new edition), separate them with ` / ` (e.g. `"Immobilisation une personne / un humanoïde"`). Never use `|` as a separator.
 - `translations.{locale}.range` — locale-specific raw text (English uses feet, French uses metres)
 - `translations.{locale}.materialDescription` — string or `null`; always present, never omitted
-- `translations.{locale}.description` — GFM Markdown; use `|` block scalar for multiline content
+- `translations.{locale}.description` — HTML (Phase 1); use `|` block scalar for multiline content
 
 ### Spell Checklist
 
@@ -83,7 +83,7 @@ translations:
 - [ ] `translations.{locale}.range`
 - [ ] `translations.{locale}.duration`
 - [ ] `translations.{locale}.materialDescription` — string or `null`
-- [ ] `translations.{locale}.description` — GFM Markdown
+- [ ] `translations.{locale}.description` — HTML
 
 ---
 

--- a/scripts/build_compendium.py
+++ b/scripts/build_compendium.py
@@ -3,17 +3,18 @@
 Build script: aggregates YAML source files into the three JSON compendium files
 consumed by the KMP app and the Rust server.
 
+Descriptions are kept as-is (HTML for now). Markdown conversion is deferred to
+Phase 2, alongside the Compose renderer update.
+
 Usage:
-    pip install pyyaml markdown
+    pip install pyyaml
     python scripts/build_compendium.py
 
 Output:
     data/compendium/spells.json
     data/compendium/monsters.json
     data/compendium/magical-items.json
-    cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/spells.json
-    cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/monsters.json
-    cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/magical-items.json
+    (app resource files are symlinks to the above — no copy needed)
 
 CI mode (--check):
     Verifies that the committed JSON files are up to date with the YAML source.
@@ -21,7 +22,6 @@ CI mode (--check):
 """
 
 import argparse
-import copy
 import glob
 import json
 import os
@@ -32,11 +32,6 @@ try:
     import yaml
 except ImportError:
     sys.exit("Missing dependency: pip install pyyaml")
-
-try:
-    import markdown as markdown_lib
-except ImportError:
-    sys.exit("Missing dependency: pip install markdown")
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(REPO_ROOT, "data", "compendium")
@@ -50,14 +45,6 @@ APP_RESOURCES_DIR = os.path.join(
     "files",
 )
 
-_MD_EXTENSIONS = ["tables", "nl2br"]
-
-
-def markdown_to_html(text: str | None) -> str | None:
-    if not text:
-        return text
-    return markdown_lib.markdown(text, extensions=_MD_EXTENSIONS)
-
 
 def load_yaml_dir(directory: str) -> list[dict]:
     pattern = os.path.join(directory, "*.yaml")
@@ -70,18 +57,6 @@ def load_yaml_dir(directory: str) -> list[dict]:
             entity = yaml.safe_load(f)
         entities.append(entity)
     return entities
-
-
-def convert_descriptions_to_html(entities: list[dict]) -> list[dict]:
-    """Return a deep copy with all description fields converted Markdown → HTML."""
-    result = []
-    for entity in entities:
-        e = copy.deepcopy(entity)
-        for locale, t in (e.get("translations") or {}).items():
-            if t.get("description"):
-                t["description"] = markdown_to_html(t["description"])
-        result.append(e)
-    return result
 
 
 def write_json(path: str, data: list[dict]) -> None:
@@ -110,14 +85,15 @@ def build_type(type_name: str, check: bool) -> tuple[int, bool]:
     app_path = os.path.join(APP_RESOURCES_DIR, f"{type_name}.json")
 
     entities = load_yaml_dir(src_dir)
-    converted = convert_descriptions_to_html(entities)
 
     if check:
-        ok = check_json(out_path, converted)
+        ok = check_json(out_path, entities)
         return len(entities), ok
 
-    write_json(out_path, converted)
-    shutil.copy2(out_path, app_path)
+    write_json(out_path, entities)
+    # The app resource files are symlinks to data/compendium/ — no copy needed.
+    if os.path.exists(app_path) and not os.path.samefile(out_path, app_path):
+        shutil.copy2(out_path, app_path)
     print(f"  {type_name}: {len(entities)} entities → {out_path}")
     return len(entities), True
 

--- a/scripts/build_compendium.py
+++ b/scripts/build_compendium.py
@@ -46,22 +46,6 @@ APP_RESOURCES_DIR = os.path.join(
 )
 
 
-def load_yaml_dir(directory: str) -> list[dict]:
-    pattern = os.path.join(directory, "*.yaml")
-    paths = sorted(glob.glob(pattern))
-    if not paths:
-        print(f"  WARNING: no YAML files found in {directory}", file=sys.stderr)
-    entities = []
-    for path in paths:
-        with open(path, encoding="utf-8") as f:
-            entity = yaml.safe_load(f)
-        if entity is not None:
-            entities.append(entity)
-        else:
-            print(f"  WARNING: skipping empty file {path}", file=sys.stderr)
-    return entities
-
-
 def write_json(path: str, data: list[dict]) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
@@ -87,7 +71,21 @@ def build_type(type_name: str, check: bool) -> tuple[int, bool]:
     out_path = os.path.join(DATA_DIR, f"{type_name}.json")
     app_path = os.path.join(APP_RESOURCES_DIR, f"{type_name}.json")
 
-    entities = load_yaml_dir(src_dir)
+    yaml_files = sorted(glob.glob(os.path.join(src_dir, "*.yaml")))
+    if not yaml_files:
+        print(f"  WARNING: no YAML files found in {src_dir}", file=sys.stderr)
+        if check:
+            print(f"  SKIPPED: {type_name} (no YAML source files — migration pending)")
+            return 0, True
+
+    entities = []
+    for path in yaml_files:
+        with open(path, encoding="utf-8") as f:
+            entity = yaml.safe_load(f)
+        if entity is not None:
+            entities.append(entity)
+        else:
+            print(f"  WARNING: skipping empty file {path}", file=sys.stderr)
 
     if check:
         ok = check_json(out_path, entities)

--- a/scripts/build_compendium.py
+++ b/scripts/build_compendium.py
@@ -55,7 +55,10 @@ def load_yaml_dir(directory: str) -> list[dict]:
     for path in paths:
         with open(path, encoding="utf-8") as f:
             entity = yaml.safe_load(f)
-        entities.append(entity)
+        if entity is not None:
+            entities.append(entity)
+        else:
+            print(f"  WARNING: skipping empty file {path}", file=sys.stderr)
     return entities
 
 

--- a/scripts/build_compendium.py
+++ b/scripts/build_compendium.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Build script: aggregates YAML source files into the three JSON compendium files
+consumed by the KMP app and the Rust server.
+
+Usage:
+    pip install pyyaml markdown
+    python scripts/build_compendium.py
+
+Output:
+    data/compendium/spells.json
+    data/compendium/monsters.json
+    data/compendium/magical-items.json
+    cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/spells.json
+    cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/monsters.json
+    cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/magical-items.json
+
+CI mode (--check):
+    Verifies that the committed JSON files are up to date with the YAML source.
+    Exits with code 1 if any file differs.
+"""
+
+import argparse
+import copy
+import glob
+import json
+import os
+import shutil
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("Missing dependency: pip install pyyaml")
+
+try:
+    import markdown as markdown_lib
+except ImportError:
+    sys.exit("Missing dependency: pip install markdown")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DATA_DIR = os.path.join(REPO_ROOT, "data", "compendium")
+APP_RESOURCES_DIR = os.path.join(
+    REPO_ROOT,
+    "cmp-ttrpg-companion",
+    "composeApp",
+    "src",
+    "commonMain",
+    "composeResources",
+    "files",
+)
+
+_MD_EXTENSIONS = ["tables", "nl2br"]
+
+
+def markdown_to_html(text: str | None) -> str | None:
+    if not text:
+        return text
+    return markdown_lib.markdown(text, extensions=_MD_EXTENSIONS)
+
+
+def load_yaml_dir(directory: str) -> list[dict]:
+    pattern = os.path.join(directory, "*.yaml")
+    paths = sorted(glob.glob(pattern))
+    if not paths:
+        print(f"  WARNING: no YAML files found in {directory}", file=sys.stderr)
+    entities = []
+    for path in paths:
+        with open(path, encoding="utf-8") as f:
+            entity = yaml.safe_load(f)
+        entities.append(entity)
+    return entities
+
+
+def convert_descriptions_to_html(entities: list[dict]) -> list[dict]:
+    """Return a deep copy with all description fields converted Markdown → HTML."""
+    result = []
+    for entity in entities:
+        e = copy.deepcopy(entity)
+        for locale, t in (e.get("translations") or {}).items():
+            if t.get("description"):
+                t["description"] = markdown_to_html(t["description"])
+        result.append(e)
+    return result
+
+
+def write_json(path: str, data: list[dict]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+
+def check_json(path: str, data: list[dict]) -> bool:
+    """Return True if the file on disk matches `data`."""
+    if not os.path.exists(path):
+        print(f"  MISSING: {path}")
+        return False
+    with open(path, encoding="utf-8") as f:
+        on_disk = json.load(f)
+    if on_disk != data:
+        print(f"  OUT OF DATE: {path}")
+        return False
+    return True
+
+
+def build_type(type_name: str, check: bool) -> tuple[int, bool]:
+    src_dir = os.path.join(DATA_DIR, type_name)
+    out_path = os.path.join(DATA_DIR, f"{type_name}.json")
+    app_path = os.path.join(APP_RESOURCES_DIR, f"{type_name}.json")
+
+    entities = load_yaml_dir(src_dir)
+    converted = convert_descriptions_to_html(entities)
+
+    if check:
+        ok = check_json(out_path, converted)
+        return len(entities), ok
+
+    write_json(out_path, converted)
+    shutil.copy2(out_path, app_path)
+    print(f"  {type_name}: {len(entities)} entities → {out_path}")
+    return len(entities), True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build compendium JSON from YAML source.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify committed JSON files are up to date (CI mode). Exit 1 if not.",
+    )
+    args = parser.parse_args()
+
+    mode = "Checking" if args.check else "Building"
+    print(f"{mode} compendium...")
+
+    total = 0
+    all_ok = True
+    for type_name in ("spells", "monsters", "magical-items"):
+        count, ok = build_type(type_name, check=args.check)
+        total += count
+        all_ok = all_ok and ok
+
+    if args.check:
+        if all_ok:
+            print(f"\nOK — all JSON files are up to date ({total} entities).")
+        else:
+            print("\nFAIL — run `python scripts/build_compendium.py` and commit the result.")
+            sys.exit(1)
+    else:
+        print(f"\nDone. {total} entities written.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_json_to_yaml.py
+++ b/scripts/migrate_json_to_yaml.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+One-time migration script: converts the three monolithic JSON compendium files
+into one YAML file per entity, with descriptions converted from HTML to Markdown.
+
+Usage:
+    pip install pyyaml html2text
+    python scripts/migrate_json_to_yaml.py
+
+Output: data/compendium/spells/, data/compendium/monsters/, data/compendium/magical-items/
+
+The existing JSON files are left untouched. After reviewing the YAML output,
+run scripts/build_compendium.py to regenerate the JSON from YAML and verify round-trip fidelity.
+"""
+
+import json
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("Missing dependency: pip install pyyaml")
+
+try:
+    import html2text
+except ImportError:
+    sys.exit("Missing dependency: pip install html2text")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DATA_DIR = os.path.join(REPO_ROOT, "data", "compendium")
+
+_md_converter = html2text.HTML2Text()
+_md_converter.body_width = 0       # no line wrapping
+_md_converter.protect_links = True
+_md_converter.wrap_links = False
+
+
+def html_to_markdown(html: str | None) -> str | None:
+    if not html:
+        return html
+    md = _md_converter.handle(html).strip()
+    return md if md else None
+
+
+def write_yaml(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(
+            data,
+            f,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False,
+            width=10000,  # avoid yaml wrapping long strings mid-line
+        )
+
+
+def migrate_spells() -> int:
+    src = os.path.join(DATA_DIR, "spells.json")
+    out_dir = os.path.join(DATA_DIR, "spells")
+    with open(src, encoding="utf-8") as f:
+        spells = json.load(f)
+
+    for spell in spells:
+        for locale, t in (spell.get("translations") or {}).items():
+            if t.get("description"):
+                t["description"] = html_to_markdown(t["description"])
+
+        dest = os.path.join(out_dir, f"{spell['id']}.yaml")
+        write_yaml(dest, spell)
+
+    print(f"  spells: {len(spells)} files written to {out_dir}/")
+    return len(spells)
+
+
+def migrate_monsters() -> int:
+    src = os.path.join(DATA_DIR, "monsters.json")
+    out_dir = os.path.join(DATA_DIR, "monsters")
+    with open(src, encoding="utf-8") as f:
+        monsters = json.load(f)
+
+    for monster in monsters:
+        for locale, t in (monster.get("translations") or {}).items():
+            if t.get("description"):
+                t["description"] = html_to_markdown(t["description"])
+
+        dest = os.path.join(out_dir, f"{monster['id']}.yaml")
+        write_yaml(dest, monster)
+
+    print(f"  monsters: {len(monsters)} files written to {out_dir}/")
+    return len(monsters)
+
+
+def migrate_magical_items() -> int:
+    src = os.path.join(DATA_DIR, "magical-items.json")
+    out_dir = os.path.join(DATA_DIR, "magical-items")
+    with open(src, encoding="utf-8") as f:
+        items = json.load(f)
+
+    for item in items:
+        for locale, t in (item.get("translations") or {}).items():
+            if t.get("description"):
+                t["description"] = html_to_markdown(t["description"])
+
+        dest = os.path.join(out_dir, f"{item['id']}.yaml")
+        write_yaml(dest, item)
+
+    print(f"  magical-items: {len(items)} files written to {out_dir}/")
+    return len(items)
+
+
+def main() -> None:
+    print("Migrating compendium JSON → YAML...")
+    total = 0
+    total += migrate_spells()
+    total += migrate_monsters()
+    total += migrate_magical_items()
+    print(f"\nDone. {total} YAML files created.")
+    print("\nNext steps:")
+    print("  1. Review a sample of generated YAML files (especially descriptions).")
+    print("  2. Run: python scripts/build_compendium.py")
+    print("  3. Verify the rebuilt JSON matches the originals.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_json_to_yaml.py
+++ b/scripts/migrate_json_to_yaml.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 """
 One-time migration script: converts the three monolithic JSON compendium files
-into one YAML file per entity, with descriptions converted from HTML to Markdown.
+into one YAML file per entity.
+
+Descriptions are kept as-is (HTML). Migrating descriptions to Markdown is
+deferred to Phase 2, alongside the Compose renderer update.
 
 Usage:
-    pip install pyyaml html2text
+    pip install pyyaml
     python scripts/migrate_json_to_yaml.py
 
 Output: data/compendium/spells/, data/compendium/monsters/, data/compendium/magical-items/
@@ -22,25 +25,21 @@ try:
 except ImportError:
     sys.exit("Missing dependency: pip install pyyaml")
 
-try:
-    import html2text
-except ImportError:
-    sys.exit("Missing dependency: pip install html2text")
+
+class _BlockScalarDumper(yaml.Dumper):
+    """PyYAML dumper that renders multiline strings as literal block scalars (|)."""
+
+
+def _str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_BlockScalarDumper.add_representer(str, _str_representer)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(REPO_ROOT, "data", "compendium")
-
-_md_converter = html2text.HTML2Text()
-_md_converter.body_width = 0       # no line wrapping
-_md_converter.protect_links = True
-_md_converter.wrap_links = False
-
-
-def html_to_markdown(html: str | None) -> str | None:
-    if not html:
-        return html
-    md = _md_converter.handle(html).strip()
-    return md if md else None
 
 
 def write_yaml(path: str, data: dict) -> None:
@@ -49,73 +48,33 @@ def write_yaml(path: str, data: dict) -> None:
         yaml.dump(
             data,
             f,
+            Dumper=_BlockScalarDumper,
             allow_unicode=True,
             default_flow_style=False,
             sort_keys=False,
-            width=10000,  # avoid yaml wrapping long strings mid-line
         )
 
 
-def migrate_spells() -> int:
-    src = os.path.join(DATA_DIR, "spells.json")
-    out_dir = os.path.join(DATA_DIR, "spells")
+def migrate_type(type_name: str, id_field: str = "id") -> int:
+    src = os.path.join(DATA_DIR, f"{type_name}.json")
+    out_dir = os.path.join(DATA_DIR, type_name)
     with open(src, encoding="utf-8") as f:
-        spells = json.load(f)
+        entities = json.load(f)
 
-    for spell in spells:
-        for locale, t in (spell.get("translations") or {}).items():
-            if t.get("description"):
-                t["description"] = html_to_markdown(t["description"])
+    for entity in entities:
+        dest = os.path.join(out_dir, f"{entity[id_field]}.yaml")
+        write_yaml(dest, entity)
 
-        dest = os.path.join(out_dir, f"{spell['id']}.yaml")
-        write_yaml(dest, spell)
-
-    print(f"  spells: {len(spells)} files written to {out_dir}/")
-    return len(spells)
-
-
-def migrate_monsters() -> int:
-    src = os.path.join(DATA_DIR, "monsters.json")
-    out_dir = os.path.join(DATA_DIR, "monsters")
-    with open(src, encoding="utf-8") as f:
-        monsters = json.load(f)
-
-    for monster in monsters:
-        for locale, t in (monster.get("translations") or {}).items():
-            if t.get("description"):
-                t["description"] = html_to_markdown(t["description"])
-
-        dest = os.path.join(out_dir, f"{monster['id']}.yaml")
-        write_yaml(dest, monster)
-
-    print(f"  monsters: {len(monsters)} files written to {out_dir}/")
-    return len(monsters)
-
-
-def migrate_magical_items() -> int:
-    src = os.path.join(DATA_DIR, "magical-items.json")
-    out_dir = os.path.join(DATA_DIR, "magical-items")
-    with open(src, encoding="utf-8") as f:
-        items = json.load(f)
-
-    for item in items:
-        for locale, t in (item.get("translations") or {}).items():
-            if t.get("description"):
-                t["description"] = html_to_markdown(t["description"])
-
-        dest = os.path.join(out_dir, f"{item['id']}.yaml")
-        write_yaml(dest, item)
-
-    print(f"  magical-items: {len(items)} files written to {out_dir}/")
-    return len(items)
+    print(f"  {type_name}: {len(entities)} files written to {out_dir}/")
+    return len(entities)
 
 
 def main() -> None:
     print("Migrating compendium JSON → YAML...")
     total = 0
-    total += migrate_spells()
-    total += migrate_monsters()
-    total += migrate_magical_items()
+    total += migrate_type("spells")
+    total += migrate_type("monsters")
+    total += migrate_type("magical-items")
     print(f"\nDone. {total} YAML files created.")
     print("\nNext steps:")
     print("  1. Review a sample of generated YAML files (especially descriptions).")


### PR DESCRIPTION
## 📝 Description

Introduces a new source format for the compendium: one YAML file per entity in typed subdirectories, replacing the three monolithic JSON files as the editing surface.

**Why:** The monolithic JSON files were impractical for human editing (large files, catastrophic merge conflicts, hard to locate a single entry). See ADR-002 for the full rationale.

**What this PR includes:**
- `docs(conventions)`: new rule requiring an ADR before any structural change
- `docs(adr)`: ADR-002 documenting the format decision
- `docs(data)`: updated ingestion guides for spells, monsters, and magical items
- `build(compendium)`: `scripts/migrate_json_to_yaml.py` — one-time migration script
- `build(compendium)`: `scripts/build_compendium.py` — build step (YAML → JSON), with `--check` mode for CI
- `ci(compendium)`: new workflow that verifies JSON files are up to date on every YAML change

**What this PR does NOT include:**
- The actual data migration (see PR #87: `refactor/compendium-yaml-source-data`)
- Markdown descriptions (deferred to Phase 2 alongside the Compose renderer update — see ADR-002 §2)

**Note:** The app resource JSON files (`composeResources/files/*.json`) are symlinks to `data/compendium/*.json` — no changes needed on the KMP or Rust server side.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed