### PR TITLE
docs(agents): add /ingest skill to normalize compendium entities from external sources

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ingest
-description: Ingest new compendium entities from an external source file (JSON or YAML) into the normalized YAML format
+description: Ingest new compendium entities from an external source file (JSON, YAML, or HTML) into the normalized YAML format
 argument-hint: <entity-type> <source-file>
 allowed-tools:
   - Bash(python3 scripts/build_compendium.py*)
@@ -47,7 +47,22 @@ Read `<source-file>`. It may contain one entity or a list.
 Detect the format:
 - **JSON**: parse as object or array
 - **YAML**: parse as mapping or sequence
-- **Unknown**: if the format cannot be detected (HTML, CSV, plain text, etc.), stop and ask the user how to proceed before attempting any parsing.
+- **HTML**: see extraction guidance below
+- **Unknown**: if the format cannot be detected (CSV, plain text, etc.), stop and ask the user how to proceed before attempting any parsing.
+
+#### HTML extraction guidance
+
+HTML sources vary significantly by origin (D&D Beyond, aidedd.org, homebrew, etc.). For each entity block in the HTML:
+
+1. Identify the repeating structure that delimits one entity (e.g. `<div class="monster">`, `<section>`, `<h2>` headings, etc.)
+2. Extract fields by mapping HTML content to schema fields using the ingestion guide as reference:
+   - Headings and labels → field names
+   - Inline text, `<p>`, `<td>` → field values
+   - `<table>` → structured data (speeds, abilities, damage affinities, etc.)
+   - `<em>`, `<strong>` → formatting hints, not field boundaries
+3. Preserve HTML markup in `description` fields — do not strip tags (descriptions are stored as HTML in Phase 1).
+4. If the source locale cannot be determined from the HTML, ask the user.
+5. If a field is ambiguous or cannot be reliably extracted, flag it as ⚠️ in the triage table rather than guessing.
 
 ### Step 4 — Normalize and triage
 

--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -44,11 +44,19 @@ Also read `docs/data/srd-fr-en.md` for enum mappings (schools, classes, types, r
 
 Read `<source-file>`. It may contain one entity or a list.
 
-Detect the format:
+Detect the format by file extension first, then by content if the extension is absent or ambiguous:
+
+| Extension | Format |
+|-----------|--------|
+| `.json` | JSON |
+| `.yaml`, `.yml` | YAML |
+| `.html`, `.htm` | HTML |
+| other / none | inspect content: starts with `{` or `[` → JSON, starts with `<` → HTML, otherwise YAML or unknown |
+
 - **JSON**: parse as object or array
 - **YAML**: parse as mapping or sequence
 - **HTML**: see extraction guidance below
-- **Unknown**: if the format cannot be detected (CSV, plain text, etc.), stop and ask the user how to proceed before attempting any parsing.
+- **Unknown**: if the format still cannot be determined, stop and ask the user before attempting any parsing.
 
 #### HTML extraction guidance
 

--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ingest
+description: Ingest new compendium entities from an external source file (JSON or YAML) into the normalized YAML format
+argument-hint: <entity-type> <source-file>
+allowed-tools:
+  - Bash(python3 scripts/build_compendium.py*)
+  - Bash(ls data/compendium/*)
+  - Bash(gh repo view:*)
+  - Read
+  - Edit
+  - Write
+---
+
+## Context
+
+- Arguments: $ARGUMENTS
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Follow these steps in order.
+
+### Step 1 — Parse arguments
+
+Extract from `$ARGUMENTS`:
+- `<entity-type>`: one of `spell`, `monster`, `magical-item`
+- `<source-file>`: path to the source file to ingest (JSON or YAML)
+
+If either is missing, ask the user before proceeding.
+
+### Step 2 — Read the ingestion guide
+
+Read the relevant guide to understand the expected schema, field names, enum values, and validation rules:
+
+| Entity type   | Guide |
+|---------------|-------|
+| `spell`       | `docs/data/srd-spell-ingestion.md` |
+| `monster`     | `docs/data/srd-monster-ingestion.md` |
+| `magical-item`| `docs/data/srd-magical-item-ingestion.md` |
+
+Also read `docs/data/srd-fr-en.md` for enum mappings (schools, classes, types, rarities, etc.).
+
+### Step 3 — Read and parse the source file
+
+Read `<source-file>`. It may contain one entity or a list.
+
+Detect the format:
+- **JSON**: parse as object or array
+- **YAML**: parse as mapping or sequence
+
+### Step 4 — Normalize and triage
+
+For each entity, map the source fields to the normalized schema defined in the ingestion guide.
+
+Then present a triage table:
+
+| # | id (proposed) | Name | Issues |
+|---|---------------|------|--------|
+| 1 | `slug` | Entity name | ⚠️ missing EN translation / ⚠️ unknown enum value / ✅ none |
+| … | | | |
+
+**Flag as ⚠️ when:**
+- A required field is missing or null
+- An enum value is unrecognized (school, type, rarity, class, etc.)
+- The proposed `id` already exists in `data/compendium/<type>/`
+- Only one locale is present (both `en` and `fr` are required)
+- The `id` is not a valid slug (lowercase, hyphens only, English)
+
+For each ⚠️, propose a resolution and ask the user to confirm before writing.
+
+### Step 5 — Write YAML files
+
+For each validated entity, write a YAML file to `data/compendium/<type>/<id>.yaml`.
+
+Follow the style conventions:
+- All keys in camelCase
+- Multiline strings use block scalar style (`|`)
+- Null values written explicitly as `null`
+- No trailing whitespace
+
+Do not overwrite an existing file without explicit user confirmation.
+
+### Step 6 — Build and verify
+
+Run the build script to regenerate the JSON and verify the round-trip:
+
+```bash
+python3 scripts/build_compendium.py
+python3 scripts/build_compendium.py --check
+```
+
+If `--check` fails, show the error and stop. Do not proceed to git steps until the check passes.
+
+### Step 7 — Ask for git permission
+
+**Do NOT run any git commit, push, or rebase commands without explicit user approval.**
+
+Summarise what was written (number of entities, any skipped), then ask:
+> "May I commit and push these changes? Branch: `<branch>`, suggested commit message: `<conventional-commit-message>`"
+
+Use commit type `feat(data)` for new entities, `fix(data)` for corrections.
+
+Wait for approval before proceeding.
+
+### Step 8 — Commit and push
+
+Once approved, stage and commit the new YAML files and the regenerated JSON, then push to the current branch.

--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: <entity-type> <source-file>
 allowed-tools:
   - Bash(python3 scripts/build_compendium.py*)
   - Bash(ls data/compendium/*)
-  - Bash(gh repo view:*)
+  - Bash(git branch:*)
   - Read
   - Edit
   - Write
@@ -47,6 +47,7 @@ Read `<source-file>`. It may contain one entity or a list.
 Detect the format:
 - **JSON**: parse as object or array
 - **YAML**: parse as mapping or sequence
+- **Unknown**: if the format cannot be detected (HTML, CSV, plain text, etc.), stop and ask the user how to proceed before attempting any parsing.
 
 ### Step 4 — Normalize and triage
 
@@ -67,6 +68,8 @@ Then present a triage table:
 - The `id` is not a valid slug (lowercase, hyphens only, English)
 
 For each ⚠️, propose a resolution and ask the user to confirm before writing.
+
+Once the full triage table is presented, **wait for explicit user confirmation** before proceeding to Step 5. Do not write any file until the user approves the triage as a whole.
 
 ### Step 5 — Write YAML files
 


### PR DESCRIPTION
## 📝 Description

Adds a new Claude Code skill \`/ingest\` at \`.claude/skills/ingest/SKILL.md\`.

This skill handles ingestion of new compendium entities (spells, monsters, magical items) from external source files in any format (JSON, YAML, or HTML):

1. Parses arguments: entity type + source file path
2. Reads the relevant ingestion guide (\`docs/data/srd-*-ingestion.md\`) and FR↔EN enum mapping
3. Reads and parses the source file — auto-detects format by extension then content (JSON, YAML, HTML); asks the user if format is ambiguous
4. Normalizes fields to the project schema and presents a triage table — flags missing fields, unknown enums, duplicate IDs, missing translations, and non-slug IDs
5. Waits for global user confirmation on the triage before writing any file
6. Writes YAML files to \`data/compendium/<type>/\` (asks before overwriting)
7. Runs \`build_compendium.py\` + \`--check\` to verify the round-trip
8. Asks for explicit git permission before any commit or push

## ✅ Checklist

- [x] Code follows the conventions in \`AGENTS.md\` and \`docs/conventions/\`
- [x] The author has proofread the PR
- [ ] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed