### PR TITLE
feat(character): Phase 5a — Race enum, Character model enrichment, and doc alignment

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!-- Character race -->
+    <string name="race_human">Humain</string>
+    <string name="race_elf">Elfe</string>
+    <string name="race_dwarf">Nain</string>
+    <string name="race_halfling">Halfelin</string>
+    <string name="race_half_elf">Demi-elfe</string>
+    <string name="race_half_orc">Demi-orc</string>
+    <string name="race_dragonborn">Dragonné</string>
+    <string name="race_gnome">Gnome</string>
+    <string name="race_tiefling">Tieffelin</string>
+</resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!-- Character race -->
+    <string name="race_human">Human</string>
+    <string name="race_elf">Elf</string>
+    <string name="race_dwarf">Dwarf</string>
+    <string name="race_halfling">Halfling</string>
+    <string name="race_half_elf">Half-Elf</string>
+    <string name="race_half_orc">Half-Orc</string>
+    <string name="race_dragonborn">Dragonborn</string>
+    <string name="race_gnome">Gnome</string>
+    <string name="race_tiefling">Tiefling</string>
+</resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
@@ -1,9 +1,23 @@
 package com.cyrillrx.rpg.core.presentation.component.dnd
 
 import androidx.compose.runtime.Composable
+import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Race
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.class_barbarian
+import rpg_companion.composeapp.generated.resources.class_bard
+import rpg_companion.composeapp.generated.resources.class_cleric
+import rpg_companion.composeapp.generated.resources.class_druid
+import rpg_companion.composeapp.generated.resources.class_fighter
+import rpg_companion.composeapp.generated.resources.class_monk
+import rpg_companion.composeapp.generated.resources.class_paladin
+import rpg_companion.composeapp.generated.resources.class_ranger
+import rpg_companion.composeapp.generated.resources.class_rogue
+import rpg_companion.composeapp.generated.resources.class_sorcerer
+import rpg_companion.composeapp.generated.resources.class_unknown
+import rpg_companion.composeapp.generated.resources.class_warlock
+import rpg_companion.composeapp.generated.resources.class_wizard
 import rpg_companion.composeapp.generated.resources.race_dragonborn
 import rpg_companion.composeapp.generated.resources.race_dwarf
 import rpg_companion.composeapp.generated.resources.race_elf
@@ -26,6 +40,26 @@ fun Race.toFormattedString(): String {
         Race.DRAGONBORN -> Res.string.race_dragonborn
         Race.GNOME -> Res.string.race_gnome
         Race.TIEFLING -> Res.string.race_tiefling
+    }
+    return stringResource(stringRes)
+}
+
+@Composable
+fun Character.Class.toFormattedString(): String {
+    val stringRes = when (this) {
+        Character.Class.BARBARIAN -> Res.string.class_barbarian
+        Character.Class.BARD -> Res.string.class_bard
+        Character.Class.CLERIC -> Res.string.class_cleric
+        Character.Class.DRUID -> Res.string.class_druid
+        Character.Class.FIGHTER -> Res.string.class_fighter
+        Character.Class.MONK -> Res.string.class_monk
+        Character.Class.PALADIN -> Res.string.class_paladin
+        Character.Class.RANGER -> Res.string.class_ranger
+        Character.Class.ROGUE -> Res.string.class_rogue
+        Character.Class.SORCERER -> Res.string.class_sorcerer
+        Character.Class.WARLOCK -> Res.string.class_warlock
+        Character.Class.WIZARD -> Res.string.class_wizard
+        Character.Class.UNKNOWN -> Res.string.class_unknown
     }
     return stringResource(stringRes)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
@@ -1,0 +1,31 @@
+package com.cyrillrx.rpg.core.presentation.component.dnd
+
+import androidx.compose.runtime.Composable
+import com.cyrillrx.rpg.character.domain.Race
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.race_dragonborn
+import rpg_companion.composeapp.generated.resources.race_dwarf
+import rpg_companion.composeapp.generated.resources.race_elf
+import rpg_companion.composeapp.generated.resources.race_gnome
+import rpg_companion.composeapp.generated.resources.race_half_elf
+import rpg_companion.composeapp.generated.resources.race_half_orc
+import rpg_companion.composeapp.generated.resources.race_halfling
+import rpg_companion.composeapp.generated.resources.race_human
+import rpg_companion.composeapp.generated.resources.race_tiefling
+
+@Composable
+fun Race.toFormattedString(): String {
+    val stringRes = when (this) {
+        Race.HUMAN -> Res.string.race_human
+        Race.ELF -> Res.string.race_elf
+        Race.DWARF -> Res.string.race_dwarf
+        Race.HALFLING -> Res.string.race_halfling
+        Race.HALF_ELF -> Res.string.race_half_elf
+        Race.HALF_ORC -> Res.string.race_half_orc
+        Race.DRAGONBORN -> Res.string.race_dragonborn
+        Race.GNOME -> Res.string.race_gnome
+        Race.TIEFLING -> Res.string.race_tiefling
+    }
+    return stringResource(stringRes)
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
@@ -12,24 +12,10 @@ import androidx.compose.material.icons.outlined.Dangerous
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.presentation.theme.Red900
 import com.cyrillrx.rpg.spell.domain.Spell
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.class_barbarian
-import rpg_companion.composeapp.generated.resources.class_bard
-import rpg_companion.composeapp.generated.resources.class_cleric
-import rpg_companion.composeapp.generated.resources.class_druid
-import rpg_companion.composeapp.generated.resources.class_fighter
-import rpg_companion.composeapp.generated.resources.class_monk
-import rpg_companion.composeapp.generated.resources.class_paladin
-import rpg_companion.composeapp.generated.resources.class_ranger
-import rpg_companion.composeapp.generated.resources.class_rogue
-import rpg_companion.composeapp.generated.resources.class_sorcerer
-import rpg_companion.composeapp.generated.resources.class_unknown
-import rpg_companion.composeapp.generated.resources.class_warlock
-import rpg_companion.composeapp.generated.resources.class_wizard
 import rpg_companion.composeapp.generated.resources.formatted_spell_school_level
 import rpg_companion.composeapp.generated.resources.school_abjuration
 import rpg_companion.composeapp.generated.resources.school_conjuration
@@ -92,26 +78,6 @@ fun Spell.School?.toIcon(): ImageVector = when (this) {
     Spell.School.NECROMANCY -> Icons.Outlined.Dangerous
     Spell.School.TRANSMUTATION -> Icons.Filled.SwapHoriz
     null -> Icons.Filled.AutoAwesome
-}
-
-@Composable
-fun Character.Class.toFormattedString(): String {
-    val stringRes = when (this) {
-        Character.Class.BARBARIAN -> Res.string.class_barbarian
-        Character.Class.BARD -> Res.string.class_bard
-        Character.Class.CLERIC -> Res.string.class_cleric
-        Character.Class.DRUID -> Res.string.class_druid
-        Character.Class.FIGHTER -> Res.string.class_fighter
-        Character.Class.MONK -> Res.string.class_monk
-        Character.Class.PALADIN -> Res.string.class_paladin
-        Character.Class.RANGER -> Res.string.class_ranger
-        Character.Class.ROGUE -> Res.string.class_rogue
-        Character.Class.SORCERER -> Res.string.class_sorcerer
-        Character.Class.WARLOCK -> Res.string.class_warlock
-        Character.Class.WIZARD -> Res.string.class_wizard
-        Character.Class.UNKNOWN -> Res.string.class_unknown
-    }
-    return stringResource(stringRes)
 }
 
 @Composable

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
@@ -1,0 +1,78 @@
+package com.cyrillrx.rpg.character.data
+
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.domain.CharacterFilter
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.character.domain.applyFilter
+import com.cyrillrx.rpg.creature.domain.Abilities
+import com.cyrillrx.rpg.creature.domain.Ability
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.Skills
+import com.cyrillrx.rpg.creature.domain.Speeds
+
+class SampleCharacterRepository : CharacterRepository {
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> =
+        characters.applyFilter(filter)
+
+    override suspend fun get(id: String): Character? =
+        characters.firstOrNull { it.id == id }
+
+    override suspend fun save(character: Character) = Unit
+
+    override suspend fun delete(id: String) = Unit
+
+    companion object {
+        private val characters: List<Character> = listOf(
+            humanFighter(),
+            elfRogue(),
+        )
+
+        fun getAll(): List<Character> = characters
+
+        fun humanFighter() = Character(
+            id = "sample-fighter",
+            name = "Borin Pierrenoire",
+            description = "",
+            size = Creature.Size.MEDIUM,
+            alignment = Creature.Alignment.LAWFUL_GOOD,
+            abilities = Abilities(
+                str = Ability(16),
+                dex = Ability(12),
+                con = Ability(14),
+                int = Ability(10),
+                wis = Ability(10),
+                cha = Ability(8),
+            ),
+            armorClass = 16,
+            maxHitPoints = 12,
+            speeds = Speeds(walk = 30),
+            languages = listOf("common", "dwarvish"),
+            level = 1,
+            clazz = Character.Class.FIGHTER,
+            skills = Skills(),
+        )
+
+        fun elfRogue() = Character(
+            id = "sample-rogue",
+            name = "Lyra Vossen",
+            description = "",
+            size = Creature.Size.MEDIUM,
+            alignment = Creature.Alignment.CHAOTIC_NEUTRAL,
+            abilities = Abilities(
+                str = Ability(8),
+                dex = Ability(16),
+                con = Ability(12),
+                int = Ability(14),
+                wis = Ability(10),
+                cha = Ability(14),
+            ),
+            armorClass = 14,
+            maxHitPoints = 8,
+            speeds = Speeds(walk = 30),
+            languages = listOf("common", "elvish"),
+            level = 1,
+            clazz = Character.Class.ROGUE,
+            skills = Skills(),
+        )
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -36,7 +36,7 @@ class Character(
 ) {
     fun initiativeModifier(): Int = abilities.dex.modifier
 
-    val proficiencyBonus: Int = when (level) {
+    fun proficiencyBonus(): Int = when (level) {
         in 1..4 -> 2
         in 5..8 -> 3
         in 9..12 -> 4

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -18,8 +18,12 @@ class Character(
     languages: List<String>,
     val level: Int,
     val clazz: Class,
-    val initiativeModifier: Int = abilities.dex.modifier,
     val skills: Skills,
+    val race: Race = Race.HUMAN,
+    val shortDescription: String? = null,
+    val background: String? = null,
+    val currentHp: Int = maxHitPoints,
+    val temporaryHp: Int = 0,
 ) : Creature(
     id = id,
     size = size,
@@ -30,6 +34,8 @@ class Character(
     speeds = speeds,
     languages = languages,
 ) {
+    fun initiativeModifier(): Int = abilities.dex.modifier
+
     val proficiencyBonus: Int = when (level) {
         in 1..4 -> 2
         in 5..8 -> 3

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -22,8 +22,8 @@ class Character(
     val race: Race = Race.HUMAN,
     val shortDescription: String? = null,
     val background: String? = null,
-    val currentHp: Int = maxHitPoints,
-    val temporaryHp: Int = 0,
+    val currentHitPoints: Int = maxHitPoints,
+    val temporaryHitPoints: Int = 0,
 ) : Creature(
     id = id,
     size = size,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Race.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Race.kt
@@ -1,0 +1,13 @@
+package com.cyrillrx.rpg.character.domain
+
+enum class Race {
+    HUMAN,
+    ELF,
+    DWARF,
+    HALFLING,
+    HALF_ELF,
+    HALF_ORC,
+    DRAGONBORN,
+    GNOME,
+    TIEFLING,
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterApplyFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterApplyFilterTest.kt
@@ -1,0 +1,42 @@
+package com.cyrillrx.rpg.character.domain
+
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CharacterApplyFilterTest {
+
+    private val characters = SampleCharacterRepository.getAll()
+
+    @Test
+    fun `null filter returns the full list`() {
+        val result = characters.applyFilter(null)
+        assertEquals(characters, result)
+    }
+
+    @Test
+    fun `default filter returns all characters`() {
+        val result = characters.applyFilter(CharacterFilter())
+        assertEquals(characters.size, result.size)
+    }
+
+    @Test
+    fun `filter by query keeps only matching characters`() {
+        val result = characters.applyFilter(CharacterFilter(query = "Lyra"))
+        assertEquals(1, result.size)
+        assertEquals("Lyra Vossen", result.first().name)
+    }
+
+    @Test
+    fun `filter by query is case insensitive`() {
+        val result = characters.applyFilter(CharacterFilter(query = "lyra"))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `filter with no match returns empty list`() {
+        val result = characters.applyFilter(CharacterFilter(query = "Gandalf"))
+        assertTrue(result.isEmpty())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterTest.kt
@@ -1,0 +1,60 @@
+package com.cyrillrx.rpg.character.domain
+
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.creature.domain.Abilities
+import com.cyrillrx.rpg.creature.domain.Ability
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.Skills
+import com.cyrillrx.rpg.creature.domain.Speeds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CharacterTest {
+
+    @Test
+    fun `initiativeModifier returns dex modifier`() {
+        val fighter = SampleCharacterRepository.humanFighter() // DEX 12 → modifier +1
+        assertEquals(1, fighter.initiativeModifier())
+    }
+
+    @Test
+    fun `initiativeModifier reflects updated dex value`() {
+        val highDexCharacter = character(dex = 20) // DEX 20 → modifier +5
+        assertEquals(5, highDexCharacter.initiativeModifier())
+    }
+
+    @Test
+    fun `initiativeModifier is negative for low dex`() {
+        val lowDexCharacter = character(dex = 8) // DEX 8 → modifier -1
+        assertEquals(-1, lowDexCharacter.initiativeModifier())
+    }
+
+    @Test
+    fun `initiativeModifier is zero for average dex`() {
+        val averageDexCharacter = character(dex = 10) // DEX 10 → modifier 0
+        assertEquals(0, averageDexCharacter.initiativeModifier())
+    }
+
+    private fun character(dex: Int) = Character(
+        id = "test",
+        name = "Test",
+        description = "",
+        size = Creature.Size.MEDIUM,
+        alignment = Creature.Alignment.NEUTRAL,
+        abilities = Abilities(
+            str = Ability(10),
+            dex = Ability(dex),
+            con = Ability(10),
+            int = Ability(10),
+            wis = Ability(10),
+            cha = Ability(10),
+        ),
+        armorClass = 10,
+        maxHitPoints = 10,
+        speeds = Speeds(walk = 30),
+        languages = emptyList(),
+        level = 1,
+        clazz = Character.Class.FIGHTER,
+        skills = Skills(),
+    )
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterTest.kt
@@ -35,7 +35,25 @@ class CharacterTest {
         assertEquals(0, averageDexCharacter.initiativeModifier())
     }
 
-    private fun character(dex: Int) = Character(
+    @Test
+    fun `proficiencyBonus is 2 for levels 1 to 4`() {
+        assertEquals(2, character(level = 1).proficiencyBonus())
+        assertEquals(2, character(level = 4).proficiencyBonus())
+    }
+
+    @Test
+    fun `proficiencyBonus is 3 for levels 5 to 8`() {
+        assertEquals(3, character(level = 5).proficiencyBonus())
+        assertEquals(3, character(level = 8).proficiencyBonus())
+    }
+
+    @Test
+    fun `proficiencyBonus is 6 for levels 17 to 20`() {
+        assertEquals(6, character(level = 17).proficiencyBonus())
+        assertEquals(6, character(level = 20).proficiencyBonus())
+    }
+
+    private fun character(dex: Int = 10, level: Int = 1) = Character(
         id = "test",
         name = "Test",
         description = "",
@@ -53,7 +71,7 @@ class CharacterTest {
         maxHitPoints = 10,
         speeds = Speeds(walk = 30),
         languages = emptyList(),
-        level = 1,
+        level = level,
         clazz = Character.Class.FIGHTER,
         skills = Skills(),
     )

--- a/docs/adr/adr-001-data-model.md
+++ b/docs/adr/adr-001-data-model.md
@@ -229,10 +229,10 @@ data class ConditionImmunities(
 
 ---
 
-## 9. hitDice on Creature Only, Not BaseCreature
+## 9. hitDice on Monster Only, Not Creature
 
 ### Decision
-`hitDice` (e.g., `"6d8+6"`) is a field on `Creature` only. It is **not** on `BaseCreature` and **not** on `PlayerCharacter`.
+`hitDice` (e.g., `"6d8+6"`) is a field on `Monster` only. It is **not** on `Creature` and **not** on `Character`.
 
 For `Character`, hit dice are computed from `level` and `clazz.hitDie` — never stored.
 

--- a/docs/prd/prd-002-character-sheet.md
+++ b/docs/prd/prd-002-character-sheet.md
@@ -57,7 +57,7 @@ Campaign integration (attaching sheets to a campaign, sharing with other players
 **Skills & Proficiencies**
 - [ ] Saving throws (with proficiency toggle)
 - [ ] Skill list with proficiency and expertise toggles
-- [ ] Passive Perception (auto-calculated)
+- [ ] Passive Perception (auto-calculated from WIS modifier by default; trait/feat bonuses handled in a later phase)
 - [ ] Proficiency bonus (auto-calculated from level)
 - [ ] Languages and other proficiencies
 

--- a/docs/prd/prd-002-character-sheet.md
+++ b/docs/prd/prd-002-character-sheet.md
@@ -1,6 +1,6 @@
 # PRD-002 — Character Sheet
 
-> **Status**: Draft | **Version**: 0.2 | **Last updated**: 2026-05-09
+> **Status**: Draft | **Version**: 0.3 | **Last updated**: 2026-05-10
 
 ## Overview
 
@@ -37,7 +37,7 @@ Campaign integration (attaching sheets to a campaign, sharing with other players
 ### Phase 1 — MVP (Offline)
 
 **General Info**
-- [ ] Character name, player name
+- [ ] Character name
 - [ ] Race / Ancestry
 - [ ] Class(es) and level
 - [ ] Background
@@ -49,10 +49,10 @@ Campaign integration (attaching sheets to a campaign, sharing with other players
 
 **Combat Stats**
 - [ ] Armor Class (AC)
-- [ ] Initiative
+- [ ] Initiative (calculated from DEX modifier by default; trait/feat bonuses handled in a later phase)
 - [ ] Speed
 - [ ] Current HP, Maximum HP, Temporary HP
-- [ ] Hit Dice
+- [ ] Hit Dice (calculated from `level + class.hitDie`, not stored — see [ADR-001 §9](../adr/adr-001-data-model.md))
 
 **Skills & Proficiencies**
 - [ ] Saving throws (with proficiency toggle)


### PR DESCRIPTION
## 📝 Description

Phase 5a of the Character Sheets feature. Aligns documentation with current architectural decisions (ADR-001, ADR-003) and enriches the `Character` domain model before building the UI (PR 5b).

**Documentation updates:**
- ADR-001 §9: rename outdated `BaseCreature`→`Creature` and `PlayerCharacter`→`Character`; clarify that `hitDice` lives on `Monster` only
- PRD-002 v0.3: remove `playerName` (campaign-layer concern per ADR-003); mark `hitDice` and `initiative` as calculated fields, not stored

**Domain changes (`shared/core`):**
- New `Race` enum with the 9 SRD races (Human, Elf, Dwarf, Halfling, Half-Elf, Half-Orc, Dragonborn, Gnome, Tiefling)
- `Character` new fields (all with defaults, non-breaking): `race`, `shortDescription`, `background`, `currentHitPoints`, `temporaryHitPoints`
- `initiativeModifier` and `proficiencyBonus` promoted from stored values to computed methods

**Presentation (`composeApp`):**
- `strings_character.xml` (EN + FR) with all 9 race names
- `CharacterFormatExt.kt`: `Race.toFormattedString()` + `Character.Class.toFormattedString()` (moved from `SpellFormatExt`)

**Tests:**
- `CharacterTest`: `initiativeModifier()` (4 cases) + `proficiencyBonus()` (3 cases)
- `CharacterApplyFilterTest`: `applyFilter` (5 cases)
- `SampleCharacterRepository`: reusable test fixtures (humanFighter, elfRogue)

## 🖼️ Media

No UI changes in this PR.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed