### PR TITLE
docs(agents): add address-review skill to address and resolve PR review comments

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -85,7 +85,9 @@ Wait for the user to confirm, adjust, or override each recommendation before pro
 
 ### Step 4 — Apply fixes and reply to all threads
 
-For each thread, apply the outcome and post a reply via the GitHub REST API:
+For each thread, apply the outcome and post a reply via the GitHub REST API.
+
+For **inline** review comments (attached to a file and line):
 
 ```bash
 gh api repos/<OWNER>/<REPO>/pulls/comments/<COMMENT_DATABASE_ID>/replies \
@@ -93,6 +95,13 @@ gh api repos/<OWNER>/<REPO>/pulls/comments/<COMMENT_DATABASE_ID>/replies \
 ```
 
 Use the `databaseId` of the **first** comment in the thread as `<COMMENT_DATABASE_ID>`.
+
+For **general** PR comments (no associated file/line — the above endpoint returns 404):
+
+```bash
+gh api repos/<OWNER>/<REPO>/issues/<PR_NUMBER>/comments \
+  -X POST -f body="<reply>"
+```
 
 **Reply tone per outcome:**
 
@@ -105,6 +114,8 @@ Do not touch code for ⚠️ or ❌ threads.
 ### Step 5 — Ask for git permission
 
 **Do NOT run any git commit, push, or rebase commands without explicit user approval.**
+
+Note: `git add`, `git commit`, and `git push` are intentionally absent from `allowed-tools` so that each git operation requires explicit user confirmation in the Claude Code UI — in addition to the approval requested below.
 
 Summarise the fixes made (files changed, what was fixed), then ask:
 > "May I commit and push these changes? Branch: `<branch>`, suggested commit message: `<conventional-commit-message>`"

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: fix-pr
+name: address-review
 description: Address open review comments on a PR, resolve threads, then re-run /review
 argument-hint: <pr-number>
 allowed-tools:

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: address-review
-description: Address open review comments on a PR, resolve threads, then re-run /review
+description: Address open review comments on a PR, reply to each thread, resolve approved ones, then re-run /review
 argument-hint: <pr-number>
 allowed-tools:
   - Bash(gh api:*)
@@ -43,6 +43,7 @@ query($owner:String!, $repo:String!, $pr:Int!) {
           isResolved
           comments(first:10) {
             nodes {
+              databaseId
               body
               path
               line
@@ -74,19 +75,32 @@ For each unresolved thread, read the file at `path` around the relevant `line`, 
 | … | | | |
 
 **Recommendation criteria:**
-- ✅ **Apply** — comment is valid, clear, and consistent with project conventions
+- ✅ **Apply** — comment is valid, clear, consistent with project conventions, and backed by a justification or source
 - ⚠️ **Discuss** — comment requires a design decision, is ambiguous, or contradicts existing conventions
-- ❌ **Skip** — comment is factually wrong, out of scope, or already addressed
+- ❌ **Skip** — comment is factually wrong, out of scope, already addressed, or not backed by any source or justification
+
+Per project conventions, reviewers are expected to back their requests with sources (docs, articles, benchmarks). A comment that expresses personal preference without justification should be marked ❌ or ⚠️.
 
 Wait for the user to confirm, adjust, or override each recommendation before proceeding.
 
-### Step 4 — Apply approved fixes
+### Step 4 — Apply fixes and reply to all threads
 
-For each comment the user approved (✅):
-1. Apply the fix using Edit or Write
-2. Note the thread `id` for Step 7
+For each thread, apply the outcome and post a reply via the GitHub REST API:
 
-Do not touch comments marked ⚠️ until the user has clarified intent. Do not touch comments marked ❌.
+```bash
+gh api repos/<OWNER>/<REPO>/pulls/comments/<COMMENT_DATABASE_ID>/replies \
+  -X POST -f body="<reply>"
+```
+
+Use the `databaseId` of the **first** comment in the thread as `<COMMENT_DATABASE_ID>`.
+
+**Reply tone per outcome:**
+
+- ✅ **Apply**: briefly confirm what was changed (e.g. "Fixed — renamed `X` to `Y` in `path/to/file.kt`.")
+- ⚠️ **Discuss**: ask for clarification or a source (e.g. "Could you point to a reference or clarify the intent? Happy to adjust once the approach is clearer.")
+- ❌ **Skip**: explain concisely why the comment is being declined, citing conventions or sources where applicable (e.g. "Keeping the current approach — it follows the pattern established in `docs/conventions/X.md`. Feel free to reopen if you disagree.")
+
+Do not touch code for ⚠️ or ❌ threads.
 
 ### Step 5 — Ask for git permission
 
@@ -103,7 +117,7 @@ Once the user approves:
 
 1. Stage and commit the changes using the approved message.
 2. Push to the current branch.
-3. For each thread fixed (✅ only), resolve it via GraphQL:
+3. For each ✅ thread only, resolve it via GraphQL:
 
 ```bash
 gh api graphql -f query='
@@ -113,6 +127,8 @@ mutation($threadId:ID!) {
   }
 }' -f threadId=<THREAD_ID>
 ```
+
+⚠️ and ❌ threads are left open for the reviewer to follow up.
 
 ### Step 7 — Re-run /review
 

--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -102,4 +102,8 @@ mutation($threadId:ID!) {
 
 ### Step 6 — Re-run /review
 
-Invoke the `/review` skill on the same PR number to verify the state of the PR after fixes.
+Invoke the `/review` skill with the same PR number to verify the state of the PR after fixes:
+
+```
+/review <PR_NUMBER>
+```

--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: fix-pr
+description: Address open review comments on a PR, resolve threads, then re-run /review
+argument-hint: <pr-number>
+allowed-tools:
+  - Bash(gh api:*)
+  - Bash(gh pr:*)
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git log:*)
+  - Bash(git branch:*)
+  - Read
+  - Edit
+  - Write
+---
+
+## Context
+
+- PR number: $ARGUMENTS
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Follow these steps in order.
+
+### Step 1 — Identify the PR
+
+If `$ARGUMENTS` is empty, run `gh pr list` and ask the user which PR to fix.
+Otherwise use `$ARGUMENTS` as the PR number.
+
+### Step 2 — Fetch open review threads
+
+Use the GitHub GraphQL API to get all unresolved review threads with their comments:
+
+```bash
+gh api graphql -f query='
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100) {
+        nodes {
+          id
+          isResolved
+          comments(first:1) {
+            nodes {
+              body
+              path
+              line
+              originalLine
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner=cyrillrx -f repo=kmp-ttrpg-companion -F pr=<PR_NUMBER>
+```
+
+Filter for `isResolved: false` threads. If there are none, inform the user and stop.
+
+### Step 3 — Understand and fix each comment
+
+For each unresolved thread:
+1. Read the file at `path` around the relevant `line`
+2. Understand what the reviewer is asking
+3. Apply the fix using Edit or Write
+4. Note the thread `id` for Step 5
+
+If a comment requires judgment (e.g. design decision, ambiguous intent), explain the issue to the user and ask how to proceed before making the change.
+
+### Step 4 — Ask for git permission
+
+**Do NOT run any git commit, push, or rebase commands without explicit user approval.**
+
+Summarise the fixes made (files changed, what was fixed), then ask:
+> "Puis-je committer et pusher ces changements ? Branche : `<branch>`, message de commit suggéré : `<conventional-commit-message>`"
+
+Wait for approval before proceeding.
+
+### Step 5 — Commit, push, and resolve threads
+
+Once the user approves:
+
+1. Stage and commit the changes using the approved message.
+2. Push to the current branch.
+3. For each thread fixed, resolve it via GraphQL:
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!) {
+  resolveReviewThread(input:{threadId:$threadId}) {
+    thread { isResolved }
+  }
+}' -f threadId=<THREAD_ID>
+```
+
+### Step 6 — Re-run /review
+
+Invoke the `/review` skill on the same PR number to verify the state of the PR after fixes.

--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -41,7 +41,7 @@ query($owner:String!, $repo:String!, $pr:Int!) {
         nodes {
           id
           isResolved
-          comments(first:1) {
+          comments(first:10) {
             nodes {
               body
               path
@@ -53,7 +53,13 @@ query($owner:String!, $repo:String!, $pr:Int!) {
       }
     }
   }
-}' -f owner=cyrillrx -f repo=kmp-ttrpg-companion -F pr=<PR_NUMBER>
+}' -f owner=<OWNER> -f repo=<REPO> -F pr=<PR_NUMBER>
+```
+
+Determine `<OWNER>` and `<REPO>` dynamically before running the query:
+
+```bash
+gh repo view --json owner,name -q '"\(.owner.login) \(.name)"'
 ```
 
 Filter for `isResolved: false` threads. If there are none, inform the user and stop.
@@ -73,7 +79,7 @@ If a comment requires judgment (e.g. design decision, ambiguous intent), explain
 **Do NOT run any git commit, push, or rebase commands without explicit user approval.**
 
 Summarise the fixes made (files changed, what was fixed), then ask:
-> "Puis-je committer et pusher ces changements ? Branche : `<branch>`, message de commit suggéré : `<conventional-commit-message>`"
+> "May I commit and push these changes? Branch: `<branch>`, suggested commit message: `<conventional-commit-message>`"
 
 Wait for approval before proceeding.
 

--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -64,17 +64,31 @@ gh repo view --json owner,name -q '"\(.owner.login) \(.name)"'
 
 Filter for `isResolved: false` threads. If there are none, inform the user and stop.
 
-### Step 3 — Understand and fix each comment
+### Step 3 — Triage comments
 
-For each unresolved thread:
-1. Read the file at `path` around the relevant `line`
-2. Understand what the reviewer is asking
-3. Apply the fix using Edit or Write
-4. Note the thread `id` for Step 5
+For each unresolved thread, read the file at `path` around the relevant `line`, then present a triage table to the user:
 
-If a comment requires judgment (e.g. design decision, ambiguous intent), explain the issue to the user and ask how to proceed before making the change.
+| # | File | Comment summary | Recommendation |
+|---|------|-----------------|----------------|
+| 1 | `path:line` | one-line summary | ✅ Apply / ⚠️ Discuss / ❌ Skip |
+| … | | | |
 
-### Step 4 — Ask for git permission
+**Recommendation criteria:**
+- ✅ **Apply** — comment is valid, clear, and consistent with project conventions
+- ⚠️ **Discuss** — comment requires a design decision, is ambiguous, or contradicts existing conventions
+- ❌ **Skip** — comment is factually wrong, out of scope, or already addressed
+
+Wait for the user to confirm, adjust, or override each recommendation before proceeding.
+
+### Step 4 — Apply approved fixes
+
+For each comment the user approved (✅):
+1. Apply the fix using Edit or Write
+2. Note the thread `id` for Step 7
+
+Do not touch comments marked ⚠️ until the user has clarified intent. Do not touch comments marked ❌.
+
+### Step 5 — Ask for git permission
 
 **Do NOT run any git commit, push, or rebase commands without explicit user approval.**
 
@@ -83,13 +97,13 @@ Summarise the fixes made (files changed, what was fixed), then ask:
 
 Wait for approval before proceeding.
 
-### Step 5 — Commit, push, and resolve threads
+### Step 6 — Commit, push, and resolve threads
 
 Once the user approves:
 
 1. Stage and commit the changes using the approved message.
 2. Push to the current branch.
-3. For each thread fixed, resolve it via GraphQL:
+3. For each thread fixed (✅ only), resolve it via GraphQL:
 
 ```bash
 gh api graphql -f query='
@@ -100,7 +114,7 @@ mutation($threadId:ID!) {
 }' -f threadId=<THREAD_ID>
 ```
 
-### Step 6 — Re-run /review
+### Step 7 — Re-run /review
 
 Invoke the `/review` skill with the same PR number to verify the state of the PR after fixes:
 

--- a/docs/conventions/git-and-collaboration.md
+++ b/docs/conventions/git-and-collaboration.md
@@ -81,7 +81,22 @@ Bad (monolithic):
 feat(spell): redesign spell list screen with new item, samples, and strings
 ```
 
-## 6. CI & Policies
+## 6. Pull Request Etiquette
+
+### Authors
+
+- Keep the diff under 200 lines and 10 files when possible. For mechanical changes (renaming, moving files), exceptions are acceptable.
+- Proofread your own PR before submitting — check diff, description, and comments.
+- Assign reviewers directly on GitHub.
+
+### Reviewers
+
+- Review PRs within 24 hours when possible. If you're short on time, don't rush — an unreviewed PR is better than a rubber-stamped one.
+- Be constructive and kind: critique the code, not the author.
+- Back your comments with sources (docs, articles, benchmarks) rather than personal preference. Don't request changes you can't justify.
+- Use [Code Review Emojis](https://github.com/cyrillrx/coding-conventions/blob/main/code-review-emojis.md) to add meaning to your comments (blocking vs. non-blocking, suggestion vs. question, etc.).
+
+## 7. CI & Policies
 
 - **Pull Requests**: All code must be reviewed via PRs before merging into `main`.
 - **Code Quality**: PRs must pass all automated checks (linting, tests, build) on the CI pipeline. The CI pipeline (`.github/workflows/ci.yml`) runs `KMP Client - JVM Tests` (`./gradlew jvmTest` in `cmp-ttrpg-companion/`) on every PR targeting the default branch. It must pass for a PR to be mergeable.


### PR DESCRIPTION
## 📝 Description

Adds a new Claude Code skill `/address-review` at `.claude/skills/address-review/SKILL.md`, and a Pull Request Etiquette section to `docs/conventions/git-and-collaboration.md`.

The skill automates the PR review feedback loop with human-in-the-loop validation at two explicit checkpoints:

1. Fetches all unresolved review threads via GitHub GraphQL API
2. Reads each flagged file and triages every comment (✅ Apply / ⚠️ Discuss / ❌ Skip) — including checking whether the comment is backed by a source or justification
3. Waits for user confirmation on the triage before touching any code
4. Applies fixes and posts a GitHub reply to every thread (inline or general), adapted to the outcome
5. Asks for explicit git permission before any commit or push
6. Commits, pushes, and resolves approved (✅) threads via `resolveReviewThread` — ⚠️ and ❌ threads are left open for the reviewer to follow up
7. Re-runs `/review` on the same PR to verify the updated state

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [ ] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed