### PR TITLE
fix(creature): fix stats formatting and unify labels

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -2,8 +2,8 @@
 
 <resources>
     <!-- Character stats -->
-    <string name="label_armor_class">CA %d</string>
-    <string name="label_hit_points">%d PV</string>
+    <string name="label_armor_class">CA %1$d</string>
+    <string name="label_hit_points">%1$d PV</string>
 
     <!-- Character list -->
     <string name="title_character_list">Personnages</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-    <!-- Character stats -->
-    <string name="label_armor_class">CA %1$d</string>
-    <string name="label_hit_points">%1$d PV</string>
-
     <!-- Character list -->
     <string name="title_character_list">Personnages</string>
     <string name="title_preset_gallery">Création rapide</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_creature.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_creature.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-    <string name="creature_ac">Class d\'armure</string>
+    <!-- Creature stats -->
+    <string name="label_armor_class">CA %1$d</string>
+    <string name="label_hit_points">%1$d PV</string>
+
+    <string name="creature_ac">Classe d'armure</string>
     <string name="creature_hp">Point de vie</string>
     <string name="creature_speed">Vitesse</string>
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-    <!-- Character stats -->
-    <string name="label_armor_class">AC %1$d</string>
-    <string name="label_hit_points">%1$d HP</string>
-
     <!-- Character list -->
     <string name="title_character_list">Characters</string>
     <string name="title_preset_gallery">Quick Create</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -2,8 +2,8 @@
 
 <resources>
     <!-- Character stats -->
-    <string name="label_armor_class">AC %d</string>
-    <string name="label_hit_points">%d HP</string>
+    <string name="label_armor_class">AC %1$d</string>
+    <string name="label_hit_points">%1$d HP</string>
 
     <!-- Character list -->
     <string name="title_character_list">Characters</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
@@ -6,7 +6,7 @@
     <string name="label_hit_points">%1$d HP</string>
 
     <string name="creature_ac">Armor class</string>
-    <string name="creature_hp">Hit point</string>
+    <string name="creature_hp">Hit points</string>
     <string name="creature_speed">Speed</string>
 
     <!-- Speed types -->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
+    <!-- Creature stats -->
+    <string name="label_armor_class">AC %1$d</string>
+    <string name="label_hit_points">%1$d HP</string>
+
     <string name="creature_ac">Armor class</string>
     <string name="creature_hp">Hit point</string>
     <string name="creature_speed">Speed</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -39,7 +39,11 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.creature.data.SampleMonsterRepository
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.creature.domain.Monster
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.label_armor_class
+import rpg_companion.composeapp.generated.resources.label_hit_points
 
 private val typeIconSize = 36.dp
 private val typeIconPadding = 8.dp
@@ -117,7 +121,7 @@ fun MonsterListItem(
                             modifier = Modifier.size(iconSizeSmall),
                         )
                         Text(
-                            text = "AC ${monster.armorClass}",
+                            text = stringResource(Res.string.label_armor_class, monster.armorClass),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -134,7 +138,7 @@ fun MonsterListItem(
                             modifier = Modifier.size(iconSizeSmall),
                         )
                         Text(
-                            text = "${monster.maxHitPoints} HP",
+                            text = stringResource(Res.string.label_hit_points, monster.maxHitPoints),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )


### PR DESCRIPTION
## 📝 Description

This PR fixes a formatting issue in `CharacterListItem` where AC and HP stats were displaying literal `%d` instead of numeric values. It also refactors the labels to be shared between characters and monsters.

### Changes
- Added positional arguments (`%1$d`) to `label_armor_class` and `label_hit_points` in EN/FR resources.
- Moved these labels from `strings_character.xml` to `strings_creature.xml` for shared usage.
- Updated `MonsterListItem` to use these localized resources instead of hardcoded strings.
- Fixed French translations for consistency.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed