### PR TITLE
feat(character): Phase 5b - character list screen, preset gallery, and JSON presets

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/character_presets.json
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/character_presets.json
@@ -12,6 +12,7 @@
     "armorClass": 16,
     "maxHitPoints": 12,
     "speeds": { "walk": 30 },
+    "skills": {},
     "languages": ["common"],
     "translations": {
       "en": { "shortDescription": "Human Fighter", "description": "" },
@@ -31,6 +32,7 @@
     "armorClass": 14,
     "maxHitPoints": 8,
     "speeds": { "walk": 30 },
+    "skills": { "acrobatics": "proficient", "stealth": "proficient", "sleightOfHand": "proficient" },
     "languages": ["common", "elvish"],
     "translations": {
       "en": { "shortDescription": "Elf Rogue", "description": "" },
@@ -50,6 +52,7 @@
     "armorClass": 12,
     "maxHitPoints": 6,
     "speeds": { "walk": 30 },
+    "skills": { "arcana": "proficient", "history": "proficient" },
     "languages": ["common", "elvish", "draconic"],
     "translations": {
       "en": { "shortDescription": "Human Wizard", "description": "" },
@@ -69,6 +72,7 @@
     "armorClass": 16,
     "maxHitPoints": 10,
     "speeds": { "walk": 25 },
+    "skills": { "medicine": "proficient", "religion": "proficient" },
     "languages": ["common", "dwarvish"],
     "translations": {
       "en": { "shortDescription": "Dwarf Cleric", "description": "" },
@@ -87,6 +91,7 @@
     "armorClass": 16,
     "maxHitPoints": 11,
     "speeds": { "walk": 30 },
+    "skills": { "athletics": "proficient", "perception": "proficient" },
     "languages": ["common"],
     "translations": {
       "en": { "shortDescription": "City Guard", "description": "A loyal soldier of the city watch, stationed at the main gate." },
@@ -105,6 +110,7 @@
     "armorClass": 10,
     "maxHitPoints": 10,
     "speeds": { "walk": 30 },
+    "skills": { "insight": "proficient", "persuasion": "proficient" },
     "languages": ["common"],
     "translations": {
       "en": { "shortDescription": "Innkeeper", "description": "A warm and practical woman who runs the Silver Flagon with an iron fist hidden in a velvet glove." },
@@ -123,6 +129,7 @@
     "armorClass": 10,
     "maxHitPoints": 8,
     "speeds": { "walk": 30 },
+    "skills": { "persuasion": "proficient", "insight": "proficient" },
     "languages": ["common", "elvish"],
     "translations": {
       "en": { "shortDescription": "Merchant", "description": "A well-traveled trader who deals in exotic goods and knows the value of a well-placed rumor." },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/character_presets.json
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/character_presets.json
@@ -1,0 +1,132 @@
+[
+  {
+    "id": "preset-fighter-human",
+    "name": "Gareth Ironhold",
+    "race": "HUMAN",
+    "clazz": "FIGHTER",
+    "level": 1,
+    "size": "MEDIUM",
+    "alignment": "NEUTRAL",
+    "background": "Soldier",
+    "abilities": { "str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8 },
+    "armorClass": 16,
+    "maxHitPoints": 12,
+    "speeds": { "walk": 30 },
+    "languages": ["common"],
+    "translations": {
+      "en": { "shortDescription": "Human Fighter", "description": "" },
+      "fr": { "shortDescription": "Guerrier humain", "description": "" }
+    }
+  },
+  {
+    "id": "preset-rogue-elf",
+    "name": "Sylara Dawnwhisper",
+    "race": "ELF",
+    "clazz": "ROGUE",
+    "level": 1,
+    "size": "MEDIUM",
+    "alignment": "CHAOTIC_NEUTRAL",
+    "background": "Urchin",
+    "abilities": { "str": 8, "dex": 18, "con": 12, "int": 14, "wis": 10, "cha": 14 },
+    "armorClass": 14,
+    "maxHitPoints": 8,
+    "speeds": { "walk": 30 },
+    "languages": ["common", "elvish"],
+    "translations": {
+      "en": { "shortDescription": "Elf Rogue", "description": "" },
+      "fr": { "shortDescription": "Roublard elfe", "description": "" }
+    }
+  },
+  {
+    "id": "preset-wizard-human",
+    "name": "Aldus Vance",
+    "race": "HUMAN",
+    "clazz": "WIZARD",
+    "level": 1,
+    "size": "MEDIUM",
+    "alignment": "NEUTRAL_GOOD",
+    "background": "Sage",
+    "abilities": { "str": 8, "dex": 14, "con": 12, "int": 18, "wis": 12, "cha": 10 },
+    "armorClass": 12,
+    "maxHitPoints": 6,
+    "speeds": { "walk": 30 },
+    "languages": ["common", "elvish", "draconic"],
+    "translations": {
+      "en": { "shortDescription": "Human Wizard", "description": "" },
+      "fr": { "shortDescription": "Mage humain", "description": "" }
+    }
+  },
+  {
+    "id": "preset-cleric-dwarf",
+    "name": "Thordak Stonecraft",
+    "race": "DWARF",
+    "clazz": "CLERIC",
+    "level": 1,
+    "size": "MEDIUM",
+    "alignment": "LAWFUL_GOOD",
+    "background": "Acolyte",
+    "abilities": { "str": 14, "dex": 8, "con": 14, "int": 10, "wis": 16, "cha": 12 },
+    "armorClass": 16,
+    "maxHitPoints": 10,
+    "speeds": { "walk": 25 },
+    "languages": ["common", "dwarvish"],
+    "translations": {
+      "en": { "shortDescription": "Dwarf Cleric", "description": "" },
+      "fr": { "shortDescription": "Clerc nain", "description": "" }
+    }
+  },
+  {
+    "id": "preset-npc-guard",
+    "name": "Aldric Brennan",
+    "race": "HUMAN",
+    "clazz": "UNKNOWN",
+    "level": 1,
+    "size": "MEDIUM",
+    "alignment": "LAWFUL_NEUTRAL",
+    "abilities": { "str": 13, "dex": 12, "con": 12, "int": 10, "wis": 11, "cha": 10 },
+    "armorClass": 16,
+    "maxHitPoints": 11,
+    "speeds": { "walk": 30 },
+    "languages": ["common"],
+    "translations": {
+      "en": { "shortDescription": "City Guard", "description": "A loyal soldier of the city watch, stationed at the main gate." },
+      "fr": { "shortDescription": "Garde de la cité", "description": "Un soldat loyal de la garde de la ville, posté à la porte principale." }
+    }
+  },
+  {
+    "id": "preset-npc-innkeeper",
+    "name": "Marta Hollowell",
+    "race": "HUMAN",
+    "clazz": "UNKNOWN",
+    "level": 1,
+    "size": "MEDIUM",
+    "alignment": "NEUTRAL",
+    "abilities": { "str": 12, "dex": 11, "con": 12, "int": 12, "wis": 13, "cha": 14 },
+    "armorClass": 10,
+    "maxHitPoints": 10,
+    "speeds": { "walk": 30 },
+    "languages": ["common"],
+    "translations": {
+      "en": { "shortDescription": "Innkeeper", "description": "A warm and practical woman who runs the Silver Flagon with an iron fist hidden in a velvet glove." },
+      "fr": { "shortDescription": "Aubergiste", "description": "Une femme chaleureuse et pragmatique qui tient le Flacon d'Argent d'une main de fer dans un gant de velours." }
+    }
+  },
+  {
+    "id": "preset-npc-merchant",
+    "name": "Oryn Fairweather",
+    "race": "HUMAN",
+    "clazz": "UNKNOWN",
+    "level": 1,
+    "size": "MEDIUM",
+    "alignment": "NEUTRAL",
+    "abilities": { "str": 10, "dex": 10, "con": 10, "int": 13, "wis": 12, "cha": 14 },
+    "armorClass": 10,
+    "maxHitPoints": 8,
+    "speeds": { "walk": 30 },
+    "languages": ["common", "elvish"],
+    "translations": {
+      "en": { "shortDescription": "Merchant", "description": "A well-traveled trader who deals in exotic goods and knows the value of a well-placed rumor." },
+      "fr": { "shortDescription": "Marchand", "description": "Un commerçant bien voyagé qui traite en marchandises exotiques et connaît la valeur d'une rumeur bien placée." }
+    }
+  }
+]

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
+    <!-- Character list -->
+    <string name="title_character_list">Personnages</string>
+    <string name="title_preset_gallery">Création rapide</string>
+    <string name="tab_player_characters">Personnages</string>
+    <string name="tab_non_player_characters">PNJ</string>
+    <string name="btn_new_character">Nouveau PJ</string>
+    <string name="btn_quick_create">Création rapide</string>
+    <string name="hint_search_character">Rechercher un personnage…</string>
+
     <!-- Character race -->
     <string name="race_human">Humain</string>
     <string name="race_elf">Elfe</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -7,7 +7,9 @@
     <string name="tab_player_characters">Personnages</string>
     <string name="tab_non_player_characters">PNJ</string>
     <string name="btn_new_character">Nouveau PJ</string>
+    <string name="btn_new_character_subtitle">Assistant pas-à-pas</string>
     <string name="btn_quick_create">Création rapide</string>
+    <string name="btn_quick_create_subtitle">Presets PJ &amp; PNJ</string>
     <string name="hint_search_character">Rechercher un personnage…</string>
 
     <!-- Character race -->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
+    <!-- Character stats -->
+    <string name="label_armor_class">CA %d</string>
+    <string name="label_hit_points">%d PV</string>
+
     <!-- Character list -->
     <string name="title_character_list">Personnages</string>
     <string name="title_preset_gallery">Création rapide</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -7,7 +7,9 @@
     <string name="tab_player_characters">Characters</string>
     <string name="tab_non_player_characters">NPCs</string>
     <string name="btn_new_character">New Character</string>
+    <string name="btn_new_character_subtitle">Step-by-step wizard</string>
     <string name="btn_quick_create">Quick Create</string>
+    <string name="btn_quick_create_subtitle">PC &amp; NPC presets</string>
     <string name="hint_search_character">Search characters…</string>
 
     <!-- Character race -->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
+    <!-- Character stats -->
+    <string name="label_armor_class">AC %d</string>
+    <string name="label_hit_points">%d HP</string>
+
     <!-- Character list -->
     <string name="title_character_list">Characters</string>
     <string name="title_preset_gallery">Quick Create</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
+    <!-- Character list -->
+    <string name="title_character_list">Characters</string>
+    <string name="title_preset_gallery">Quick Create</string>
+    <string name="tab_player_characters">Characters</string>
+    <string name="tab_non_player_characters">NPCs</string>
+    <string name="btn_new_character">New Character</string>
+    <string name="btn_quick_create">Quick Create</string>
+    <string name="hint_search_character">Search characters…</string>
+
     <!-- Character race -->
     <string name="race_human">Human</string>
     <string name="race_elf">Elf</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -18,6 +18,7 @@ import androidx.savedstate.serialization.SavedStateConfiguration
 import com.cyrillrx.rpg.campaign.data.SQLDelightCampaignRepository
 import com.cyrillrx.rpg.campaign.navigation.handleCampaignRoutes
 import com.cyrillrx.rpg.campaign.navigation.registerCampaignRoutes
+import com.cyrillrx.rpg.character.data.JsonCharacterPresetRepository
 import com.cyrillrx.rpg.character.data.RamCharacterRepository
 import com.cyrillrx.rpg.character.presentation.navigation.handleCharacterRoutes
 import com.cyrillrx.rpg.character.presentation.navigation.registerCharacterRoutes
@@ -47,22 +48,24 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
-private val navSavedStateConfig = SavedStateConfiguration {
-    serializersModule = SerializersModule {
-        polymorphic(NavKey::class) {
-            subclass(MainRoute.Home::class, MainRoute.Home.serializer())
+private val navSavedStateConfig =
+    SavedStateConfiguration {
+        serializersModule =
+            SerializersModule {
+                polymorphic(NavKey::class) {
+                    subclass(MainRoute.Home::class, MainRoute.Home.serializer())
 
-            registerCampaignRoutes()
-            registerCharacterRoutes()
+                    registerCampaignRoutes()
+                    registerCharacterRoutes()
 
-            registerSpellRoutes()
-            registerMagicalItemRoutes()
-            registerMonsterRoutes()
+                    registerSpellRoutes()
+                    registerMagicalItemRoutes()
+                    registerMonsterRoutes()
 
-            registerUserListRoutes()
-        }
+                    registerUserListRoutes()
+                }
+            }
     }
-}
 
 @Composable
 @Preview
@@ -75,9 +78,10 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
         NavDisplay(
             backStack = backStack,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
             onBack = backStack::navigateUp,
             transitionSpec = {
                 slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
@@ -87,31 +91,36 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 slideInHorizontally(initialOffsetX = { -it }) + fadeIn() togetherWith
                     slideOutHorizontally(targetOffsetX = { it }) + fadeOut()
             },
-            entryProvider = entryProvider {
-                val homeRouter = HomeRouterImpl(backStack)
-                entry<MainRoute.Home> { HomeScreen(homeRouter) }
+            entryProvider =
+                entryProvider {
+                    val homeRouter = HomeRouterImpl(backStack)
+                    entry<MainRoute.Home> { HomeScreen(homeRouter) }
 
-                handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
-                handleCharacterRoutes(backStack, RamCharacterRepository())
+                    handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
+                    handleCharacterRoutes(
+                        backStack = backStack,
+                        characterRepository = RamCharacterRepository(),
+                        presetRepository = JsonCharacterPresetRepository(fileReader),
+                    )
 
-                handleSpellRoutes(
-                    router = SpellRouterImpl(backStack),
-                    spellRepository = JsonSpellRepository(fileReader),
-                    userListRepository = userListRepository,
-                )
-                handleMagicalItemRoutes(
-                    router = MagicalItemRouterImpl(backStack),
-                    repository = JsonMagicalItemRepository(fileReader),
-                    userListRepository = userListRepository,
-                )
-                handleMonsterRoutes(
-                    router = MonsterRouterImpl(backStack),
-                    repository = JsonMonsterRepository(fileReader),
-                    userListRepository = userListRepository,
-                )
+                    handleSpellRoutes(
+                        router = SpellRouterImpl(backStack),
+                        spellRepository = JsonSpellRepository(fileReader),
+                        userListRepository = userListRepository,
+                    )
+                    handleMagicalItemRoutes(
+                        router = MagicalItemRouterImpl(backStack),
+                        repository = JsonMagicalItemRepository(fileReader),
+                        userListRepository = userListRepository,
+                    )
+                    handleMonsterRoutes(
+                        router = MonsterRouterImpl(backStack),
+                        repository = JsonMonsterRepository(fileReader),
+                        userListRepository = userListRepository,
+                    )
 
-                handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
-            },
+                    handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
+                },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -48,24 +48,22 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
-private val navSavedStateConfig =
-    SavedStateConfiguration {
-        serializersModule =
-            SerializersModule {
-                polymorphic(NavKey::class) {
-                    subclass(MainRoute.Home::class, MainRoute.Home.serializer())
+private val navSavedStateConfig = SavedStateConfiguration {
+    serializersModule = SerializersModule {
+        polymorphic(NavKey::class) {
+            subclass(MainRoute.Home::class, MainRoute.Home.serializer())
 
-                    registerCampaignRoutes()
-                    registerCharacterRoutes()
+            registerCampaignRoutes()
+            registerCharacterRoutes()
 
-                    registerSpellRoutes()
-                    registerMagicalItemRoutes()
-                    registerMonsterRoutes()
+            registerSpellRoutes()
+            registerMagicalItemRoutes()
+            registerMonsterRoutes()
 
-                    registerUserListRoutes()
-                }
-            }
+            registerUserListRoutes()
+        }
     }
+}
 
 @Composable
 @Preview
@@ -78,10 +76,9 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
         NavDisplay(
             backStack = backStack,
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
             onBack = backStack::navigateUp,
             transitionSpec = {
                 slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
@@ -91,36 +88,35 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 slideInHorizontally(initialOffsetX = { -it }) + fadeIn() togetherWith
                     slideOutHorizontally(targetOffsetX = { it }) + fadeOut()
             },
-            entryProvider =
-                entryProvider {
-                    val homeRouter = HomeRouterImpl(backStack)
-                    entry<MainRoute.Home> { HomeScreen(homeRouter) }
+            entryProvider = entryProvider {
+                val homeRouter = HomeRouterImpl(backStack)
+                entry<MainRoute.Home> { HomeScreen(homeRouter) }
 
-                    handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
-                    handleCharacterRoutes(
-                        backStack = backStack,
-                        characterRepository = RamCharacterRepository(),
-                        presetRepository = JsonCharacterPresetRepository(fileReader),
-                    )
+                handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
+                handleCharacterRoutes(
+                    backStack = backStack,
+                    characterRepository = RamCharacterRepository(),
+                    presetRepository = JsonCharacterPresetRepository(fileReader),
+                )
 
-                    handleSpellRoutes(
-                        router = SpellRouterImpl(backStack),
-                        spellRepository = JsonSpellRepository(fileReader),
-                        userListRepository = userListRepository,
-                    )
-                    handleMagicalItemRoutes(
-                        router = MagicalItemRouterImpl(backStack),
-                        repository = JsonMagicalItemRepository(fileReader),
-                        userListRepository = userListRepository,
-                    )
-                    handleMonsterRoutes(
-                        router = MonsterRouterImpl(backStack),
-                        repository = JsonMonsterRepository(fileReader),
-                        userListRepository = userListRepository,
-                    )
+                handleSpellRoutes(
+                    router = SpellRouterImpl(backStack),
+                    spellRepository = JsonSpellRepository(fileReader),
+                    userListRepository = userListRepository,
+                )
+                handleMagicalItemRoutes(
+                    router = MagicalItemRouterImpl(backStack),
+                    repository = JsonMagicalItemRepository(fileReader),
+                    userListRepository = userListRepository,
+                )
+                handleMonsterRoutes(
+                    router = MonsterRouterImpl(backStack),
+                    repository = JsonMonsterRepository(fileReader),
+                    userListRepository = userListRepository,
+                )
 
-                    handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
-                },
+                handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
+            },
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
@@ -85,7 +85,7 @@ fun CampaignListScreen(
             }
         },
     ) { paddingValues ->
-        Column(Modifier.padding(paddingValues)) {
+        Column(Modifier.padding(paddingValues).fillMaxSize()) {
             when (val body = state.body) {
                 is CampaignListState.Body.Loading -> Loader()
                 is CampaignListState.Body.Empty -> EmptySearch(state.searchQuery)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterPresetGalleryState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterPresetGalleryState.kt
@@ -10,8 +10,6 @@ data class CharacterPresetGalleryState(
     sealed interface Body {
         data object Loading : Body
 
-        data object Empty : Body
-
         data class Error(
             val errorMessage: StringResource,
         ) : Body

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterPresetGalleryState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterPresetGalleryState.kt
@@ -1,0 +1,24 @@
+package com.cyrillrx.rpg.character.presentation
+
+import com.cyrillrx.rpg.character.domain.Character
+import org.jetbrains.compose.resources.StringResource
+
+data class CharacterPresetGalleryState(
+    val selectedTabIndex: Int = 0,
+    val body: Body = Body.Loading,
+) {
+    sealed interface Body {
+        data object Loading : Body
+
+        data object Empty : Body
+
+        data class Error(
+            val errorMessage: StringResource,
+        ) : Body
+
+        data class WithData(
+            val pcPresets: List<Character>,
+            val npcPresets: List<Character>,
+        ) : Body
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterPresetGalleryState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterPresetGalleryState.kt
@@ -9,11 +9,7 @@ data class CharacterPresetGalleryState(
 ) {
     sealed interface Body {
         data object Loading : Body
-
-        data class Error(
-            val errorMessage: StringResource,
-        ) : Body
-
+        data class Error(val errorMessage: StringResource) : Body
         data class WithData(
             val pcPresets: List<Character>,
             val npcPresets: List<Character>,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
@@ -1,0 +1,151 @@
+package com.cyrillrx.rpg.character.presentation.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Favorite
+import androidx.compose.material.icons.outlined.Shield
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.cyrillrx.rpg.app.currentLocale
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
+import com.cyrillrx.rpg.core.presentation.theme.borderWidth
+import com.cyrillrx.rpg.core.presentation.theme.iconSizeSmall
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun CharacterListItem(
+    character: Character,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val locale = currentLocale()
+    val shortDescription = character.resolveTranslation(locale)?.shortDescription.orEmpty()
+
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(borderWidth, MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(spacingCommon),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(spacingSmall),
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = character.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                if (shortDescription.isNotBlank()) {
+                    Text(
+                        text = shortDescription,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(spacingSmall),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Shield,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(iconSizeSmall),
+                        )
+                        Text(
+                            text = "AC ${character.armorClass}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(spacingSmall),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Favorite,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(iconSizeSmall),
+                        )
+                        Text(
+                            text = "${character.maxHitPoints} HP",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.width(spacingCommon))
+
+            Text(
+                text = character.clazz.toFormattedString(),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterListItemLight() {
+    AppThemePreview(darkTheme = false) {
+        Column(verticalArrangement = Arrangement.spacedBy(spacingSmall)) {
+            SampleCharacterRepository.getAll().forEach {
+                CharacterListItem(character = it, onClick = {})
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterListItemDark() {
+    AppThemePreview(darkTheme = true) {
+        Column(verticalArrangement = Arrangement.spacedBy(spacingSmall)) {
+            SampleCharacterRepository.getAll().forEach {
+                CharacterListItem(character = it, onClick = {})
+            }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
@@ -31,7 +31,11 @@ import com.cyrillrx.rpg.core.presentation.theme.borderWidth
 import com.cyrillrx.rpg.core.presentation.theme.iconSizeSmall
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.label_armor_class
+import rpg_companion.composeapp.generated.resources.label_hit_points
 
 @Composable
 fun CharacterListItem(
@@ -91,7 +95,7 @@ fun CharacterListItem(
                             modifier = Modifier.size(iconSizeSmall),
                         )
                         Text(
-                            text = "AC ${character.armorClass}",
+                            text = stringResource(Res.string.label_armor_class, character.armorClass),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -108,7 +112,7 @@ fun CharacterListItem(
                             modifier = Modifier.size(iconSizeSmall),
                         )
                         Text(
-                            text = "${character.maxHitPoints} HP",
+                            text = stringResource(Res.string.label_hit_points, character.maxHitPoints),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
@@ -41,6 +41,8 @@ fun CharacterListItem(
 ) {
     val locale = currentLocale()
     val shortDescription = character.resolveTranslation(locale)?.shortDescription.orEmpty()
+    val primaryText = shortDescription.ifBlank { character.name }
+    val secondaryText = if (shortDescription.isNotBlank()) character.name else ""
 
     Card(
         onClick = onClick,
@@ -58,7 +60,7 @@ fun CharacterListItem(
                 modifier = Modifier.weight(1f),
             ) {
                 Text(
-                    text = character.name,
+                    text = primaryText,
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
@@ -66,7 +68,7 @@ fun CharacterListItem(
 
                 if (shortDescription.isNotBlank()) {
                     Text(
-                        text = shortDescription,
+                        text = secondaryText,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -1,6 +1,9 @@
 package com.cyrillrx.rpg.character.presentation.component
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,12 +11,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
 import com.cyrillrx.rpg.character.domain.Character
@@ -25,6 +36,8 @@ import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
+import com.cyrillrx.rpg.core.presentation.theme.borderWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -32,7 +45,9 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_new_character
+import rpg_companion.composeapp.generated.resources.btn_new_character_subtitle
 import rpg_companion.composeapp.generated.resources.btn_quick_create
+import rpg_companion.composeapp.generated.resources.btn_quick_create_subtitle
 import rpg_companion.composeapp.generated.resources.title_character_list
 
 @Composable
@@ -66,39 +81,91 @@ fun CharacterListScreen(
                 onNavigateUpClicked = onNavigateUpClicked,
             )
         },
-        bottomBar = {
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+        ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(spacingCommon),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(spacingCommon),
             ) {
-                Button(
+                CharacterActionCard(
+                    icon = Icons.Filled.Add,
+                    title = stringResource(Res.string.btn_new_character),
+                    subtitle = stringResource(Res.string.btn_new_character_subtitle),
                     onClick = onNewCharacterClicked,
+                    filled = true,
                     modifier = Modifier.weight(1f),
-                ) {
-                    Text(stringResource(Res.string.btn_new_character))
-                }
-                Button(
+                )
+                CharacterActionCard(
+                    icon = Icons.Filled.Bolt,
+                    title = stringResource(Res.string.btn_quick_create),
+                    subtitle = stringResource(Res.string.btn_quick_create_subtitle),
                     onClick = onQuickCreateClicked,
+                    filled = false,
                     modifier = Modifier.weight(1f),
-                ) {
-                    Text(stringResource(Res.string.btn_quick_create))
+                )
+            }
+
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                when (val body = state.body) {
+                    is CharacterListState.Body.Loading -> Loader()
+                    is CharacterListState.Body.Empty -> EmptySearch(searchQuery = state.searchQuery)
+                    is CharacterListState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
+                    is CharacterListState.Body.WithData ->
+                        CharacterList(
+                            characters = body.searchResults,
+                            onCharacterClicked = onCharacterClicked,
+                        )
                 }
             }
-        },
-    ) { paddingValues ->
-        when (val body = state.body) {
-            is CharacterListState.Body.Loading -> Loader()
-            is CharacterListState.Body.Empty -> EmptySearch(searchQuery = state.searchQuery)
-            is CharacterListState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
-            is CharacterListState.Body.WithData ->
-                CharacterList(
-                    characters = body.searchResults,
-                    onCharacterClicked = onCharacterClicked,
-                    modifier = Modifier.padding(paddingValues),
-                )
+        }
+    }
+}
+
+@Composable
+private fun CharacterActionCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    filled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val containerColor = if (filled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface
+    val contentColor = if (filled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.medium,
+        border = if (filled) null else BorderStroke(borderWidth, MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha)),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        modifier = modifier,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(spacingSmall),
+            modifier = Modifier.padding(spacingCommon),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = contentColor,
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = contentColor,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = contentColor,
+            )
         }
     }
 }
@@ -139,11 +206,10 @@ private fun PreviewCharacterListScreenDark() {
 @Composable
 private fun CharacterListScreenPreview() {
     CharacterListScreen(
-        state =
-            CharacterListState(
-                searchQuery = "",
-                body = CharacterListState.Body.WithData(SampleCharacterRepository.getAll()),
-            ),
+        state = CharacterListState(
+            searchQuery = "",
+            body = CharacterListState.Body.WithData(SampleCharacterRepository.getAll()),
+        ),
         onNavigateUpClicked = {},
         onCharacterClicked = {},
         onNewCharacterClicked = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -1,23 +1,152 @@
 package com.cyrillrx.rpg.character.presentation.component
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.presentation.CharacterListState
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
 import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterListViewModel
+import com.cyrillrx.rpg.core.presentation.component.EmptySearch
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_new_character
+import rpg_companion.composeapp.generated.resources.btn_quick_create
+import rpg_companion.composeapp.generated.resources.title_character_list
 
 @Composable
-fun CharacterListScreen(viewModel: CharacterListViewModel, router: CharacterRouter) {
-    Scaffold { paddingValues ->
-        Text(
-            text = "Character List Screen",
-            Modifier.clickable(onClick = router::navigateUp)
-                .padding(paddingValues)
-                .fillMaxSize(),
-        )
+fun CharacterListScreen(
+    viewModel: CharacterListViewModel,
+    router: CharacterRouter,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    CharacterListScreen(
+        state = state,
+        onNavigateUpClicked = router::navigateUp,
+        onCharacterClicked = viewModel::onCharacterClicked,
+        onNewCharacterClicked = viewModel::onCreateCharacterClicked,
+        onQuickCreateClicked = viewModel::onQuickCreateClicked,
+    )
+}
+
+@Composable
+fun CharacterListScreen(
+    state: CharacterListState,
+    onNavigateUpClicked: () -> Unit,
+    onCharacterClicked: (Character) -> Unit,
+    onNewCharacterClicked: () -> Unit,
+    onQuickCreateClicked: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            SimpleTopBar(
+                titleResource = Res.string.title_character_list,
+                onNavigateUpClicked = onNavigateUpClicked,
+            )
+        },
+        bottomBar = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(spacingCommon),
+            ) {
+                Button(
+                    onClick = onNewCharacterClicked,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(Res.string.btn_new_character))
+                }
+                Button(
+                    onClick = onQuickCreateClicked,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(Res.string.btn_quick_create))
+                }
+            }
+        },
+    ) { paddingValues ->
+        when (val body = state.body) {
+            is CharacterListState.Body.Loading -> Loader()
+            is CharacterListState.Body.Empty -> EmptySearch(searchQuery = state.searchQuery)
+            is CharacterListState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
+            is CharacterListState.Body.WithData ->
+                CharacterList(
+                    characters = body.searchResults,
+                    onCharacterClicked = onCharacterClicked,
+                    modifier = Modifier.padding(paddingValues),
+                )
+        }
     }
+}
+
+@Composable
+private fun CharacterList(
+    characters: List<Character>,
+    onCharacterClicked: (Character) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(spacingMedium),
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+    ) {
+        items(characters, key = { it.id }) { character ->
+            CharacterListItem(
+                character = character,
+                onClick = { onCharacterClicked(character) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterListScreenLight() {
+    AppThemePreview(darkTheme = false) { CharacterListScreenPreview() }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterListScreenDark() {
+    AppThemePreview(darkTheme = true) { CharacterListScreenPreview() }
+}
+
+@Composable
+private fun CharacterListScreenPreview() {
+    CharacterListScreen(
+        state =
+            CharacterListState(
+                searchQuery = "",
+                body = CharacterListState.Body.WithData(SampleCharacterRepository.getAll()),
+            ),
+        onNavigateUpClicked = {},
+        onCharacterClicked = {},
+        onNewCharacterClicked = {},
+        onQuickCreateClicked = {},
+    )
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -2,7 +2,6 @@ package com.cyrillrx.rpg.character.presentation.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -83,15 +82,17 @@ fun CharacterListScreen(
         },
     ) { paddingValues ->
         Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize(),
+            modifier =
+                Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize(),
         ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(spacingCommon),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(spacingCommon),
             ) {
                 CharacterActionCard(
                     icon = Icons.Filled.Add,
@@ -111,7 +112,7 @@ fun CharacterListScreen(
                 )
             }
 
-            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            Column(modifier = Modifier.weight(1f).fillMaxWidth()) {
                 when (val body = state.body) {
                     is CharacterListState.Body.Loading -> Loader()
                     is CharacterListState.Body.Empty -> EmptySearch(searchQuery = state.searchQuery)
@@ -206,10 +207,11 @@ private fun PreviewCharacterListScreenDark() {
 @Composable
 private fun CharacterListScreenPreview() {
     CharacterListScreen(
-        state = CharacterListState(
-            searchQuery = "",
-            body = CharacterListState.Body.WithData(SampleCharacterRepository.getAll()),
-        ),
+        state =
+            CharacterListState(
+                searchQuery = "",
+                body = CharacterListState.Body.WithData(SampleCharacterRepository.getAll()),
+            ),
         onNavigateUpClicked = {},
         onCharacterClicked = {},
         onNewCharacterClicked = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
@@ -86,8 +86,7 @@ fun CharacterPresetGalleryScreen(
         when (val body = state.body) {
             is CharacterPresetGalleryState.Body.Loading -> Loader()
             is CharacterPresetGalleryState.Body.Empty -> EmptySearch(searchQuery = "")
-            is CharacterPresetGalleryState.Body.Error ->
-                ErrorLayout(errorMessage = body.errorMessage)
+            is CharacterPresetGalleryState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
             is CharacterPresetGalleryState.Body.WithData -> {
                 val presets = if (state.selectedTabIndex == 0) body.pcPresets else body.npcPresets
                 PresetList(
@@ -137,15 +136,13 @@ private fun PreviewCharacterPresetGalleryScreenDark() {
 private fun CharacterPresetGalleryScreenPreview() {
     val characters = SampleCharacterRepository.getAll()
     CharacterPresetGalleryScreen(
-        state =
-            CharacterPresetGalleryState(
-                selectedTabIndex = 0,
-                body =
-                    CharacterPresetGalleryState.Body.WithData(
-                        pcPresets = characters,
-                        npcPresets = emptyList(),
-                    ),
+        state = CharacterPresetGalleryState(
+            selectedTabIndex = 0,
+            body = CharacterPresetGalleryState.Body.WithData(
+                pcPresets = characters,
+                npcPresets = emptyList(),
             ),
+        ),
         onNavigateUpClicked = {},
         onTabSelected = {},
         onPresetSelected = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
@@ -22,7 +22,6 @@ import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.presentation.CharacterPresetGalleryState
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
 import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterPresetGalleryViewModel
-import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
@@ -61,12 +60,18 @@ fun CharacterPresetGalleryScreen(
 ) {
     Scaffold(
         topBar = {
-            Column {
-                SimpleTopBar(
-                    titleResource = Res.string.title_preset_gallery,
-                    onNavigateUpClicked = onNavigateUpClicked,
-                )
-                if (state.body is CharacterPresetGalleryState.Body.WithData) {
+            SimpleTopBar(
+                titleResource = Res.string.title_preset_gallery,
+                onNavigateUpClicked = onNavigateUpClicked,
+            )
+        },
+    ) { paddingValues ->
+        when (val body = state.body) {
+            is CharacterPresetGalleryState.Body.Loading -> Loader()
+            is CharacterPresetGalleryState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
+            is CharacterPresetGalleryState.Body.WithData -> {
+                val presets = if (state.selectedTabIndex == 0) body.pcPresets else body.npcPresets
+                Column(modifier = Modifier.padding(paddingValues).fillMaxSize()) {
                     PrimaryTabRow(selectedTabIndex = state.selectedTabIndex) {
                         Tab(
                             selected = state.selectedTabIndex == 0,
@@ -79,21 +84,11 @@ fun CharacterPresetGalleryScreen(
                             text = { Text(stringResource(Res.string.tab_non_player_characters)) },
                         )
                     }
+                    PresetList(
+                        presets = presets,
+                        onPresetSelected = onPresetSelected,
+                    )
                 }
-            }
-        },
-    ) { paddingValues ->
-        when (val body = state.body) {
-            is CharacterPresetGalleryState.Body.Loading -> Loader()
-            is CharacterPresetGalleryState.Body.Empty -> EmptySearch(searchQuery = "")
-            is CharacterPresetGalleryState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
-            is CharacterPresetGalleryState.Body.WithData -> {
-                val presets = if (state.selectedTabIndex == 0) body.pcPresets else body.npcPresets
-                PresetList(
-                    presets = presets,
-                    onPresetSelected = onPresetSelected,
-                    modifier = Modifier.padding(paddingValues),
-                )
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
@@ -66,12 +66,12 @@ fun CharacterPresetGalleryScreen(
             )
         },
     ) { paddingValues ->
-        when (val body = state.body) {
-            is CharacterPresetGalleryState.Body.Loading -> Loader()
-            is CharacterPresetGalleryState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
-            is CharacterPresetGalleryState.Body.WithData -> {
-                val presets = if (state.selectedTabIndex == 0) body.pcPresets else body.npcPresets
-                Column(modifier = Modifier.padding(paddingValues).fillMaxSize()) {
+        Column(modifier = Modifier.padding(paddingValues).fillMaxSize()) {
+            when (val body = state.body) {
+                is CharacterPresetGalleryState.Body.Loading -> Loader()
+                is CharacterPresetGalleryState.Body.Error -> ErrorLayout(errorMessage = body.errorMessage)
+                is CharacterPresetGalleryState.Body.WithData -> {
+                    val presets = if (state.selectedTabIndex == 0) body.pcPresets else body.npcPresets
                     PrimaryTabRow(selectedTabIndex = state.selectedTabIndex) {
                         Tab(
                             selected = state.selectedTabIndex == 0,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterPresetGalleryScreen.kt
@@ -1,0 +1,153 @@
+package com.cyrillrx.rpg.character.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.presentation.CharacterPresetGalleryState
+import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterPresetGalleryViewModel
+import com.cyrillrx.rpg.core.presentation.component.EmptySearch
+import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.Loader
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.tab_non_player_characters
+import rpg_companion.composeapp.generated.resources.tab_player_characters
+import rpg_companion.composeapp.generated.resources.title_preset_gallery
+
+@Composable
+fun CharacterPresetGalleryScreen(
+    viewModel: CharacterPresetGalleryViewModel,
+    router: CharacterRouter,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    CharacterPresetGalleryScreen(
+        state = state,
+        onNavigateUpClicked = router::navigateUp,
+        onTabSelected = viewModel::onTabSelected,
+        onPresetSelected = viewModel::onPresetSelected,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CharacterPresetGalleryScreen(
+    state: CharacterPresetGalleryState,
+    onNavigateUpClicked: () -> Unit,
+    onTabSelected: (Int) -> Unit,
+    onPresetSelected: (Character) -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            Column {
+                SimpleTopBar(
+                    titleResource = Res.string.title_preset_gallery,
+                    onNavigateUpClicked = onNavigateUpClicked,
+                )
+                if (state.body is CharacterPresetGalleryState.Body.WithData) {
+                    PrimaryTabRow(selectedTabIndex = state.selectedTabIndex) {
+                        Tab(
+                            selected = state.selectedTabIndex == 0,
+                            onClick = { onTabSelected(0) },
+                            text = { Text(stringResource(Res.string.tab_player_characters)) },
+                        )
+                        Tab(
+                            selected = state.selectedTabIndex == 1,
+                            onClick = { onTabSelected(1) },
+                            text = { Text(stringResource(Res.string.tab_non_player_characters)) },
+                        )
+                    }
+                }
+            }
+        },
+    ) { paddingValues ->
+        when (val body = state.body) {
+            is CharacterPresetGalleryState.Body.Loading -> Loader()
+            is CharacterPresetGalleryState.Body.Empty -> EmptySearch(searchQuery = "")
+            is CharacterPresetGalleryState.Body.Error ->
+                ErrorLayout(errorMessage = body.errorMessage)
+            is CharacterPresetGalleryState.Body.WithData -> {
+                val presets = if (state.selectedTabIndex == 0) body.pcPresets else body.npcPresets
+                PresetList(
+                    presets = presets,
+                    onPresetSelected = onPresetSelected,
+                    modifier = Modifier.padding(paddingValues),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PresetList(
+    presets: List<Character>,
+    onPresetSelected: (Character) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(spacingMedium),
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+    ) {
+        items(presets, key = { it.id }) { preset ->
+            CharacterListItem(
+                character = preset,
+                onClick = { onPresetSelected(preset) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterPresetGalleryScreenLight() {
+    AppThemePreview(darkTheme = false) { CharacterPresetGalleryScreenPreview() }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterPresetGalleryScreenDark() {
+    AppThemePreview(darkTheme = true) { CharacterPresetGalleryScreenPreview() }
+}
+
+@Composable
+private fun CharacterPresetGalleryScreenPreview() {
+    val characters = SampleCharacterRepository.getAll()
+    CharacterPresetGalleryScreen(
+        state =
+            CharacterPresetGalleryState(
+                selectedTabIndex = 0,
+                body =
+                    CharacterPresetGalleryState.Body.WithData(
+                        pcPresets = characters,
+                        npcPresets = emptyList(),
+                    ),
+            ),
+        onNavigateUpClicked = {},
+        onTabSelected = {},
+        onPresetSelected = {},
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRoute.kt
@@ -6,11 +6,14 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.rpg.character.domain.CharacterRepository
-import com.cyrillrx.rpg.character.presentation.component.CreateCharacterScreen
 import com.cyrillrx.rpg.character.presentation.component.CharacterDetailScreen
 import com.cyrillrx.rpg.character.presentation.component.CharacterListScreen
+import com.cyrillrx.rpg.character.presentation.component.CharacterPresetGalleryScreen
+import com.cyrillrx.rpg.character.presentation.component.CreateCharacterScreen
 import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterListViewModel
 import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterListViewModelFactory
+import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterPresetGalleryViewModel
+import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterPresetGalleryViewModelFactory
 import com.cyrillrx.rpg.core.navigation.navigateUp
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
@@ -20,25 +23,32 @@ interface CharacterRoute {
     data object List : NavKey
 
     @Serializable
-    data class Detail(val serializedCharacter: String) : NavKey
+    data class Detail(
+        val serializedCharacter: String,
+    ) : NavKey
 
     @Serializable
     data object Create : NavKey
+
+    @Serializable
+    data object PresetGallery : NavKey
 }
 
 fun PolymorphicModuleBuilder<NavKey>.registerCharacterRoutes() {
     subclass(CharacterRoute.List::class, CharacterRoute.List.serializer())
     subclass(CharacterRoute.Detail::class, CharacterRoute.Detail.serializer())
     subclass(CharacterRoute.Create::class, CharacterRoute.Create.serializer())
+    subclass(CharacterRoute.PresetGallery::class, CharacterRoute.PresetGallery.serializer())
 }
 
 fun EntryProviderScope<NavKey>.handleCharacterRoutes(
     backStack: NavBackStack<NavKey>,
-    repository: CharacterRepository,
+    characterRepository: CharacterRepository,
+    presetRepository: CharacterRepository,
 ) {
     entry<CharacterRoute.List> {
         val router = CharacterRouterImpl(backStack)
-        val viewModelFactory = CharacterListViewModelFactory(router, repository)
+        val viewModelFactory = CharacterListViewModelFactory(router, characterRepository)
         val viewModel = viewModel<CharacterListViewModel>(factory = viewModelFactory)
         CharacterListScreen(viewModel, router)
     }
@@ -54,5 +64,12 @@ fun EntryProviderScope<NavKey>.handleCharacterRoutes(
         CreateCharacterScreen(
             onNavigateUpClicked = backStack::navigateUp,
         )
+    }
+
+    entry<CharacterRoute.PresetGallery> {
+        val router = CharacterRouterImpl(backStack)
+        val viewModelFactory = CharacterPresetGalleryViewModelFactory(router, presetRepository, characterRepository)
+        val viewModel = viewModel<CharacterPresetGalleryViewModel>(factory = viewModelFactory)
+        CharacterPresetGalleryScreen(viewModel, router)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRoute.kt
@@ -23,9 +23,7 @@ interface CharacterRoute {
     data object List : NavKey
 
     @Serializable
-    data class Detail(
-        val serializedCharacter: String,
-    ) : NavKey
+    data class Detail(val serializedCharacter: String) : NavKey
 
     @Serializable
     data object Create : NavKey

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRouter.kt
@@ -8,17 +8,12 @@ import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface CharacterRouter {
     fun navigateUp()
-
     fun openCharacterDetail(character: Character)
-
     fun openCreateCharacter()
-
     fun openPresetGallery()
 }
 
-class CharacterRouterImpl(
-    private val backStack: NavBackStack<NavKey>,
-) : CharacterRouter {
+class CharacterRouterImpl(private val backStack: NavBackStack<NavKey>) : CharacterRouter {
     override fun navigateUp() {
         backStack.navigateUp()
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRouter.kt
@@ -8,11 +8,17 @@ import com.cyrillrx.rpg.core.navigation.navigateUp
 
 interface CharacterRouter {
     fun navigateUp()
+
     fun openCharacterDetail(character: Character)
+
     fun openCreateCharacter()
+
+    fun openPresetGallery()
 }
 
-class CharacterRouterImpl(private val backStack: NavBackStack<NavKey>) : CharacterRouter {
+class CharacterRouterImpl(
+    private val backStack: NavBackStack<NavKey>,
+) : CharacterRouter {
     override fun navigateUp() {
         backStack.navigateUp()
     }
@@ -23,5 +29,9 @@ class CharacterRouterImpl(private val backStack: NavBackStack<NavKey>) : Charact
 
     override fun openCharacterDetail(character: Character) {
         backStack.add(CharacterRoute.Detail(character.serialize()))
+    }
+
+    override fun openPresetGallery() {
+        backStack.add(CharacterRoute.PresetGallery)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -2,10 +2,10 @@ package com.cyrillrx.rpg.character.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cyrillrx.rpg.character.presentation.CharacterListState
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.CharacterFilter
 import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.character.presentation.CharacterListState
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +20,6 @@ class CharacterListViewModel(
     private val router: CharacterRouter,
     private val repository: CharacterRepository,
 ) : ViewModel() {
-
     private var updateJob: Job? = null
     val state: StateFlow<CharacterListState>
         field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Empty))
@@ -40,6 +39,10 @@ class CharacterListViewModel(
 
     fun onCreateCharacterClicked() {
         router.openCreateCharacter()
+    }
+
+    fun onQuickCreateClicked() {
+        router.openPresetGallery()
     }
 
     private suspend fun updateData(query: String) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
@@ -1,0 +1,68 @@
+package com.cyrillrx.rpg.character.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.character.presentation.CharacterPresetGalleryState
+import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.error_while_loading_characters
+import kotlin.coroutines.cancellation.CancellationException
+
+class CharacterPresetGalleryViewModel(
+    private val router: CharacterRouter,
+    private val presetRepository: CharacterRepository,
+    private val characterRepository: CharacterRepository,
+) : ViewModel() {
+    val state: StateFlow<CharacterPresetGalleryState>
+        field = MutableStateFlow(CharacterPresetGalleryState())
+
+    init {
+        loadPresets()
+    }
+
+    fun onTabSelected(tabIndex: Int) {
+        state.update { it.copy(selectedTabIndex = tabIndex) }
+    }
+
+    fun onPresetSelected(preset: Character) {
+        viewModelScope.launch {
+            characterRepository.save(preset)
+            router.navigateUp()
+        }
+    }
+
+    private fun loadPresets() {
+        viewModelScope.launch {
+            try {
+                val presets = presetRepository.getAll(null)
+                if (presets.isEmpty()) {
+                    state.update { it.copy(body = CharacterPresetGalleryState.Body.Empty) }
+                } else {
+                    val pcPresets = presets.filter { it.clazz != Character.Class.UNKNOWN }
+                    val npcPresets = presets.filter { it.clazz == Character.Class.UNKNOWN }
+                    state.update {
+                        it.copy(
+                            body =
+                                CharacterPresetGalleryState.Body.WithData(
+                                    pcPresets = pcPresets,
+                                    npcPresets = npcPresets,
+                                ),
+                        )
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                state.update {
+                    it.copy(body = CharacterPresetGalleryState.Body.Error(Res.string.error_while_loading_characters))
+                }
+            }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
@@ -6,15 +6,15 @@ import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.presentation.CharacterPresetGalleryState
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
-import kotlin.coroutines.cancellation.CancellationException
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_characters
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class CharacterPresetGalleryViewModel(
     private val router: CharacterRouter,
@@ -51,11 +51,10 @@ class CharacterPresetGalleryViewModel(
                     val npcPresets = presets.filter { it.clazz == Character.Class.UNKNOWN }
                     state.update {
                         it.copy(
-                            body =
-                                CharacterPresetGalleryState.Body.WithData(
-                                    pcPresets = pcPresets,
-                                    npcPresets = npcPresets,
-                                ),
+                            body = CharacterPresetGalleryState.Body.WithData(
+                                pcPresets = pcPresets,
+                                npcPresets = npcPresets,
+                            ),
                         )
                     }
                 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
@@ -6,13 +6,15 @@ import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.presentation.CharacterPresetGalleryState
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_characters
-import kotlin.coroutines.cancellation.CancellationException
 
 class CharacterPresetGalleryViewModel(
     private val router: CharacterRouter,
@@ -30,9 +32,10 @@ class CharacterPresetGalleryViewModel(
         state.update { it.copy(selectedTabIndex = tabIndex) }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     fun onPresetSelected(preset: Character) {
         viewModelScope.launch {
-            characterRepository.save(preset)
+            characterRepository.save(preset.copy(id = Uuid.random().toString()))
             router.navigateUp()
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
@@ -44,19 +44,15 @@ class CharacterPresetGalleryViewModel(
         viewModelScope.launch {
             try {
                 val presets = presetRepository.getAll(null)
-                if (presets.isEmpty()) {
-                    state.update { it.copy(body = CharacterPresetGalleryState.Body.Empty) }
-                } else {
-                    val pcPresets = presets.filter { it.clazz != Character.Class.UNKNOWN }
-                    val npcPresets = presets.filter { it.clazz == Character.Class.UNKNOWN }
-                    state.update {
-                        it.copy(
-                            body = CharacterPresetGalleryState.Body.WithData(
-                                pcPresets = pcPresets,
-                                npcPresets = npcPresets,
-                            ),
-                        )
-                    }
+                val pcPresets = presets.filter { it.clazz != Character.Class.UNKNOWN }
+                val npcPresets = presets.filter { it.clazz == Character.Class.UNKNOWN }
+                state.update {
+                    it.copy(
+                        body = CharacterPresetGalleryState.Body.WithData(
+                            pcPresets = pcPresets,
+                            npcPresets = npcPresets,
+                        ),
+                    )
                 }
             } catch (e: CancellationException) {
                 throw e

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModelFactory.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModelFactory.kt
@@ -1,0 +1,19 @@
+package com.cyrillrx.rpg.character.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import kotlin.reflect.KClass
+
+class CharacterPresetGalleryViewModelFactory(
+    private val router: CharacterRouter,
+    private val presetRepository: CharacterRepository,
+    private val characterRepository: CharacterRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(
+        modelClass: KClass<T>,
+        extras: CreationExtras,
+    ): T = CharacterPresetGalleryViewModel(router, presetRepository, characterRepository) as T
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
@@ -70,7 +70,7 @@ fun MagicalItemCardCarouselScreen(
             )
         },
     ) { paddingValues ->
-        Column(Modifier.padding(paddingValues)) {
+        Column(Modifier.padding(paddingValues).fillMaxSize()) {
             when (val body = state.body) {
                 is MagicalItemListState.Body.Loading -> Loader()
                 is MagicalItemListState.Body.Empty -> EmptySearch(state.filter.query)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -74,7 +74,7 @@ fun SpellCardCarouselScreen(
             )
         },
     ) { paddingValues ->
-        Column(Modifier.padding(paddingValues)) {
+        Column(Modifier.padding(paddingValues).fillMaxSize()) {
             when (val body = state.body) {
                 is SpellListState.Body.Loading -> Loader()
                 is SpellListState.Body.Empty -> EmptySearch(state.filter.query)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Locale.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/domain/Locale.kt
@@ -1,0 +1,3 @@
+package com.cyrillrx.core.domain
+
+const val FALLBACK_LOCALE = "en"

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
@@ -29,6 +29,10 @@ sealed class CharacterImportError : Error {
         val id: String,
     ) : CharacterImportError()
 
+    data class MissingSkills(
+        val id: String,
+    ) : CharacterImportError()
+
     data class MissingTranslations(
         val id: String,
     ) : CharacterImportError()

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
@@ -2,16 +2,66 @@ package com.cyrillrx.rpg.character.data
 
 import com.cyrillrx.core.domain.Error
 
-sealed class CharacterImportError : Error {
-    data object MissingId : CharacterImportError()
-    data class MissingName(val id: String) : CharacterImportError()
-    data class MissingSize(val id: String) : CharacterImportError()
-    data class MissingAlignment(val id: String) : CharacterImportError()
-    data class MissingLevel(val id: String) : CharacterImportError()
-    data class MissingArmorClass(val id: String) : CharacterImportError()
-    data class MissingMaxHitPoints(val id: String) : CharacterImportError()
-    data class MissingSkills(val id: String) : CharacterImportError()
-    data class MissingTranslations(val id: String) : CharacterImportError()
-    data class UnknownSize(val id: String, val value: String) : CharacterImportError()
-    data class UnknownAlignment(val id: String, val value: String) : CharacterImportError()
+sealed interface CharacterImportError : Error {
+    data object MissingId : CharacterImportError
+
+    data class MissingName(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingRace(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingClass(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingSize(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingAlignment(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingLevel(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingArmorClass(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingMaxHitPoints(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingSkills(
+        val id: String,
+    ) : CharacterImportError
+
+    data class MissingTranslations(
+        val id: String,
+    ) : CharacterImportError
+
+    data class UnknownRace(
+        val id: String,
+        val value: String,
+    ) : CharacterImportError
+
+    data class UnknownClass(
+        val id: String,
+        val value: String,
+    ) : CharacterImportError
+
+    data class UnknownSize(
+        val id: String,
+        val value: String,
+    ) : CharacterImportError
+
+    data class UnknownAlignment(
+        val id: String,
+        val value: String,
+    ) : CharacterImportError
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
@@ -9,6 +9,30 @@ sealed class CharacterImportError : Error {
         val id: String,
     ) : CharacterImportError()
 
+    data class MissingSize(
+        val id: String,
+    ) : CharacterImportError()
+
+    data class MissingAlignment(
+        val id: String,
+    ) : CharacterImportError()
+
+    data class MissingLevel(
+        val id: String,
+    ) : CharacterImportError()
+
+    data class MissingArmorClass(
+        val id: String,
+    ) : CharacterImportError()
+
+    data class MissingMaxHitPoints(
+        val id: String,
+    ) : CharacterImportError()
+
+    data class MissingTranslations(
+        val id: String,
+    ) : CharacterImportError()
+
     data class UnknownSize(
         val id: String,
         val value: String,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
@@ -1,0 +1,21 @@
+package com.cyrillrx.rpg.character.data
+
+import com.cyrillrx.core.domain.Error
+
+sealed class CharacterImportError : Error {
+    data object MissingId : CharacterImportError()
+
+    data class MissingName(
+        val id: String,
+    ) : CharacterImportError()
+
+    data class UnknownSize(
+        val id: String,
+        val value: String,
+    ) : CharacterImportError()
+
+    data class UnknownAlignment(
+        val id: String,
+        val value: String,
+    ) : CharacterImportError()
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/CharacterImportError.kt
@@ -4,46 +4,14 @@ import com.cyrillrx.core.domain.Error
 
 sealed class CharacterImportError : Error {
     data object MissingId : CharacterImportError()
-
-    data class MissingName(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class MissingSize(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class MissingAlignment(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class MissingLevel(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class MissingArmorClass(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class MissingMaxHitPoints(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class MissingSkills(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class MissingTranslations(
-        val id: String,
-    ) : CharacterImportError()
-
-    data class UnknownSize(
-        val id: String,
-        val value: String,
-    ) : CharacterImportError()
-
-    data class UnknownAlignment(
-        val id: String,
-        val value: String,
-    ) : CharacterImportError()
+    data class MissingName(val id: String) : CharacterImportError()
+    data class MissingSize(val id: String) : CharacterImportError()
+    data class MissingAlignment(val id: String) : CharacterImportError()
+    data class MissingLevel(val id: String) : CharacterImportError()
+    data class MissingArmorClass(val id: String) : CharacterImportError()
+    data class MissingMaxHitPoints(val id: String) : CharacterImportError()
+    data class MissingSkills(val id: String) : CharacterImportError()
+    data class MissingTranslations(val id: String) : CharacterImportError()
+    data class UnknownSize(val id: String, val value: String) : CharacterImportError()
+    data class UnknownAlignment(val id: String, val value: String) : CharacterImportError()
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -1,0 +1,120 @@
+package com.cyrillrx.rpg.character.data
+
+import com.cyrillrx.core.data.FileReader
+import com.cyrillrx.core.data.deserialize
+import com.cyrillrx.core.domain.Result
+import com.cyrillrx.core.domain.partitionBy
+import com.cyrillrx.rpg.character.data.api.ApiCharacter
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.domain.CharacterFilter
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.character.domain.Race
+import com.cyrillrx.rpg.character.domain.applyFilter
+import com.cyrillrx.rpg.creature.domain.Abilities
+import com.cyrillrx.rpg.creature.domain.Ability
+import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.Skills
+import com.cyrillrx.rpg.creature.domain.Speeds
+
+class JsonCharacterPresetRepository(
+    private val fileReader: FileReader,
+) : CharacterRepository {
+    private var cache: List<Character>? = null
+
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> {
+        val all = cache ?: loadFromFile().parse().also { cache = it }
+        return all.applyFilter(filter)
+    }
+
+    override suspend fun get(id: String): Character? = getAll(null).firstOrNull { it.id == id }
+
+    override suspend fun save(character: Character) = Unit
+
+    override suspend fun delete(id: String) = Unit
+
+    private suspend fun loadFromFile(): List<ApiCharacter> {
+        val result = fileReader.readFile("files/character_presets.json")
+        if (result is Result.Success) {
+            return result.value.deserialize() ?: listOf()
+        }
+        return listOf()
+    }
+
+    companion object {
+        private fun List<ApiCharacter>.parse(): List<Character> {
+            val (characters, errors) = partitionBy { it.toCharacter() }
+            errors.forEach { println("WARNING: character preset import error: $it") }
+            return characters
+        }
+
+        private fun ApiCharacter.toCharacter(): Result<Character, CharacterImportError> {
+            val id = id ?: return Result.Failure(CharacterImportError.MissingId)
+            val name = name ?: return Result.Failure(CharacterImportError.MissingName(id))
+            val resolvedSize =
+                size?.let { s ->
+                    s.toSize() ?: return Result.Failure(CharacterImportError.UnknownSize(id, s))
+                } ?: Creature.Size.MEDIUM
+            val resolvedAlignment =
+                alignment?.let { a ->
+                    a.toAlignment() ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, a))
+                } ?: Creature.Alignment.NEUTRAL
+
+            val characterTranslations =
+                translations
+                    ?.mapValues { (_, t) ->
+                        Character.Translation(
+                            shortDescription = t.shortDescription.orEmpty(),
+                            description = t.description.orEmpty(),
+                        )
+                    }
+                    ?: emptyMap()
+
+            return Result.Success(
+                Character(
+                    id = id,
+                    name = name,
+                    translations = characterTranslations,
+                    description = characterTranslations["en"]?.description.orEmpty(),
+                    background = background,
+                    race = race?.toRace() ?: Race.HUMAN,
+                    clazz = clazz?.toClass() ?: Character.Class.UNKNOWN,
+                    level = level ?: 1,
+                    size = resolvedSize,
+                    alignment = resolvedAlignment,
+                    abilities = abilities.toDomain(),
+                    armorClass = armorClass ?: 10,
+                    maxHitPoints = maxHitPoints ?: 10,
+                    speeds = speeds.toDomain(),
+                    languages = languages ?: emptyList(),
+                    skills = Skills(),
+                ),
+            )
+        }
+
+        private fun ApiCharacter.ApiAbilities?.toDomain(): Abilities =
+            Abilities(
+                str = Ability(this?.str ?: Ability.DEFAULT_VALUE),
+                dex = Ability(this?.dex ?: Ability.DEFAULT_VALUE),
+                con = Ability(this?.con ?: Ability.DEFAULT_VALUE),
+                int = Ability(this?.int ?: Ability.DEFAULT_VALUE),
+                wis = Ability(this?.wis ?: Ability.DEFAULT_VALUE),
+                cha = Ability(this?.cha ?: Ability.DEFAULT_VALUE),
+            )
+
+        private fun ApiCharacter.ApiSpeeds?.toDomain(): Speeds =
+            Speeds(
+                walk = this?.walk,
+                fly = this?.fly,
+                swim = this?.swim,
+                climb = this?.climb,
+            )
+
+        private fun String.toRace(): Race? = Race.entries.find { it.name.equals(this, ignoreCase = true) }
+
+        private fun String.toClass(): Character.Class? = Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
+
+        private fun String.toSize(): Creature.Size? = Creature.Size.entries.find { it.name.equals(this, ignoreCase = true) }
+
+        private fun String.toAlignment(): Creature.Alignment? = Creature.Alignment.entries.find { it.name.equals(this, ignoreCase = true) }
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -10,9 +10,10 @@ import com.cyrillrx.rpg.character.domain.CharacterFilter
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.domain.Race
 import com.cyrillrx.rpg.character.domain.applyFilter
+import com.cyrillrx.rpg.creature.data.toAlignment
+import com.cyrillrx.rpg.creature.data.toSize
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
-import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
 
@@ -54,37 +55,45 @@ class JsonCharacterPresetRepository(
                 ?: return Result.Failure(CharacterImportError.MissingId)
             val name = name
                 ?: return Result.Failure(CharacterImportError.MissingName(id))
-            val resolvedSize = size?.let { s ->
-                s.toSize()
-                    ?: return Result.Failure(CharacterImportError.UnknownSize(id, s))
-            } ?: Creature.Size.MEDIUM
-            val resolvedAlignment = alignment?.let { a ->
-                a.toAlignment()
-                    ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, a))
-            } ?: Creature.Alignment.NEUTRAL
-            val characterTranslations = translations
-                ?.mapValues { (_, t) ->
-                    Character.Translation(
-                        shortDescription = t.shortDescription.orEmpty(),
-                        description = t.description.orEmpty(),
-                    )
-                }
-                ?: emptyMap()
+            val apiTranslations = translations
+                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val translationMap = apiTranslations.mapValues { (_, t) ->
+                Character.Translation(
+                    shortDescription = t.shortDescription.orEmpty(),
+                    description = t.description.orEmpty(),
+                )
+            }
+            val translations = translationMap.takeIf { it.isNotEmpty() }
+                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val level = level
+                ?: return Result.Failure(CharacterImportError.MissingLevel(id))
+            val apiSize = this@toCharacter.size
+                ?: return Result.Failure(CharacterImportError.MissingSize(id))
+            val size = apiSize.toSize()
+                ?: return Result.Failure(CharacterImportError.UnknownSize(id, apiSize))
+            val apiAlignment = this@toCharacter.alignment
+                ?: return Result.Failure(CharacterImportError.MissingAlignment(id))
+            val alignment = apiAlignment.toAlignment()
+                ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, apiAlignment))
+            val armorClass = armorClass
+                ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
+            val maxHitPoints = maxHitPoints
+                ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
 
             return Result.Success(
                 Character(
                     id = id,
                     name = name,
-                    translations = characterTranslations,
+                    translations = translations,
                     background = background,
                     race = race?.toRace() ?: Race.HUMAN,
                     clazz = clazz?.toClass() ?: Character.Class.UNKNOWN,
-                    level = level ?: 1,
-                    size = resolvedSize,
-                    alignment = resolvedAlignment,
+                    level = level,
+                    size = size,
+                    alignment = alignment,
                     abilities = abilities.toDomain(),
-                    armorClass = armorClass ?: 10,
-                    maxHitPoints = maxHitPoints ?: 10,
+                    armorClass = armorClass,
+                    maxHitPoints = maxHitPoints,
                     speeds = speeds.toDomain(),
                     languages = languages ?: emptyList(),
                     skills = Skills(),
@@ -112,11 +121,5 @@ class JsonCharacterPresetRepository(
 
         private fun String.toClass(): Character.Class? =
             Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
-
-        private fun String.toSize(): Creature.Size? =
-            Creature.Size.entries.find { it.name.equals(this, ignoreCase = true) }
-
-        private fun String.toAlignment(): Creature.Alignment? =
-            Creature.Alignment.entries.find { it.name.equals(this, ignoreCase = true) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -74,7 +74,6 @@ class JsonCharacterPresetRepository(
                     id = id,
                     name = name,
                     translations = characterTranslations,
-                    description = characterTranslations["en"]?.description.orEmpty(),
                     background = background,
                     race = race?.toRace() ?: Race.HUMAN,
                     clazz = clazz?.toClass() ?: Character.Class.UNKNOWN,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -22,7 +22,9 @@ class JsonCharacterPresetRepository(
     private var cache: List<Character>? = null
 
     override suspend fun getAll(filter: CharacterFilter?): List<Character> {
-        val all = cache ?: loadFromFile().parse().also { cache = it }
+        val all = cache ?: loadFromFile()
+            .parse()
+            .also { cache = it }
         return all.applyFilter(filter)
     }
 
@@ -48,26 +50,26 @@ class JsonCharacterPresetRepository(
         }
 
         private fun ApiCharacter.toCharacter(): Result<Character, CharacterImportError> {
-            val id = id ?: return Result.Failure(CharacterImportError.MissingId)
-            val name = name ?: return Result.Failure(CharacterImportError.MissingName(id))
-            val resolvedSize =
-                size?.let { s ->
-                    s.toSize() ?: return Result.Failure(CharacterImportError.UnknownSize(id, s))
-                } ?: Creature.Size.MEDIUM
-            val resolvedAlignment =
-                alignment?.let { a ->
-                    a.toAlignment() ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, a))
-                } ?: Creature.Alignment.NEUTRAL
-
-            val characterTranslations =
-                translations
-                    ?.mapValues { (_, t) ->
-                        Character.Translation(
-                            shortDescription = t.shortDescription.orEmpty(),
-                            description = t.description.orEmpty(),
-                        )
-                    }
-                    ?: emptyMap()
+            val id = id
+                ?: return Result.Failure(CharacterImportError.MissingId)
+            val name = name
+                ?: return Result.Failure(CharacterImportError.MissingName(id))
+            val resolvedSize = size?.let { s ->
+                s.toSize()
+                    ?: return Result.Failure(CharacterImportError.UnknownSize(id, s))
+            } ?: Creature.Size.MEDIUM
+            val resolvedAlignment = alignment?.let { a ->
+                a.toAlignment()
+                    ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, a))
+            } ?: Creature.Alignment.NEUTRAL
+            val characterTranslations = translations
+                ?.mapValues { (_, t) ->
+                    Character.Translation(
+                        shortDescription = t.shortDescription.orEmpty(),
+                        description = t.description.orEmpty(),
+                    )
+                }
+                ?: emptyMap()
 
             return Result.Success(
                 Character(
@@ -90,30 +92,31 @@ class JsonCharacterPresetRepository(
             )
         }
 
-        private fun ApiCharacter.ApiAbilities?.toDomain(): Abilities =
-            Abilities(
-                str = Ability(this?.str ?: Ability.DEFAULT_VALUE),
-                dex = Ability(this?.dex ?: Ability.DEFAULT_VALUE),
-                con = Ability(this?.con ?: Ability.DEFAULT_VALUE),
-                int = Ability(this?.int ?: Ability.DEFAULT_VALUE),
-                wis = Ability(this?.wis ?: Ability.DEFAULT_VALUE),
-                cha = Ability(this?.cha ?: Ability.DEFAULT_VALUE),
-            )
+        private fun ApiCharacter.ApiAbilities?.toDomain(): Abilities = Abilities(
+            str = Ability(this?.str ?: Ability.DEFAULT_VALUE),
+            dex = Ability(this?.dex ?: Ability.DEFAULT_VALUE),
+            con = Ability(this?.con ?: Ability.DEFAULT_VALUE),
+            int = Ability(this?.int ?: Ability.DEFAULT_VALUE),
+            wis = Ability(this?.wis ?: Ability.DEFAULT_VALUE),
+            cha = Ability(this?.cha ?: Ability.DEFAULT_VALUE),
+        )
 
-        private fun ApiCharacter.ApiSpeeds?.toDomain(): Speeds =
-            Speeds(
-                walk = this?.walk,
-                fly = this?.fly,
-                swim = this?.swim,
-                climb = this?.climb,
-            )
+        private fun ApiCharacter.ApiSpeeds?.toDomain(): Speeds = Speeds(
+            walk = this?.walk,
+            fly = this?.fly,
+            swim = this?.swim,
+            climb = this?.climb,
+        )
 
         private fun String.toRace(): Race? = Race.entries.find { it.name.equals(this, ignoreCase = true) }
 
-        private fun String.toClass(): Character.Class? = Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
+        private fun String.toClass(): Character.Class? =
+            Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
 
-        private fun String.toSize(): Creature.Size? = Creature.Size.entries.find { it.name.equals(this, ignoreCase = true) }
+        private fun String.toSize(): Creature.Size? =
+            Creature.Size.entries.find { it.name.equals(this, ignoreCase = true) }
 
-        private fun String.toAlignment(): Creature.Alignment? = Creature.Alignment.entries.find { it.name.equals(this, ignoreCase = true) }
+        private fun String.toAlignment(): Creature.Alignment? =
+            Creature.Alignment.entries.find { it.name.equals(this, ignoreCase = true) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -11,10 +11,10 @@ import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.domain.Race
 import com.cyrillrx.rpg.character.domain.applyFilter
 import com.cyrillrx.rpg.creature.data.toAlignment
+import com.cyrillrx.rpg.creature.data.toDomain
 import com.cyrillrx.rpg.creature.data.toSize
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
-import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
 
 class JsonCharacterPresetRepository(
@@ -79,6 +79,8 @@ class JsonCharacterPresetRepository(
                 ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
             val maxHitPoints = maxHitPoints
                 ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
+            val apiSkills = skills
+                ?: return Result.Failure(CharacterImportError.MissingSkills(id))
 
             return Result.Success(
                 Character(
@@ -96,7 +98,7 @@ class JsonCharacterPresetRepository(
                     maxHitPoints = maxHitPoints,
                     speeds = speeds.toDomain(),
                     languages = languages ?: emptyList(),
-                    skills = Skills(),
+                    skills = apiSkills.toDomain(),
                 ),
             )
         }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -23,9 +23,10 @@ class JsonCharacterPresetRepository(
     private var cache: List<Character>? = null
 
     override suspend fun getAll(filter: CharacterFilter?): List<Character> {
-        val all = cache ?: loadFromFile()
-            .parse()
-            .also { cache = it }
+        val all =
+            cache ?: loadFromFile()
+                .parse()
+                .also { cache = it }
         return all.applyFilter(filter)
     }
 
@@ -51,36 +52,61 @@ class JsonCharacterPresetRepository(
         }
 
         private fun ApiCharacter.toCharacter(): Result<Character, CharacterImportError> {
-            val id = id
-                ?: return Result.Failure(CharacterImportError.MissingId)
-            val name = name
-                ?: return Result.Failure(CharacterImportError.MissingName(id))
-            val apiTranslations = translations
-                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
-            val translationMap = apiTranslations.mapValues { (_, t) ->
-                Character.Translation(
-                    shortDescription = t.shortDescription.orEmpty(),
-                    description = t.description.orEmpty(),
-                )
-            }
-            val translations = translationMap.takeIf { it.isNotEmpty() }
-                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
-            val level = level
-                ?: return Result.Failure(CharacterImportError.MissingLevel(id))
-            val apiSize = this@toCharacter.size
-                ?: return Result.Failure(CharacterImportError.MissingSize(id))
-            val size = apiSize.toSize()
-                ?: return Result.Failure(CharacterImportError.UnknownSize(id, apiSize))
-            val apiAlignment = this@toCharacter.alignment
-                ?: return Result.Failure(CharacterImportError.MissingAlignment(id))
-            val alignment = apiAlignment.toAlignment()
-                ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, apiAlignment))
-            val armorClass = armorClass
-                ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
-            val maxHitPoints = maxHitPoints
-                ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
-            val apiSkills = skills
-                ?: return Result.Failure(CharacterImportError.MissingSkills(id))
+            val id =
+                id
+                    ?: return Result.Failure(CharacterImportError.MissingId)
+            val name =
+                name
+                    ?: return Result.Failure(CharacterImportError.MissingName(id))
+            val apiTranslations =
+                translations
+                    ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val translationMap =
+                apiTranslations.mapValues { (_, t) ->
+                    Character.Translation(
+                        shortDescription = t.shortDescription.orEmpty(),
+                        description = t.description.orEmpty(),
+                    )
+                }
+            val translations =
+                translationMap.takeIf { it.isNotEmpty() }
+                    ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val level =
+                level
+                    ?: return Result.Failure(CharacterImportError.MissingLevel(id))
+            val apiSize =
+                this@toCharacter.size
+                    ?: return Result.Failure(CharacterImportError.MissingSize(id))
+            val size =
+                apiSize.toSize()
+                    ?: return Result.Failure(CharacterImportError.UnknownSize(id, apiSize))
+            val apiAlignment =
+                this@toCharacter.alignment
+                    ?: return Result.Failure(CharacterImportError.MissingAlignment(id))
+            val alignment =
+                apiAlignment.toAlignment()
+                    ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, apiAlignment))
+            val armorClass =
+                armorClass
+                    ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
+            val maxHitPoints =
+                maxHitPoints
+                    ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
+            val apiSkills =
+                skills
+                    ?: return Result.Failure(CharacterImportError.MissingSkills(id))
+            val apiRace =
+                race
+                    ?: return Result.Failure(CharacterImportError.MissingRace(id))
+            val race =
+                apiRace.toRace()
+                    ?: return Result.Failure(CharacterImportError.UnknownRace(id, apiRace))
+            val apiClazz =
+                clazz
+                    ?: return Result.Failure(CharacterImportError.MissingClass(id))
+            val clazz =
+                apiClazz.toClass()
+                    ?: return Result.Failure(CharacterImportError.UnknownClass(id, apiClazz))
 
             return Result.Success(
                 Character(
@@ -88,8 +114,8 @@ class JsonCharacterPresetRepository(
                     name = name,
                     translations = translations,
                     background = background,
-                    race = race?.toRace() ?: Race.HUMAN,
-                    clazz = clazz?.toClass() ?: Character.Class.UNKNOWN,
+                    race = race,
+                    clazz = clazz,
                     level = level,
                     size = size,
                     alignment = alignment,
@@ -103,25 +129,26 @@ class JsonCharacterPresetRepository(
             )
         }
 
-        private fun ApiCharacter.ApiAbilities?.toDomain(): Abilities = Abilities(
-            str = Ability(this?.str ?: Ability.DEFAULT_VALUE),
-            dex = Ability(this?.dex ?: Ability.DEFAULT_VALUE),
-            con = Ability(this?.con ?: Ability.DEFAULT_VALUE),
-            int = Ability(this?.int ?: Ability.DEFAULT_VALUE),
-            wis = Ability(this?.wis ?: Ability.DEFAULT_VALUE),
-            cha = Ability(this?.cha ?: Ability.DEFAULT_VALUE),
-        )
+        private fun ApiCharacter.ApiAbilities?.toDomain(): Abilities =
+            Abilities(
+                str = Ability(this?.str ?: Ability.DEFAULT_VALUE),
+                dex = Ability(this?.dex ?: Ability.DEFAULT_VALUE),
+                con = Ability(this?.con ?: Ability.DEFAULT_VALUE),
+                int = Ability(this?.int ?: Ability.DEFAULT_VALUE),
+                wis = Ability(this?.wis ?: Ability.DEFAULT_VALUE),
+                cha = Ability(this?.cha ?: Ability.DEFAULT_VALUE),
+            )
 
-        private fun ApiCharacter.ApiSpeeds?.toDomain(): Speeds = Speeds(
-            walk = this?.walk,
-            fly = this?.fly,
-            swim = this?.swim,
-            climb = this?.climb,
-        )
+        private fun ApiCharacter.ApiSpeeds?.toDomain(): Speeds =
+            Speeds(
+                walk = this?.walk,
+                fly = this?.fly,
+                swim = this?.swim,
+                climb = this?.climb,
+            )
 
         private fun String.toRace(): Race? = Race.entries.find { it.name.equals(this, ignoreCase = true) }
 
-        private fun String.toClass(): Character.Class? =
-            Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
+        private fun String.toClass(): Character.Class? = Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
@@ -32,7 +32,7 @@ class SampleCharacterRepository : CharacterRepository {
         fun humanFighter() = Character(
             id = "sample-fighter",
             name = "Borin Pierrenoire",
-            description = "",
+
             size = Creature.Size.MEDIUM,
             alignment = Creature.Alignment.LAWFUL_GOOD,
             abilities = Abilities(
@@ -55,7 +55,7 @@ class SampleCharacterRepository : CharacterRepository {
         fun elfRogue() = Character(
             id = "sample-rogue",
             name = "Lyra Vossen",
-            description = "",
+
             size = Creature.Size.MEDIUM,
             alignment = Creature.Alignment.CHAOTIC_NEUTRAL,
             abilities = Abilities(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
@@ -11,68 +11,69 @@ import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
 
 class SampleCharacterRepository : CharacterRepository {
-    override suspend fun getAll(filter: CharacterFilter?): List<Character> =
-        characters.applyFilter(filter)
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> = characters.applyFilter(filter)
 
-    override suspend fun get(id: String): Character? =
-        characters.firstOrNull { it.id == id }
+    override suspend fun get(id: String): Character? = characters.firstOrNull { it.id == id }
 
     override suspend fun save(character: Character) = Unit
 
     override suspend fun delete(id: String) = Unit
 
     companion object {
-        private val characters: List<Character> = listOf(
-            humanFighter(),
-            elfRogue(),
-        )
+        private val characters: List<Character> =
+            listOf(
+                humanFighter(),
+                elfRogue(),
+            )
 
         fun getAll(): List<Character> = characters
 
-        fun humanFighter() = Character(
-            id = "sample-fighter",
-            name = "Borin Pierrenoire",
+        fun humanFighter() =
+            Character(
+                id = "sample-fighter",
+                name = "Borin Pierrenoire",
+                size = Creature.Size.MEDIUM,
+                alignment = Creature.Alignment.LAWFUL_GOOD,
+                abilities =
+                    Abilities(
+                        str = Ability(16),
+                        dex = Ability(12),
+                        con = Ability(14),
+                        int = Ability(10),
+                        wis = Ability(10),
+                        cha = Ability(8),
+                    ),
+                armorClass = 16,
+                maxHitPoints = 12,
+                speeds = Speeds(walk = 30),
+                languages = listOf("common", "dwarvish"),
+                level = 1,
+                clazz = Character.Class.FIGHTER,
+                skills = Skills(),
+            )
 
-            size = Creature.Size.MEDIUM,
-            alignment = Creature.Alignment.LAWFUL_GOOD,
-            abilities = Abilities(
-                str = Ability(16),
-                dex = Ability(12),
-                con = Ability(14),
-                int = Ability(10),
-                wis = Ability(10),
-                cha = Ability(8),
-            ),
-            armorClass = 16,
-            maxHitPoints = 12,
-            speeds = Speeds(walk = 30),
-            languages = listOf("common", "dwarvish"),
-            level = 1,
-            clazz = Character.Class.FIGHTER,
-            skills = Skills(),
-        )
-
-        fun elfRogue() = Character(
-            id = "sample-rogue",
-            name = "Lyra Vossen",
-
-            size = Creature.Size.MEDIUM,
-            alignment = Creature.Alignment.CHAOTIC_NEUTRAL,
-            abilities = Abilities(
-                str = Ability(8),
-                dex = Ability(16),
-                con = Ability(12),
-                int = Ability(14),
-                wis = Ability(10),
-                cha = Ability(14),
-            ),
-            armorClass = 14,
-            maxHitPoints = 8,
-            speeds = Speeds(walk = 30),
-            languages = listOf("common", "elvish"),
-            level = 1,
-            clazz = Character.Class.ROGUE,
-            skills = Skills(),
-        )
+        fun elfRogue() =
+            Character(
+                id = "sample-rogue",
+                name = "Lyra Vossen",
+                size = Creature.Size.MEDIUM,
+                alignment = Creature.Alignment.CHAOTIC_NEUTRAL,
+                abilities =
+                    Abilities(
+                        str = Ability(8),
+                        dex = Ability(16),
+                        con = Ability(12),
+                        int = Ability(14),
+                        wis = Ability(10),
+                        cha = Ability(14),
+                    ),
+                armorClass = 14,
+                maxHitPoints = 8,
+                speeds = Speeds(walk = 30),
+                languages = listOf("common", "elvish"),
+                level = 1,
+                clazz = Character.Class.ROGUE,
+                skills = Skills(),
+            )
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/api/ApiCharacter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/api/ApiCharacter.kt
@@ -1,0 +1,45 @@
+package com.cyrillrx.rpg.character.data.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal class ApiCharacter(
+    val id: String?,
+    val name: String?,
+    val background: String?,
+    val race: String?,
+    val clazz: String?,
+    val level: Int?,
+    val size: String?,
+    val alignment: String?,
+    val abilities: ApiAbilities?,
+    val armorClass: Int?,
+    val maxHitPoints: Int?,
+    val speeds: ApiSpeeds?,
+    val languages: List<String>?,
+    val translations: Map<String, Translation>?,
+) {
+    @Serializable
+    class Translation(
+        val shortDescription: String?,
+        val description: String?,
+    )
+
+    @Serializable
+    class ApiAbilities(
+        val str: Int?,
+        val dex: Int?,
+        val con: Int?,
+        val int: Int?,
+        val wis: Int?,
+        val cha: Int?,
+    )
+
+    @Serializable
+    class ApiSpeeds(
+        val walk: Int?,
+        val fly: Int?,
+        val swim: Int?,
+        val climb: Int?,
+    )
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/api/ApiCharacter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/api/ApiCharacter.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.character.data.api
 
+import com.cyrillrx.rpg.creature.data.api.ApiSkills
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -16,6 +17,7 @@ internal class ApiCharacter(
     val armorClass: Int?,
     val maxHitPoints: Int?,
     val speeds: ApiSpeeds?,
+    val skills: ApiSkills?,
     val languages: List<String>?,
     val translations: Map<String, Translation>?,
 ) {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -20,29 +20,44 @@ class Character(
     val clazz: Class,
     val skills: Skills,
     val race: Race = Race.HUMAN,
-    val shortDescription: String? = null,
+    val translations: Map<String, Translation> = emptyMap(),
     val background: String? = null,
     val currentHitPoints: Int = maxHitPoints,
     val temporaryHitPoints: Int = 0,
 ) : Creature(
-    id = id,
-    size = size,
-    alignment = alignment,
-    abilities = abilities,
-    armorClass = armorClass,
-    maxHitPoints = maxHitPoints,
-    speeds = speeds,
-    languages = languages,
-) {
+        id = id,
+        size = size,
+        alignment = alignment,
+        abilities = abilities,
+        armorClass = armorClass,
+        maxHitPoints = maxHitPoints,
+        speeds = speeds,
+        languages = languages,
+    ) {
+    fun resolveTranslation(locale: String): Translation? =
+        translations[locale]
+            ?: translations[FALLBACK_LOCALE]
+            ?: translations.values.firstOrNull()
+
     fun initiativeModifier(): Int = abilities.dex.modifier
 
-    fun proficiencyBonus(): Int = when (level) {
-        in 1..4 -> 2
-        in 5..8 -> 3
-        in 9..12 -> 4
-        in 13..16 -> 5
-        in 17..20 -> 6
-        else -> 0
+    fun proficiencyBonus(): Int =
+        when (level) {
+            in 1..4 -> 2
+            in 5..8 -> 3
+            in 9..12 -> 4
+            in 13..16 -> 5
+            in 17..20 -> 6
+            else -> 0
+        }
+
+    data class Translation(
+        val shortDescription: String = "",
+        val description: String = "",
+    )
+
+    companion object {
+        private const val FALLBACK_LOCALE = "en"
     }
 
     enum class Class {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -34,22 +34,20 @@ data class Character(
     speeds = speeds,
     languages = languages,
 ) {
-    fun resolveTranslation(locale: String): Translation? =
-        translations[locale]
-            ?: translations[FALLBACK_LOCALE]
-            ?: translations.values.firstOrNull()
+    fun resolveTranslation(locale: String): Translation? = translations[locale]
+        ?: translations[FALLBACK_LOCALE]
+        ?: translations.values.firstOrNull()
 
     fun initiativeModifier(): Int = abilities.dex.modifier
 
-    fun proficiencyBonus(): Int =
-        when (level) {
-            in 1..4 -> 2
-            in 5..8 -> 3
-            in 9..12 -> 4
-            in 13..16 -> 5
-            in 17..20 -> 6
-            else -> 0
-        }
+    fun proficiencyBonus(): Int = when (level) {
+        in 1..4 -> 2
+        in 5..8 -> 3
+        in 9..12 -> 4
+        in 13..16 -> 5
+        in 17..20 -> 6
+        else -> 0
+    }
 
     data class Translation(
         val shortDescription: String = "",

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -1,21 +1,21 @@
 package com.cyrillrx.rpg.character.domain
 
+import com.cyrillrx.core.domain.FALLBACK_LOCALE
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
 
-class Character(
-    id: String,
+data class Character(
+    override val id: String,
     val name: String,
-    val description: String,
-    size: Size,
-    alignment: Alignment,
-    abilities: Abilities,
-    armorClass: Int,
-    maxHitPoints: Int,
-    speeds: Speeds,
-    languages: List<String>,
+    override val size: Size,
+    override val alignment: Alignment,
+    override val abilities: Abilities,
+    override val armorClass: Int,
+    override val maxHitPoints: Int,
+    override val speeds: Speeds,
+    override val languages: List<String>,
     val level: Int,
     val clazz: Class,
     val skills: Skills,
@@ -25,15 +25,15 @@ class Character(
     val currentHitPoints: Int = maxHitPoints,
     val temporaryHitPoints: Int = 0,
 ) : Creature(
-        id = id,
-        size = size,
-        alignment = alignment,
-        abilities = abilities,
-        armorClass = armorClass,
-        maxHitPoints = maxHitPoints,
-        speeds = speeds,
-        languages = languages,
-    ) {
+    id = id,
+    size = size,
+    alignment = alignment,
+    abilities = abilities,
+    armorClass = armorClass,
+    maxHitPoints = maxHitPoints,
+    speeds = speeds,
+    languages = languages,
+) {
     fun resolveTranslation(locale: String): Translation? =
         translations[locale]
             ?: translations[FALLBACK_LOCALE]
@@ -55,10 +55,6 @@ class Character(
         val shortDescription: String = "",
         val description: String = "",
     )
-
-    companion object {
-        private const val FALLBACK_LOCALE = "en"
-    }
 
     enum class Class {
         BARBARIAN,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/CreatureParseExt.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/CreatureParseExt.kt
@@ -1,9 +1,87 @@
 package com.cyrillrx.rpg.creature.data
 
+import com.cyrillrx.rpg.creature.data.api.ApiConditionImmunities
+import com.cyrillrx.rpg.creature.data.api.ApiDamageAffinities
+import com.cyrillrx.rpg.creature.data.api.ApiSkills
+import com.cyrillrx.rpg.creature.domain.ConditionImmunities
 import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.DamageAffinities
+import com.cyrillrx.rpg.creature.domain.DamageAffinity
+import com.cyrillrx.rpg.creature.domain.Proficiency
+import com.cyrillrx.rpg.creature.domain.Skills
 
 internal fun String.toSize(): Creature.Size? =
     Creature.Size.entries.find { it.name.equals(this, ignoreCase = true) }
 
 internal fun String.toAlignment(): Creature.Alignment? =
     Creature.Alignment.entries.find { it.name.equals(this, ignoreCase = true) }
+
+internal fun String?.toProficiency(): Proficiency = when (this) {
+    "proficient" -> Proficiency.PROFICIENT
+    "expert" -> Proficiency.EXPERT
+    else -> Proficiency.NONE
+}
+
+internal fun ApiSkills.toDomain(): Skills = Skills(
+    acrobatics = acrobatics.toProficiency(),
+    animalHandling = animalHandling.toProficiency(),
+    arcana = arcana.toProficiency(),
+    athletics = athletics.toProficiency(),
+    deception = deception.toProficiency(),
+    history = history.toProficiency(),
+    insight = insight.toProficiency(),
+    intimidation = intimidation.toProficiency(),
+    investigation = investigation.toProficiency(),
+    medicine = medicine.toProficiency(),
+    nature = nature.toProficiency(),
+    perception = perception.toProficiency(),
+    performance = performance.toProficiency(),
+    persuasion = persuasion.toProficiency(),
+    religion = religion.toProficiency(),
+    sleightOfHand = sleightOfHand.toProficiency(),
+    stealth = stealth.toProficiency(),
+    survival = survival.toProficiency(),
+)
+
+internal fun String?.toDamageAffinity(): DamageAffinity = when (this) {
+    "resistant" -> DamageAffinity.RESISTANT
+    "immune" -> DamageAffinity.IMMUNE
+    "vulnerable" -> DamageAffinity.VULNERABLE
+    else -> DamageAffinity.NONE
+}
+
+internal fun ApiDamageAffinities.toDomain(): DamageAffinities = DamageAffinities(
+    acid = acid.toDamageAffinity(),
+    bludgeoning = bludgeoning.toDamageAffinity(),
+    cold = cold.toDamageAffinity(),
+    fire = fire.toDamageAffinity(),
+    force = force.toDamageAffinity(),
+    lightning = lightning.toDamageAffinity(),
+    necrotic = necrotic.toDamageAffinity(),
+    piercing = piercing.toDamageAffinity(),
+    poison = poison.toDamageAffinity(),
+    psychic = psychic.toDamageAffinity(),
+    radiant = radiant.toDamageAffinity(),
+    slashing = slashing.toDamageAffinity(),
+    thunder = thunder.toDamageAffinity(),
+    bludgeoningNonMagical = bludgeoningNonMagical.toDamageAffinity(),
+    piercingNonMagical = piercingNonMagical.toDamageAffinity(),
+    slashingNonMagical = slashingNonMagical.toDamageAffinity(),
+)
+
+internal fun ApiConditionImmunities.toDomain(): ConditionImmunities = ConditionImmunities(
+    blinded = blinded ?: false,
+    charmed = charmed ?: false,
+    deafened = deafened ?: false,
+    exhaustion = exhaustion ?: false,
+    frightened = frightened ?: false,
+    grappled = grappled ?: false,
+    incapacitated = incapacitated ?: false,
+    paralyzed = paralyzed ?: false,
+    petrified = petrified ?: false,
+    poisoned = poisoned ?: false,
+    prone = prone ?: false,
+    restrained = restrained ?: false,
+    stunned = stunned ?: false,
+    unconscious = unconscious ?: false,
+)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/CreatureParseExt.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/CreatureParseExt.kt
@@ -1,0 +1,9 @@
+package com.cyrillrx.rpg.creature.data
+
+import com.cyrillrx.rpg.creature.domain.Creature
+
+internal fun String.toSize(): Creature.Size? =
+    Creature.Size.entries.find { it.name.equals(this, ignoreCase = true) }
+
+internal fun String.toAlignment(): Creature.Alignment? =
+    Creature.Alignment.entries.find { it.name.equals(this, ignoreCase = true) }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.creature.data
 
 import com.cyrillrx.core.data.FileReader
 import com.cyrillrx.core.data.deserialize
+import com.cyrillrx.core.domain.FALLBACK_LOCALE
 import com.cyrillrx.core.domain.Result
 import com.cyrillrx.core.domain.partitionBy
 import com.cyrillrx.rpg.creature.data.api.ApiMonster
@@ -79,7 +80,7 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
             val translations = translationMap.takeIf { it.isNotEmpty() }
                 ?: return Result.Failure(MonsterImportError.MissingTranslations(id))
 
-            val enTranslation = translations["en"] ?: translations.values.first()
+            val enTranslation = translations[FALLBACK_LOCALE] ?: translations.values.first()
 
             return Result.Success(
                 Monster(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -9,12 +9,11 @@ import com.cyrillrx.rpg.creature.data.api.ApiMonster
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
 import com.cyrillrx.rpg.creature.domain.ConditionImmunities
-import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.DamageAffinities
+import com.cyrillrx.rpg.creature.domain.DamageAffinity
+import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.MonsterRepository
-import com.cyrillrx.rpg.creature.domain.DamageAffinity
-import com.cyrillrx.rpg.creature.domain.DamageAffinities
-import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.Proficiency
 import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
@@ -69,8 +68,14 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
                 ?: return Result.Failure(MonsterImportError.MissingAlignment(id))
             val alignment = apiAlignment.toAlignment()
                 ?: return Result.Failure(MonsterImportError.UnknownAlignment(id, apiAlignment))
+            val challengeRating = challengeRating
+                ?: return Result.Failure(MonsterImportError.MissingChallengeRating(id))
             val apiAbilities = abilities
                 ?: return Result.Failure(MonsterImportError.MissingAbilities(id))
+            val armorClass = armorClass
+                ?: return Result.Failure(MonsterImportError.MissingArmorClass(id))
+            val maxHitPoints = maxHitPoints
+                ?: return Result.Failure(MonsterImportError.MissingMaxHitPoints(id))
             val apiTranslations = translations
                 ?: return Result.Failure(MonsterImportError.MissingTranslations(id))
             val (translationMap, translationErrors) = apiTranslations.partitionBy { locale, t ->
@@ -79,8 +84,7 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
             translationErrors.forEach { println("WARNING: monster import error: $it") }
             val translations = translationMap.takeIf { it.isNotEmpty() }
                 ?: return Result.Failure(MonsterImportError.MissingTranslations(id))
-
-            val enTranslation = translations[FALLBACK_LOCALE] ?: translations.values.first()
+            val languages = (translations[FALLBACK_LOCALE] ?: translations.values.first()).languages
 
             return Result.Success(
                 Monster(
@@ -89,13 +93,13 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
                     type = type,
                     size = size,
                     alignment = alignment,
-                    challengeRating = challengeRating ?: -1f,
+                    challengeRating = challengeRating,
                     hitDice = hitDice.orEmpty(),
                     abilities = apiAbilities.toDomain(),
-                    armorClass = armorClass ?: 10,
-                    maxHitPoints = maxHitPoints ?: 0,
+                    armorClass = armorClass,
+                    maxHitPoints = maxHitPoints,
                     speeds = speeds.toDomain(),
-                    languages = enTranslation.languages ?: emptyList(),
+                    languages = languages,
                     skills = skills.toSkills(),
                     damageAffinities = damageAffinities.toDamageAffinities(),
                     conditionImmunities = conditionImmunities.toConditionImmunities(),
@@ -225,11 +229,5 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
 
         private fun String.toType(): Monster.Type? =
             Monster.Type.entries.find { it.name.equals(this, ignoreCase = true) }
-
-        private fun String.toSize(): Creature.Size? =
-            Creature.Size.entries.find { it.name.equals(this, ignoreCase = true) }
-
-        private fun String.toAlignment(): Creature.Alignment? =
-            Creature.Alignment.entries.find { it.name.equals(this, ignoreCase = true) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -8,14 +8,9 @@ import com.cyrillrx.core.domain.partitionBy
 import com.cyrillrx.rpg.creature.data.api.ApiMonster
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
-import com.cyrillrx.rpg.creature.domain.ConditionImmunities
-import com.cyrillrx.rpg.creature.domain.DamageAffinities
-import com.cyrillrx.rpg.creature.domain.DamageAffinity
 import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.MonsterRepository
-import com.cyrillrx.rpg.creature.domain.Proficiency
-import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
 import com.cyrillrx.rpg.creature.domain.applyFilter
 
@@ -76,6 +71,12 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
                 ?: return Result.Failure(MonsterImportError.MissingArmorClass(id))
             val maxHitPoints = maxHitPoints
                 ?: return Result.Failure(MonsterImportError.MissingMaxHitPoints(id))
+            val apiSkills = skills
+                ?: return Result.Failure(MonsterImportError.MissingSkills(id))
+            val apiDamageAffinities = damageAffinities
+                ?: return Result.Failure(MonsterImportError.MissingDamageAffinities(id))
+            val apiConditionImmunities = conditionImmunities
+                ?: return Result.Failure(MonsterImportError.MissingConditionImmunities(id))
             val apiTranslations = translations
                 ?: return Result.Failure(MonsterImportError.MissingTranslations(id))
             val (translationMap, translationErrors) = apiTranslations.partitionBy { locale, t ->
@@ -100,9 +101,9 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
                     maxHitPoints = maxHitPoints,
                     speeds = speeds.toDomain(),
                     languages = languages,
-                    skills = skills.toSkills(),
-                    damageAffinities = damageAffinities.toDamageAffinities(),
-                    conditionImmunities = conditionImmunities.toConditionImmunities(),
+                    skills = apiSkills.toDomain(),
+                    damageAffinities = apiDamageAffinities.toDomain(),
+                    conditionImmunities = apiConditionImmunities.toDomain(),
                     translations = translations,
                 ),
             )
@@ -138,94 +139,14 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
             )
         }
 
-        private fun ApiMonster.ApiAbilities.toDomain(): Abilities =
-            Abilities(
-                str = Ability(str?.value ?: Ability.DEFAULT_VALUE, str?.savingThrowProficiency.toProficiency()),
-                dex = Ability(dex?.value ?: Ability.DEFAULT_VALUE, dex?.savingThrowProficiency.toProficiency()),
-                con = Ability(con?.value ?: Ability.DEFAULT_VALUE, con?.savingThrowProficiency.toProficiency()),
-                int = Ability(int?.value ?: Ability.DEFAULT_VALUE, int?.savingThrowProficiency.toProficiency()),
-                wis = Ability(wis?.value ?: Ability.DEFAULT_VALUE, wis?.savingThrowProficiency.toProficiency()),
-                cha = Ability(cha?.value ?: Ability.DEFAULT_VALUE, cha?.savingThrowProficiency.toProficiency()),
-            )
-
-        private fun String?.toProficiency(): Proficiency = when (this) {
-            "proficient" -> Proficiency.PROFICIENT
-            "expert" -> Proficiency.EXPERT
-            else -> Proficiency.NONE
-        }
-
-        private fun Map<String, String>?.toSkills(): Skills {
-            if (this == null) return Skills()
-            return Skills(
-                acrobatics = get("acrobatics").toProficiency(),
-                animalHandling = get("animalHandling").toProficiency(),
-                arcana = get("arcana").toProficiency(),
-                athletics = get("athletics").toProficiency(),
-                deception = get("deception").toProficiency(),
-                history = get("history").toProficiency(),
-                insight = get("insight").toProficiency(),
-                intimidation = get("intimidation").toProficiency(),
-                investigation = get("investigation").toProficiency(),
-                medicine = get("medicine").toProficiency(),
-                nature = get("nature").toProficiency(),
-                perception = get("perception").toProficiency(),
-                performance = get("performance").toProficiency(),
-                persuasion = get("persuasion").toProficiency(),
-                religion = get("religion").toProficiency(),
-                sleightOfHand = get("sleightOfHand").toProficiency(),
-                stealth = get("stealth").toProficiency(),
-                survival = get("survival").toProficiency(),
-            )
-        }
-
-        private fun Map<String, String>?.toDamageAffinities(): DamageAffinities {
-            if (this == null) return DamageAffinities()
-            return DamageAffinities(
-                acid = get("acid").toDamageAffinity(),
-                bludgeoning = get("bludgeoning").toDamageAffinity(),
-                cold = get("cold").toDamageAffinity(),
-                fire = get("fire").toDamageAffinity(),
-                force = get("force").toDamageAffinity(),
-                lightning = get("lightning").toDamageAffinity(),
-                necrotic = get("necrotic").toDamageAffinity(),
-                piercing = get("piercing").toDamageAffinity(),
-                poison = get("poison").toDamageAffinity(),
-                psychic = get("psychic").toDamageAffinity(),
-                radiant = get("radiant").toDamageAffinity(),
-                slashing = get("slashing").toDamageAffinity(),
-                thunder = get("thunder").toDamageAffinity(),
-                bludgeoningNonMagical = get("bludgeoningNonMagical").toDamageAffinity(),
-                piercingNonMagical = get("piercingNonMagical").toDamageAffinity(),
-                slashingNonMagical = get("slashingNonMagical").toDamageAffinity(),
-            )
-        }
-
-        private fun String?.toDamageAffinity(): DamageAffinity = when (this) {
-            "resistant" -> DamageAffinity.RESISTANT
-            "immune" -> DamageAffinity.IMMUNE
-            "vulnerable" -> DamageAffinity.VULNERABLE
-            else -> DamageAffinity.NONE
-        }
-
-        private fun Map<String, Boolean>?.toConditionImmunities(): ConditionImmunities {
-            if (this == null) return ConditionImmunities()
-            return ConditionImmunities(
-                blinded = get("blinded") ?: false,
-                charmed = get("charmed") ?: false,
-                deafened = get("deafened") ?: false,
-                exhaustion = get("exhaustion") ?: false,
-                frightened = get("frightened") ?: false,
-                grappled = get("grappled") ?: false,
-                incapacitated = get("incapacitated") ?: false,
-                paralyzed = get("paralyzed") ?: false,
-                petrified = get("petrified") ?: false,
-                poisoned = get("poisoned") ?: false,
-                prone = get("prone") ?: false,
-                restrained = get("restrained") ?: false,
-                stunned = get("stunned") ?: false,
-                unconscious = get("unconscious") ?: false,
-            )
-        }
+        private fun ApiMonster.ApiAbilities.toDomain(): Abilities = Abilities(
+            str = Ability(str?.value ?: Ability.DEFAULT_VALUE, str?.savingThrowProficiency.toProficiency()),
+            dex = Ability(dex?.value ?: Ability.DEFAULT_VALUE, dex?.savingThrowProficiency.toProficiency()),
+            con = Ability(con?.value ?: Ability.DEFAULT_VALUE, con?.savingThrowProficiency.toProficiency()),
+            int = Ability(int?.value ?: Ability.DEFAULT_VALUE, int?.savingThrowProficiency.toProficiency()),
+            wis = Ability(wis?.value ?: Ability.DEFAULT_VALUE, wis?.savingThrowProficiency.toProficiency()),
+            cha = Ability(cha?.value ?: Ability.DEFAULT_VALUE, cha?.savingThrowProficiency.toProficiency()),
+        )
 
         private fun String.toType(): Monster.Type? =
             Monster.Type.entries.find { it.name.equals(this, ignoreCase = true) }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/MonsterImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/MonsterImportError.kt
@@ -12,6 +12,9 @@ sealed interface MonsterImportError : Error {
     data class MissingAlignment(val id: String) : MonsterImportError
     data class UnknownAlignment(val id: String, val raw: String) : MonsterImportError
     data class MissingAbilities(val id: String) : MonsterImportError
+    data class MissingArmorClass(val id: String) : MonsterImportError
+    data class MissingMaxHitPoints(val id: String) : MonsterImportError
+    data class MissingChallengeRating(val id: String) : MonsterImportError
     data class MissingTranslations(val id: String) : MonsterImportError
     data class InvalidTranslation(val id: String, val locale: String) : MonsterImportError
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/MonsterImportError.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/MonsterImportError.kt
@@ -12,6 +12,9 @@ sealed interface MonsterImportError : Error {
     data class MissingAlignment(val id: String) : MonsterImportError
     data class UnknownAlignment(val id: String, val raw: String) : MonsterImportError
     data class MissingAbilities(val id: String) : MonsterImportError
+    data class MissingSkills(val id: String) : MonsterImportError
+    data class MissingDamageAffinities(val id: String) : MonsterImportError
+    data class MissingConditionImmunities(val id: String) : MonsterImportError
     data class MissingArmorClass(val id: String) : MonsterImportError
     data class MissingMaxHitPoints(val id: String) : MonsterImportError
     data class MissingChallengeRating(val id: String) : MonsterImportError

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiConditionImmunities.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiConditionImmunities.kt
@@ -1,0 +1,21 @@
+package com.cyrillrx.rpg.creature.data.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal class ApiConditionImmunities(
+    val blinded: Boolean?,
+    val charmed: Boolean?,
+    val deafened: Boolean?,
+    val exhaustion: Boolean?,
+    val frightened: Boolean?,
+    val grappled: Boolean?,
+    val incapacitated: Boolean?,
+    val paralyzed: Boolean?,
+    val petrified: Boolean?,
+    val poisoned: Boolean?,
+    val prone: Boolean?,
+    val restrained: Boolean?,
+    val stunned: Boolean?,
+    val unconscious: Boolean?,
+)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiDamageAffinities.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiDamageAffinities.kt
@@ -1,0 +1,23 @@
+package com.cyrillrx.rpg.creature.data.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal class ApiDamageAffinities(
+    val acid: String?,
+    val bludgeoning: String?,
+    val cold: String?,
+    val fire: String?,
+    val force: String?,
+    val lightning: String?,
+    val necrotic: String?,
+    val piercing: String?,
+    val poison: String?,
+    val psychic: String?,
+    val radiant: String?,
+    val slashing: String?,
+    val thunder: String?,
+    val bludgeoningNonMagical: String?,
+    val piercingNonMagical: String?,
+    val slashingNonMagical: String?,
+)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiMonster.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiMonster.kt
@@ -15,9 +15,9 @@ internal class ApiMonster(
     val hitDice: String?,
     val abilities: ApiAbilities?,
     val speeds: ApiSpeeds?,
-    val skills: Map<String, String>?,
-    val damageAffinities: Map<String, String>?,
-    val conditionImmunities: Map<String, Boolean>?,
+    val skills: ApiSkills?,
+    val damageAffinities: ApiDamageAffinities?,
+    val conditionImmunities: ApiConditionImmunities?,
     val translations: Map<String, Translation>?,
 ) {
     @Serializable

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiSkills.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/api/ApiSkills.kt
@@ -1,0 +1,25 @@
+package com.cyrillrx.rpg.creature.data.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal class ApiSkills(
+    val acrobatics: String?,
+    val animalHandling: String?,
+    val arcana: String?,
+    val athletics: String?,
+    val deception: String?,
+    val history: String?,
+    val insight: String?,
+    val intimidation: String?,
+    val investigation: String?,
+    val medicine: String?,
+    val nature: String?,
+    val perception: String?,
+    val performance: String?,
+    val persuasion: String?,
+    val religion: String?,
+    val sleightOfHand: String?,
+    val stealth: String?,
+    val survival: String?,
+)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Creature.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Creature.kt
@@ -1,14 +1,14 @@
 package com.cyrillrx.rpg.creature.domain
 
 abstract class Creature(
-    val id: String,
-    val size: Size,
-    val alignment: Alignment,
-    val abilities: Abilities,
-    val armorClass: Int,
-    val maxHitPoints: Int,
-    val speeds: Speeds,
-    val languages: List<String>,
+    open val id: String,
+    open val size: Size,
+    open val alignment: Alignment,
+    open val abilities: Abilities,
+    open val armorClass: Int,
+    open val maxHitPoints: Int,
+    open val speeds: Speeds,
+    open val languages: List<String>,
 ) {
     enum class Size {
         TINY,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
@@ -1,6 +1,6 @@
 package com.cyrillrx.rpg.creature.domain
 
-private const val FALLBACK_LOCALE = "en"
+import com.cyrillrx.core.domain.FALLBACK_LOCALE
 
 class Monster(
     id: String,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
@@ -2,7 +2,7 @@ package com.cyrillrx.rpg.magicalitem.domain
 
 import kotlinx.serialization.Serializable
 
-private const val FALLBACK_LOCALE = "en"
+import com.cyrillrx.core.domain.FALLBACK_LOCALE
 
 @Serializable
 class MagicalItem(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.spell.domain
 import com.cyrillrx.rpg.character.domain.Character
 import kotlinx.serialization.Serializable
 
-private const val FALLBACK_LOCALE = "en"
+import com.cyrillrx.core.domain.FALLBACK_LOCALE
 
 @Serializable
 class Spell(

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepositoryTest.kt
@@ -1,0 +1,147 @@
+package com.cyrillrx.rpg.character.data
+
+import com.cyrillrx.core.data.FileReader
+import com.cyrillrx.core.domain.FileReaderError
+import com.cyrillrx.core.domain.Result
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.domain.Race
+import com.cyrillrx.rpg.creature.domain.Creature
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class JsonCharacterPresetRepositoryTest {
+    @Test
+    fun `valid preset is parsed with correct field values`() =
+        runTest {
+            val result = repository(preset()).getAll(null)
+
+            assertEquals(1, result.size)
+            val character = result.first()
+            assertEquals("test-fighter", character.id)
+            assertEquals("Aldus Test", character.name)
+            assertEquals(Race.HUMAN, character.race)
+            assertEquals(Character.Class.FIGHTER, character.clazz)
+            assertEquals(3, character.level)
+            assertEquals(Creature.Size.MEDIUM, character.size)
+            assertEquals(Creature.Alignment.LAWFUL_GOOD, character.alignment)
+            assertEquals(17, character.armorClass)
+            assertEquals(28, character.maxHitPoints)
+        }
+
+    @Test
+    fun `preset with missing id is skipped`() =
+        runTest {
+            val json = preset(id = null)
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with missing name is skipped`() =
+        runTest {
+            val json = preset(name = null)
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with missing translations is skipped`() =
+        runTest {
+            val json = preset(translations = null)
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with missing level is skipped`() =
+        runTest {
+            val json = preset(level = null)
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with unknown size is skipped`() =
+        runTest {
+            val json = preset(size = "GIGANTIC")
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with unknown alignment is skipped`() =
+        runTest {
+            val json = preset(alignment = "CHAOTIC_POTATO")
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with missing skills is skipped`() =
+        runTest {
+            val json = preset(skills = null)
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with unknown race is skipped`() =
+        runTest {
+            val json = preset(race = "MARTIAN")
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `preset with unknown class is skipped`() =
+        runTest {
+            val json = preset(clazz = "JEDI")
+            assertTrue(repository(json).getAll(null).isEmpty())
+        }
+
+    @Test
+    fun `valid records are returned even when some records are invalid`() =
+        runTest {
+            val json = """[
+            ${preset().trimArray()},
+            ${preset(id = "second-fighter", race = "MARTIAN").trimArray()}
+        ]"""
+            val result = repository(json).getAll(null)
+            assertEquals(1, result.size)
+            assertEquals("test-fighter", result.first().id)
+        }
+
+    private fun repository(json: String) = JsonCharacterPresetRepository(FakeFileReader(json))
+
+    private fun String.trimArray() = trim().removePrefix("[").removeSuffix("]").trim()
+
+    private fun preset(
+        id: String? = "test-fighter",
+        name: String? = "Aldus Test",
+        race: String? = "HUMAN",
+        clazz: String? = "FIGHTER",
+        level: Int? = 3,
+        size: String? = "MEDIUM",
+        alignment: String? = "LAWFUL_GOOD",
+        armorClass: Int? = 17,
+        maxHitPoints: Int? = 28,
+        skills: String? = "{}",
+        translations: String? = """{"en": {"shortDescription": "Human Fighter", "description": ""}}""",
+    ): String {
+        val fields =
+            buildList {
+                id?.let { add(""""id": "$it"""") }
+                name?.let { add(""""name": "$it"""") }
+                race?.let { add(""""race": "$it"""") }
+                clazz?.let { add(""""clazz": "$it"""") }
+                level?.let { add(""""level": $it""") }
+                size?.let { add(""""size": "$it"""") }
+                alignment?.let { add(""""alignment": "$it"""") }
+                armorClass?.let { add(""""armorClass": $it""") }
+                maxHitPoints?.let { add(""""maxHitPoints": $it""") }
+                skills?.let { add(""""skills": $it""") }
+                translations?.let { add(""""translations": $it""") }
+            }
+        return "[{${fields.joinToString(", ")}}]"
+    }
+
+    private class FakeFileReader(
+        private val json: String,
+    ) : FileReader {
+        override suspend fun readFile(path: String): Result<String, FileReaderError> = Result.Success(json)
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CharacterTest.kt
@@ -56,7 +56,6 @@ class CharacterTest {
     private fun character(dex: Int = 10, level: Int = 1) = Character(
         id = "test",
         name = "Test",
-        description = "",
         size = Creature.Size.MEDIUM,
         alignment = Creature.Alignment.NEUTRAL,
         abilities = Abilities(


### PR DESCRIPTION
## 📝 Description

### Character feature — Phase 5b

- **CharacterListScreen**: character list with two action cards at the top (New Character / Quick Create). Cards use icon + title + subtitle layout.
- **CharacterPresetGalleryScreen**: two-tab gallery (PCs / NPCs) for quick character creation from presets. Tabs are in the content column, not the top bar, to avoid layout shift.
- **JSON presets**: 4 PC presets (Fighter, Rogue, Wizard, Cleric) and 3 NPC presets (Guard, Innkeeper, Merchant) with EN/FR translations and per-class skill proficiencies.
- **JsonCharacterPresetRepository**: reads `character_presets.json`, lazy cache, no-op save/delete.
- **CharacterListItem**: `shortDescription` shown as primary text when available; `name` as fallback (and secondary when description is present). Displays AC and HP with icons.
- **Routing**: `CharacterRoute.PresetGallery` wired up; `CharacterRouter` extended with `openPresetGallery()`.
- **String resources**: EN + FR for all new UI strings.

### Creature data layer refactoring

- `ApiSkills`, `ApiDamageAffinities`, `ApiConditionImmunities`: typed classes replacing `Map<String, String>` and `Map<String, Boolean>` in `ApiMonster` — eliminates magic string keys.
- `CreatureParseExt.kt`: shared `toDomain()` extension functions for skills, damage affinities, and condition immunities, reused by both `JsonMonsterRepository` and `JsonCharacterPresetRepository`.
- `MonsterImportError` / `CharacterImportError` (`sealed interface`): explicit `Result.Failure` for all required fields — no more silent defaults. `CharacterImportError` adds `MissingRace`, `UnknownRace`, `MissingClass`, `UnknownClass`.

### Bug fixes

- `paddingValues` now correctly propagates to all body states in `CampaignListScreen`, `SpellCardCarouselScreen`, `MagicalItemCardCarouselScreen`, and `CharacterPresetGalleryScreen`.

### Tests

- `JsonCharacterPresetRepositoryTest` (10 tests): happy path with field-level assertions + one test per error case (missing id, name, translations, level, skills; unknown size, alignment, race, class) + partition test.
- `CharacterTest.kt`: removed obsolete `description` field reference.

## 🖼️ Media

<img width="550" height="738" alt="image" src="https://github.com/user-attachments/assets/3c2e2474-6500-486c-aaa1-5e537bc7d1bf" />

<img width="552" height="762" alt="image" src="https://github.com/user-attachments/assets/76b8ebb2-c798-4d8b-b561-a67d9b43274d" />

<img width="558" height="608" alt="image" src="https://github.com/user-attachments/assets/305e213a-c699-4932-a54a-be5cd20fa873" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed