### PR TITLE
feat(character): introduce persistent SQLDelight CharacterRepository

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -19,7 +19,7 @@ import com.cyrillrx.rpg.campaign.data.SQLDelightCampaignRepository
 import com.cyrillrx.rpg.campaign.navigation.handleCampaignRoutes
 import com.cyrillrx.rpg.campaign.navigation.registerCampaignRoutes
 import com.cyrillrx.rpg.character.data.JsonCharacterPresetRepository
-import com.cyrillrx.rpg.character.data.RamCharacterRepository
+import com.cyrillrx.rpg.character.data.SQLDelightCharacterRepository
 import com.cyrillrx.rpg.character.presentation.navigation.handleCharacterRoutes
 import com.cyrillrx.rpg.character.presentation.navigation.registerCharacterRoutes
 import com.cyrillrx.rpg.core.data.ComposeFileReader
@@ -95,7 +95,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
                 handleCharacterRoutes(
                     backStack = backStack,
-                    characterRepository = RamCharacterRepository(),
+                    characterRepository = SQLDelightCharacterRepository(dbDriverFactory),
                     pcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/pc-presets.json"),
                     npcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/npc-presets.json"),
                 )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -95,7 +96,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
                 handleCharacterRoutes(
                     backStack = backStack,
-                    characterRepository = SQLDelightCharacterRepository(dbDriverFactory),
+                    characterRepository = remember(dbDriverFactory) { SQLDelightCharacterRepository(dbDriverFactory) },
                     pcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/pc-presets.json"),
                     npcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/npc-presets.json"),
                 )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -73,7 +73,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
         val backStack = rememberNavBackStack(navSavedStateConfig, MainRoute.Home)
 
         val fileReader = ComposeFileReader()
-        val userListRepository = SQLDelightUserListRepository(dbDriverFactory)
+        val userListRepository = remember(dbDriverFactory) { SQLDelightUserListRepository(dbDriverFactory) }
 
         NavDisplay(
             backStack = backStack,
@@ -93,7 +93,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 val homeRouter = HomeRouterImpl(backStack)
                 entry<MainRoute.Home> { HomeScreen(homeRouter) }
 
-                handleCampaignRoutes(backStack, SQLDelightCampaignRepository(dbDriverFactory))
+                handleCampaignRoutes(backStack, remember(dbDriverFactory) { SQLDelightCampaignRepository(dbDriverFactory) })
                 handleCharacterRoutes(
                     backStack = backStack,
                     characterRepository = remember(dbDriverFactory) { SQLDelightCharacterRepository(dbDriverFactory) },

--- a/cmp-ttrpg-companion/shared/core/build.gradle.kts
+++ b/cmp-ttrpg-companion/shared/core/build.gradle.kts
@@ -53,6 +53,9 @@ kotlin {
         jvmMain.dependencies {
             implementation(libs.sqldelight.jvm)
         }
+        jvmTest.dependencies {
+            implementation(libs.sqldelight.jvm)
+        }
     }
 }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepository.kt
@@ -1,0 +1,32 @@
+package com.cyrillrx.rpg.character.data
+
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.domain.CharacterFilter
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.core.data.cache.Database
+import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
+
+class SQLDelightCharacterRepository(databaseDriverFactory: DatabaseDriverFactory) : CharacterRepository {
+
+    private val database = Database(databaseDriverFactory)
+
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> {
+        val characters = database.getAllCharacters()
+        filter ?: return characters
+        return characters.filter { it.matches(filter) }
+    }
+
+    override suspend fun get(id: String): Character? = database.getCharacter(id)
+
+    override suspend fun getByIds(ids: List<String>): List<Character> {
+        val set = ids.toHashSet()
+        return database.getAllCharacters().filter { it.id in set }
+    }
+
+    override suspend fun save(character: Character) = database.saveCharacter(character)
+
+    override suspend fun delete(id: String) = database.deleteCharacter(id)
+
+    private fun Character.matches(filter: CharacterFilter): Boolean =
+        filter.query.isBlank() || name.contains(filter.query, ignoreCase = true)
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepository.kt
@@ -18,10 +18,8 @@ class SQLDelightCharacterRepository(databaseDriverFactory: DatabaseDriverFactory
 
     override suspend fun get(id: String): Character? = database.getCharacter(id)
 
-    override suspend fun getByIds(ids: List<String>): List<Character> {
-        val set = ids.toHashSet()
-        return database.getAllCharacters().filter { it.id in set }
-    }
+    override suspend fun getByIds(ids: List<String>): List<Character> =
+        database.getCharactersByIds(ids)
 
     override suspend fun save(character: Character) = database.saveCharacter(character)
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -5,7 +5,9 @@ import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class Character(
     override val id: String,
     val name: String,
@@ -24,20 +26,12 @@ data class Character(
     val background: String? = null,
     val currentHitPoints: Int = maxHitPoints,
     val temporaryHitPoints: Int = 0,
-) : Creature(
-    id = id,
-    size = size,
-    alignment = alignment,
-    abilities = abilities,
-    armorClass = armorClass,
-    maxHitPoints = maxHitPoints,
-    speeds = speeds,
-) {
+) : Creature() {
     fun resolveTranslation(locale: String): Translation? = translations[locale]
         ?: translations[FALLBACK_LOCALE]
         ?: translations.values.firstOrNull()
 
-    fun initiativeModifier(): Int = abilities.dex.modifier
+    fun initiativeModifier(): Int = abilities.dex.getModifier()
 
     fun proficiencyBonus(): Int = when (level) {
         in 1..4 -> 2
@@ -48,6 +42,7 @@ data class Character(
         else -> 0
     }
 
+    @Serializable
     data class Translation(
         val shortDescription: String = "",
         val description: String = "",

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -27,6 +27,7 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
         dbQuery.deleteCharacter(id)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun mapCharacterSelecting(id: String, data: String): Character = data.deserialize()
 
     fun getAllCampaigns(): List<Campaign> {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -23,6 +23,9 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
         dbQuery.saveCharacter(id = character.id, data_ = character.serialize())
     }
 
+    fun getCharactersByIds(ids: Collection<String>): List<Character> =
+        dbQuery.selectCharactersByIds(ids, ::mapCharacterSelecting).executeAsList()
+
     fun deleteCharacter(id: String) {
         dbQuery.deleteCharacter(id)
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -1,14 +1,33 @@
 package com.cyrillrx.rpg.core.data.cache
 
+import com.cyrillrx.core.data.deserialize
+import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.cache.AppDatabase
 import com.cyrillrx.rpg.campaign.domain.Campaign
 import com.cyrillrx.rpg.campaign.domain.RuleSet
+import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.userlist.domain.UserList
 import kotlinx.datetime.Instant
 
 internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     private val database = AppDatabase(databaseDriverFactory.createDriver())
     private val dbQuery = database.appDatabaseQueries
+
+    fun getAllCharacters(): List<Character> =
+        dbQuery.selectAllCharacters(::mapCharacterSelecting).executeAsList()
+
+    fun getCharacter(id: String): Character? =
+        dbQuery.selectCharacterById(id, ::mapCharacterSelecting).executeAsOneOrNull()
+
+    fun saveCharacter(character: Character) {
+        dbQuery.saveCharacter(id = character.id, data_ = character.serialize())
+    }
+
+    fun deleteCharacter(id: String) {
+        dbQuery.deleteCharacter(id)
+    }
+
+    private fun mapCharacterSelecting(id: String, data: String): Character = data.deserialize()
 
     fun getAllCampaigns(): List<Campaign> {
         return dbQuery.selectAllCampaigns(::mapCampaignSelecting).executeAsList()

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Abilities.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Abilities.kt
@@ -1,5 +1,8 @@
 package com.cyrillrx.rpg.creature.domain
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 class Abilities(
     val str: Ability,
     val dex: Ability,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Abilities.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Abilities.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.creature.domain
 import kotlinx.serialization.Serializable
 
 @Serializable
-class Abilities(
+data class Abilities(
     val str: Ability,
     val dex: Ability,
     val con: Ability,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
@@ -1,10 +1,13 @@
 package com.cyrillrx.rpg.creature.domain
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 class Ability(
     val value: Int,
     val savingThrowProficiency: Proficiency = Proficiency.NONE,
 ) {
-    val modifier: Int = getModifier(value)
+    fun getModifier(): Int = computeModifier(value)
 
     fun getValueWithModifier(): String = "$value (${getSignedModifier(value)})"
 
@@ -12,11 +15,11 @@ class Ability(
         const val DEFAULT_VALUE = 10
 
         private fun getSignedModifier(abilityValue: Int): String {
-            val modifier = getModifier(abilityValue)
+            val modifier = computeModifier(abilityValue)
             return if (modifier >= 0) "+$modifier" else "$modifier"
         }
 
-        private fun getModifier(abilityValue: Int): Int = when {
+        private fun computeModifier(abilityValue: Int): Int = when {
             abilityValue < 4 -> -4
             abilityValue < 6 -> -3
             abilityValue < 8 -> -2

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
@@ -3,7 +3,7 @@ package com.cyrillrx.rpg.creature.domain
 import kotlinx.serialization.Serializable
 
 @Serializable
-class Ability(
+data class Ability(
     val value: Int,
     val savingThrowProficiency: Proficiency = Proficiency.NONE,
 ) {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Creature.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Creature.kt
@@ -1,14 +1,14 @@
 package com.cyrillrx.rpg.creature.domain
 
-abstract class Creature(
-    open val id: String,
-    open val size: Size,
-    open val alignment: Alignment,
-    open val abilities: Abilities,
-    open val armorClass: Int,
-    open val maxHitPoints: Int,
-    open val speeds: Speeds,
-) {
+abstract class Creature {
+    abstract val id: String
+    abstract val size: Size
+    abstract val alignment: Alignment
+    abstract val abilities: Abilities
+    abstract val armorClass: Int
+    abstract val maxHitPoints: Int
+    abstract val speeds: Speeds
+
     enum class Size {
         TINY,
         SMALL,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
@@ -3,13 +3,13 @@ package com.cyrillrx.rpg.creature.domain
 import com.cyrillrx.core.domain.FALLBACK_LOCALE
 
 class Monster(
-    id: String,
-    size: Size,
-    alignment: Alignment,
-    abilities: Abilities,
-    armorClass: Int,
-    maxHitPoints: Int,
-    speeds: Speeds,
+    override val id: String,
+    override val size: Size,
+    override val alignment: Alignment,
+    override val abilities: Abilities,
+    override val armorClass: Int,
+    override val maxHitPoints: Int,
+    override val speeds: Speeds,
     val source: String,
     val type: Type,
     val challengeRating: Float,
@@ -18,15 +18,7 @@ class Monster(
     val damageAffinities: DamageAffinities = DamageAffinities(),
     val conditionImmunities: ConditionImmunities = ConditionImmunities(),
     val translations: Map<String, Translation>,
-) : Creature(
-    id = id,
-    size = size,
-    alignment = alignment,
-    abilities = abilities,
-    armorClass = armorClass,
-    maxHitPoints = maxHitPoints,
-    speeds = speeds,
-) {
+) : Creature() {
     init {
         require(translations.isNotEmpty()) { "Monster $id must have at least one translation" }
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Skills.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Skills.kt
@@ -1,7 +1,10 @@
 package com.cyrillrx.rpg.creature.domain
 
+import kotlinx.serialization.Serializable
+
 enum class Proficiency { NONE, PROFICIENT, EXPERT }
 
+@Serializable
 data class Skills(
     val acrobatics: Proficiency = Proficiency.NONE,
     val animalHandling: Proficiency = Proficiency.NONE,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Speeds.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Speeds.kt
@@ -1,5 +1,8 @@
 package com.cyrillrx.rpg.creature.domain
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Speeds(
     val walk: Int? = null,
     val fly: Int? = null,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
@@ -17,6 +17,23 @@ DELETE FROM Campaign WHERE id = ?;
 selectAllCampaigns:
 SELECT Campaign.* FROM Campaign;
 
+CREATE TABLE IF NOT EXISTS Character (
+    id TEXT NOT NULL PRIMARY KEY,
+    data TEXT NOT NULL
+);
+
+saveCharacter:
+INSERT OR REPLACE INTO Character(id, data) VALUES(?, ?);
+
+selectAllCharacters:
+SELECT Character.* FROM Character;
+
+selectCharacterById:
+SELECT Character.* FROM Character WHERE id = ?;
+
+deleteCharacter:
+DELETE FROM Character WHERE id = ?;
+
 CREATE TABLE UserList (
     id TEXT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
@@ -31,6 +31,9 @@ SELECT Character.* FROM Character;
 selectCharacterById:
 SELECT Character.* FROM Character WHERE id = ?;
 
+selectCharactersByIds:
+SELECT Character.* FROM Character WHERE id IN ?;
+
 deleteCharacter:
 DELETE FROM Character WHERE id = ?;
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/CharacterSerializationTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/CharacterSerializationTest.kt
@@ -1,0 +1,26 @@
+package com.cyrillrx.rpg.character.data
+
+import com.cyrillrx.core.data.deserialize
+import com.cyrillrx.core.data.serialize
+import com.cyrillrx.rpg.character.domain.Character
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CharacterSerializationTest {
+
+    @Test
+    fun `serializing and deserializing a character preserves all fields`() {
+        val original = SampleCharacterRepository.humanFighter()
+        val roundTripped = original.serialize().deserialize<Character>()
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `currentHitPoints and temporaryHitPoints are preserved after serialization`() {
+        val original = SampleCharacterRepository.humanFighter()
+            .copy(currentHitPoints = 5, temporaryHitPoints = 3)
+        val roundTripped = original.serialize().deserialize<Character>()
+        assertEquals(5, roundTripped.currentHitPoints)
+        assertEquals(3, roundTripped.temporaryHitPoints)
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/jvmTest/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/jvmTest/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepositoryTest.kt
@@ -1,0 +1,94 @@
+package com.cyrillrx.rpg.character.data
+
+import com.cyrillrx.rpg.character.domain.CharacterFilter
+import com.cyrillrx.rpg.core.data.cache.TestDatabaseDriverFactory
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SQLDelightCharacterRepositoryTest {
+
+    private fun buildRepository() = SQLDelightCharacterRepository(TestDatabaseDriverFactory())
+
+    @Test
+    fun `save and getAll returns all saved characters`() = runTest {
+        val repository = buildRepository()
+        val fighter = SampleCharacterRepository.humanFighter()
+        val rogue = SampleCharacterRepository.elfRogue()
+
+        repository.save(fighter)
+        repository.save(rogue)
+
+        val result = repository.getAll(null)
+        assertEquals(2, result.size)
+        assertTrue(result.contains(fighter))
+        assertTrue(result.contains(rogue))
+    }
+
+    @Test
+    fun `get returns character by id`() = runTest {
+        val repository = buildRepository()
+        val fighter = SampleCharacterRepository.humanFighter()
+
+        repository.save(fighter)
+
+        assertEquals(fighter, repository.get(fighter.id))
+    }
+
+    @Test
+    fun `get returns null for unknown id`() = runTest {
+        val repository = buildRepository()
+        assertNull(repository.get("missing"))
+    }
+
+    @Test
+    fun `save updates an existing character`() = runTest {
+        val repository = buildRepository()
+        val fighter = SampleCharacterRepository.humanFighter()
+
+        repository.save(fighter)
+        val updated = fighter.copy(currentHitPoints = 5, temporaryHitPoints = 2)
+        repository.save(updated)
+
+        assertEquals(updated, repository.get(fighter.id))
+    }
+
+    @Test
+    fun `delete removes character by id`() = runTest {
+        val repository = buildRepository()
+        val fighter = SampleCharacterRepository.humanFighter()
+
+        repository.save(fighter)
+        repository.delete(fighter.id)
+
+        assertNull(repository.get(fighter.id))
+        assertTrue(repository.getAll(null).isEmpty())
+    }
+
+    @Test
+    fun `getAll with filter returns only matching characters`() = runTest {
+        val repository = buildRepository()
+        repository.save(SampleCharacterRepository.humanFighter())
+        repository.save(SampleCharacterRepository.elfRogue())
+
+        val result = repository.getAll(CharacterFilter(query = "Lyra"))
+        assertEquals(1, result.size)
+        assertEquals("Lyra Vossen", result.first().name)
+    }
+
+    @Test
+    fun `getByIds returns only the requested characters`() = runTest {
+        val repository = buildRepository()
+        val fighter = SampleCharacterRepository.humanFighter()
+        val rogue = SampleCharacterRepository.elfRogue()
+
+        repository.save(fighter)
+        repository.save(rogue)
+
+        val result = repository.getByIds(listOf(fighter.id))
+        assertEquals(1, result.size)
+        assertEquals(fighter, result.first())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/jvmTest/kotlin/com/cyrillrx/rpg/core/data/cache/TestDatabaseDriverFactory.kt
+++ b/cmp-ttrpg-companion/shared/core/src/jvmTest/kotlin/com/cyrillrx/rpg/core/data/cache/TestDatabaseDriverFactory.kt
@@ -1,0 +1,10 @@
+package com.cyrillrx.rpg.core.data.cache
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.cyrillrx.rpg.cache.AppDatabase
+
+class TestDatabaseDriverFactory : DatabaseDriverFactory {
+    override fun createDriver(): SqlDriver =
+        JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY).also { AppDatabase.Schema.create(it) }
+}


### PR DESCRIPTION
## 📝 Description

Replaces the in-memory `RamCharacterRepository` with a persistent `SQLDelightCharacterRepository` backed by SQLite, so characters survive app restarts.

**What changed:**
- `Creature` refactored to use `abstract val` properties (no constructor params), giving it an implicit no-arg constructor required by kotlinx.serialization
- `Monster` updated to use `override val` for all inherited properties
- `Ability` and `Abilities` promoted to `data class` for structural equality
- `@Serializable` added to `Character`, `Creature`-hierarchy types, `Speeds`, `Skills` — also fixes a pre-existing runtime crash in `CharacterRouterImpl.openCharacterDetail`
- `Character` table added to `AppDatabase.sq` (id + JSON blob)
- Character CRUD methods added to `Database.kt` via `serialize()`/`deserialize()`
- New `SQLDelightCharacterRepository` in `shared/core`
- `App.kt` wired to use `SQLDelightCharacterRepository(dbDriverFactory)`

**Tests added:**
- `CharacterSerializationTest` — roundtrip serialize/deserialize covering all fields including `currentHitPoints` and `temporaryHitPoints`
- `SQLDelightCharacterRepositoryTest` — full CRUD integration test using an in-memory SQLite driver (`TestDatabaseDriverFactory`)
- New `jvmTest` sourceset declared in `shared/core/build.gradle.kts`

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [ ] Documentation updated if public APIs or architecture decisions changed