### PR TITLE
fix(character): refresh character list on screen resume

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
@@ -42,12 +42,17 @@ import rpg_companion.composeapp.generated.resources.hint_search_campaign
 @Composable
 fun CampaignListScreen(viewModel: CampaignListViewModel, router: CampaignRouter) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.silentRefresh()
+    }
+
     CampaignListScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
         onSearchQueryChanged = viewModel::filterByQuery,
-        onCampaignClicked = viewModel::onCampaignClicked,
-        onCreateCampaignClicked = viewModel::onCreateCampaignClicked,
+        onCampaignClicked = viewModel::openCampaignDetail,
+        onCreateCampaignClicked = viewModel::openCreateCampaign,
     )
 }
 
@@ -59,10 +64,6 @@ fun CampaignListScreen(
     onCampaignClicked: (Campaign) -> Unit,
     onCreateCampaignClicked: () -> Unit,
 ) {
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        onSearchQueryChanged(state.searchQuery)
-    }
-
     Scaffold(
         topBar = {
             SearchBarWithBack(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
@@ -45,7 +45,7 @@ fun CampaignListScreen(viewModel: CampaignListViewModel, router: CampaignRouter)
     CampaignListScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
-        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onSearchQueryChanged = viewModel::filterByQuery,
         onCampaignClicked = viewModel::onCampaignClicked,
         onCreateCampaignClicked = viewModel::onCreateCampaignClicked,
     )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -21,8 +21,7 @@ class CampaignListViewModel(
     private val repository: CampaignRepository,
 ) : ViewModel() {
 
-    private var filterJob: Job? = null
-    private var refreshJob: Job? = null
+    private var activeJob: Job? = null
     val state: StateFlow<CampaignListState>
         field = MutableStateFlow(CampaignListState(searchQuery = "", body = CampaignListState.Body.Loading))
 
@@ -31,15 +30,14 @@ class CampaignListViewModel(
     }
 
     fun filterByQuery(query: String) {
-        refreshJob?.cancel()
-        filterJob?.cancel()
-        filterJob = loadCampaigns(query)
+        activeJob?.cancel()
+        activeJob = loadCampaigns(query)
     }
 
     fun silentRefresh() {
         if (state.value.body is CampaignListState.Body.Loading) return
-        filterJob?.cancel()
-        refreshJob = viewModelScope.launch {
+        activeJob?.cancel()
+        activeJob = viewModelScope.launch {
             try {
                 fetchAndUpdateCampaigns(state.value.searchQuery)
             } catch (e: CancellationException) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -25,7 +25,7 @@ class CampaignListViewModel(
     val state: StateFlow<CampaignListState>
         field = MutableStateFlow(CampaignListState(searchQuery = "", body = CampaignListState.Body.Empty))
 
-    fun onSearchQueryChanged(query: String) {
+    fun filterByQuery(query: String) {
         updateJob?.cancel()
         updateJob = viewModelScope.launch { updateData(query) }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -21,38 +21,60 @@ class CampaignListViewModel(
     private val repository: CampaignRepository,
 ) : ViewModel() {
 
-    private var updateJob: Job? = null
+    private var filterJob: Job? = null
     val state: StateFlow<CampaignListState>
-        field = MutableStateFlow(CampaignListState(searchQuery = "", body = CampaignListState.Body.Empty))
+        field = MutableStateFlow(CampaignListState(searchQuery = "", body = CampaignListState.Body.Loading))
 
-    fun filterByQuery(query: String) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData(query) }
+    init {
+        loadCampaigns(query = "")
     }
 
-    fun onCampaignClicked(campaign: Campaign) {
+    fun filterByQuery(query: String) {
+        filterJob?.cancel()
+        filterJob = loadCampaigns(query)
+    }
+
+    fun silentRefresh() {
+        if (state.value.body is CampaignListState.Body.Loading) return
+        viewModelScope.launch {
+            try {
+                fetchAndUpdateCampaigns(state.value.searchQuery)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Keep existing state on refresh failure
+            }
+        }
+    }
+
+    fun openCampaignDetail(campaign: Campaign) {
         router.openCampaignDetail(campaign)
     }
 
-    fun onCreateCampaignClicked() {
+    fun openCreateCampaign() {
         router.openCreateCampaign()
     }
 
-    private suspend fun updateData(query: String) {
-        state.update { CampaignListState(searchQuery = query, body = CampaignListState.Body.Loading) }
-
-        try {
-            val filter = CampaignFilter(query = query)
-            val campaigns = repository.getAll(filter)
-            if (campaigns.isEmpty()) {
-                state.update { it.copy(body = CampaignListState.Body.Empty) }
-            } else {
-                state.update { it.copy(body = CampaignListState.Body.WithData(campaigns)) }
+    private fun loadCampaigns(query: String): Job =
+        viewModelScope.launch {
+            state.update { CampaignListState(searchQuery = query, body = CampaignListState.Body.Loading) }
+            try {
+                fetchAndUpdateCampaigns(query)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                state.update { it.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            state.update { it.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
         }
+
+    private suspend fun fetchAndUpdateCampaigns(query: String) {
+        val filter = CampaignFilter(query = query)
+        val campaigns = repository.getAll(filter)
+        val body = if (campaigns.isEmpty()) {
+            CampaignListState.Body.Empty
+        } else {
+            CampaignListState.Body.WithData(campaigns)
+        }
+        state.update { it.copy(body = body) }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -22,6 +22,7 @@ class CampaignListViewModel(
 ) : ViewModel() {
 
     private var filterJob: Job? = null
+    private var refreshJob: Job? = null
     val state: StateFlow<CampaignListState>
         field = MutableStateFlow(CampaignListState(searchQuery = "", body = CampaignListState.Body.Loading))
 
@@ -30,13 +31,15 @@ class CampaignListViewModel(
     }
 
     fun filterByQuery(query: String) {
+        refreshJob?.cancel()
         filterJob?.cancel()
         filterJob = loadCampaigns(query)
     }
 
     fun silentRefresh() {
         if (state.value.body is CampaignListState.Body.Loading) return
-        viewModelScope.launch {
+        filterJob?.cancel()
+        refreshJob = viewModelScope.launch {
             try {
                 fetchAndUpdateCampaigns(state.value.searchQuery)
             } catch (e: CancellationException) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -37,15 +37,7 @@ class CampaignListViewModel(
     fun silentRefresh() {
         if (state.value.body is CampaignListState.Body.Loading) return
         activeJob?.cancel()
-        activeJob = viewModelScope.launch {
-            try {
-                fetchAndUpdateCampaigns(state.value.searchQuery)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // Keep existing state on refresh failure
-            }
-        }
+        activeJob = refreshCampaigns()
     }
 
     fun openCampaignDetail(campaign: Campaign) {
@@ -55,6 +47,17 @@ class CampaignListViewModel(
     fun openCreateCampaign() {
         router.openCreateCampaign()
     }
+
+    private fun refreshCampaigns(): Job =
+        viewModelScope.launch {
+            try {
+                fetchAndUpdateCampaigns(state.value.searchQuery)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Keep existing state on refresh failure
+            }
+        }
 
     private fun loadCampaigns(query: String): Job =
         viewModelScope.launch {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -59,7 +59,7 @@ fun CharacterListScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        viewModel.onSearchQueryChanged(state.searchQuery)
+        viewModel.silentRefresh()
     }
 
     CharacterListScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
 import com.cyrillrx.rpg.character.domain.Character
@@ -55,6 +57,10 @@ fun CharacterListScreen(
     router: CharacterRouter,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.onSearchQueryChanged(state.searchQuery)
+    }
 
     CharacterListScreen(
         state = state,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -65,9 +65,9 @@ fun CharacterListScreen(
     CharacterListScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
-        onCharacterClicked = viewModel::onCharacterClicked,
-        onNewCharacterClicked = viewModel::onCreateCharacterClicked,
-        onQuickCreateClicked = viewModel::onQuickCreateClicked,
+        onCharacterClicked = viewModel::openCharacterDetail,
+        onNewCharacterClicked = viewModel::openCreateCharacter,
+        onQuickCreateClicked = viewModel::openPresetGallery,
     )
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -20,8 +20,7 @@ class CharacterListViewModel(
     private val router: CharacterRouter,
     private val repository: CharacterRepository,
 ) : ViewModel() {
-    private var filterJob: Job? = null
-    private var refreshJob: Job? = null
+    private var activeJob: Job? = null
     val state: StateFlow<CharacterListState>
         field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Loading))
 
@@ -30,15 +29,14 @@ class CharacterListViewModel(
     }
 
     fun filterByQuery(query: String) {
-        refreshJob?.cancel()
-        filterJob?.cancel()
-        filterJob = loadCharacters(query)
+        activeJob?.cancel()
+        activeJob = loadCharacters(query)
     }
 
     fun silentRefresh() {
         if (state.value.body is CharacterListState.Body.Loading) return
-        filterJob?.cancel()
-        refreshJob = viewModelScope.launch {
+        activeJob?.cancel()
+        activeJob = viewModelScope.launch {
             try {
                 fetchAndUpdateCharacters(state.value.searchQuery)
             } catch (e: CancellationException) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -22,7 +22,7 @@ class CharacterListViewModel(
 ) : ViewModel() {
     private var searchJob: Job? = null
     val state: StateFlow<CharacterListState>
-        field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Empty))
+        field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Loading))
 
     init {
         loadCharacters(query = "")

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -20,17 +20,31 @@ class CharacterListViewModel(
     private val router: CharacterRouter,
     private val repository: CharacterRepository,
 ) : ViewModel() {
-    private var updateJob: Job? = null
+    private var searchJob: Job? = null
     val state: StateFlow<CharacterListState>
         field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Empty))
 
     init {
-        onSearchQueryChanged(query = "")
+        loadCharacters(query = "")
     }
 
     fun onSearchQueryChanged(query: String) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData(query) }
+        searchJob?.cancel()
+        searchJob = loadCharacters(query)
+    }
+
+    fun silentRefresh() {
+        if (state.value.body is CharacterListState.Body.Loading) return
+
+        viewModelScope.launch {
+            try {
+                fetchAndUpdateCharacters(state.value.searchQuery)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Keep existing state on refresh failure
+            }
+        }
     }
 
     fun onCharacterClicked(character: Character) {
@@ -45,21 +59,26 @@ class CharacterListViewModel(
         router.openPresetGallery()
     }
 
-    private suspend fun updateData(query: String) {
-        state.update { CharacterListState(searchQuery = query, body = CharacterListState.Body.Loading) }
-
-        try {
-            val filter = CharacterFilter(query = query)
-            val characters = repository.getAll(filter)
-            if (characters.isEmpty()) {
-                state.update { it.copy(body = CharacterListState.Body.Empty) }
-            } else {
-                state.update { it.copy(body = CharacterListState.Body.WithData(characters)) }
+    private fun loadCharacters(query: String): Job =
+        viewModelScope.launch {
+            state.update { CharacterListState(searchQuery = query, body = CharacterListState.Body.Loading) }
+            try {
+                fetchAndUpdateCharacters(query)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                state.update { it.copy(body = CharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            state.update { it.copy(body = CharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
         }
+
+    private suspend fun fetchAndUpdateCharacters(query: String) {
+        val filter = CharacterFilter(query = query)
+        val characters = repository.getAll(filter)
+        val body = if (characters.isEmpty()) {
+            CharacterListState.Body.Empty
+        } else {
+            CharacterListState.Body.WithData(characters)
+        }
+        state.update { it.copy(body = body) }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -21,6 +21,7 @@ class CharacterListViewModel(
     private val repository: CharacterRepository,
 ) : ViewModel() {
     private var filterJob: Job? = null
+    private var refreshJob: Job? = null
     val state: StateFlow<CharacterListState>
         field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Loading))
 
@@ -29,14 +30,15 @@ class CharacterListViewModel(
     }
 
     fun filterByQuery(query: String) {
+        refreshJob?.cancel()
         filterJob?.cancel()
         filterJob = loadCharacters(query)
     }
 
     fun silentRefresh() {
         if (state.value.body is CharacterListState.Body.Loading) return
-
-        viewModelScope.launch {
+        filterJob?.cancel()
+        refreshJob = viewModelScope.launch {
             try {
                 fetchAndUpdateCharacters(state.value.searchQuery)
             } catch (e: CancellationException) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -47,15 +47,15 @@ class CharacterListViewModel(
         }
     }
 
-    fun onCharacterClicked(character: Character) {
+    fun openCharacterDetail(character: Character) {
         router.openCharacterDetail(character)
     }
 
-    fun onCreateCharacterClicked() {
+    fun openCreateCharacter() {
         router.openCreateCharacter()
     }
 
-    fun onQuickCreateClicked() {
+    fun openPresetGallery() {
         router.openPresetGallery()
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -36,15 +36,7 @@ class CharacterListViewModel(
     fun silentRefresh() {
         if (state.value.body is CharacterListState.Body.Loading) return
         activeJob?.cancel()
-        activeJob = viewModelScope.launch {
-            try {
-                fetchAndUpdateCharacters(state.value.searchQuery)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // Keep existing state on refresh failure
-            }
-        }
+        activeJob = refreshCharacters()
     }
 
     fun openCharacterDetail(character: Character) {
@@ -58,6 +50,17 @@ class CharacterListViewModel(
     fun openPresetGallery() {
         router.openPresetGallery()
     }
+
+    private fun refreshCharacters(): Job =
+        viewModelScope.launch {
+            try {
+                fetchAndUpdateCharacters(state.value.searchQuery)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Keep existing state on refresh failure
+            }
+        }
 
     private fun loadCharacters(query: String): Job =
         viewModelScope.launch {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -20,7 +20,7 @@ class CharacterListViewModel(
     private val router: CharacterRouter,
     private val repository: CharacterRepository,
 ) : ViewModel() {
-    private var searchJob: Job? = null
+    private var filterJob: Job? = null
     val state: StateFlow<CharacterListState>
         field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Loading))
 
@@ -28,9 +28,9 @@ class CharacterListViewModel(
         loadCharacters(query = "")
     }
 
-    fun onSearchQueryChanged(query: String) {
-        searchJob?.cancel()
-        searchJob = loadCharacters(query)
+    fun filterByQuery(query: String) {
+        filterJob?.cancel()
+        filterJob = loadCharacters(query)
     }
 
     fun silentRefresh() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListScreen.kt
@@ -51,7 +51,7 @@ fun MonsterListScreen(
     MonsterListScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
-        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onSearchQueryChanged = viewModel::filterByQuery,
         onMonsterClicked = viewModel::onMonsterClicked,
         onTypeToggled = viewModel::onTypeToggled,
         onChallengeRatingToggled = viewModel::onChallengeRatingToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
@@ -30,7 +30,7 @@ class MonsterListViewModel(
         refreshData()
     }
 
-    fun onSearchQueryChanged(query: String) {
+    fun filterByQuery(query: String) {
         updateFilter { it.copy(query = query) }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCardCarouselScreen.kt
@@ -38,7 +38,7 @@ fun MagicalItemCardCarouselScreen(viewModel: MagicalItemListViewModel, router: M
     MagicalItemCardCarouselScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
-        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onSearchQueryChanged = viewModel::filterByQuery,
         onMagicalItemClicked = viewModel::onItemClicked,
         onTypeToggled = viewModel::onTypeToggled,
         onRarityToggled = viewModel::onRarityToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -52,7 +52,7 @@ fun MagicalItemListScreen(
     MagicalItemListScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
-        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onSearchQueryChanged = viewModel::filterByQuery,
         onMagicalItemClicked = viewModel::onItemClicked,
         onTypeToggled = viewModel::onTypeToggled,
         onRarityToggled = viewModel::onRarityToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -30,7 +30,7 @@ class MagicalItemListViewModel(
         refreshData()
     }
 
-    fun onSearchQueryChanged(query: String) {
+    fun filterByQuery(query: String) {
         updateFilter { it.copy(query = query) }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -40,7 +40,7 @@ fun SpellCardCarouselScreen(viewModel: SpellListViewModel, router: SpellRouter) 
     SpellCardCarouselScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
-        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onSearchQueryChanged = viewModel::filterByQuery,
         onSpellClicked = { spell -> router.openDetail(spell.id) },
         onLevelToggled = viewModel::onLevelToggled,
         onSchoolToggled = viewModel::onSchoolToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -53,7 +53,7 @@ fun SpellListScreen(
     SpellListScreen(
         state = state,
         onNavigateUpClicked = router::navigateUp,
-        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onSearchQueryChanged = viewModel::filterByQuery,
         onSpellClicked = { spell -> router.openDetail(spell.id) },
         onLevelToggled = viewModel::onLevelToggled,
         onSchoolToggled = viewModel::onSchoolToggled,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -31,7 +31,7 @@ class SpellListViewModel(
         refreshData()
     }
 
-    fun onSearchQueryChanged(query: String) {
+    fun filterByQuery(query: String) {
         updateFilter { it.copy(query = query) }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModelTest.kt
@@ -1,0 +1,234 @@
+package com.cyrillrx.rpg.campaign.list.viewmodel
+
+import com.cyrillrx.rpg.campaign.domain.Campaign
+import com.cyrillrx.rpg.campaign.domain.CampaignFilter
+import com.cyrillrx.rpg.campaign.domain.CampaignRepository
+import com.cyrillrx.rpg.campaign.domain.RuleSet
+import com.cyrillrx.rpg.campaign.list.CampaignListState
+import com.cyrillrx.rpg.campaign.navigation.CampaignRouter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CampaignListViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = TestCampaignRepository()
+    private val router = NoOpCampaignRouter()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun buildViewModel(
+        repo: CampaignRepository = repository,
+        router: CampaignRouter = this.router,
+    ) = CampaignListViewModel(router, repo)
+
+    @Test
+    fun `initial state is Loading before coroutines run`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        assertIs<CampaignListState.Body.Loading>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `state is Error when repository throws`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel(FailingCampaignRepository())
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<CampaignListState.Body.Error>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `initial state is Empty when no campaigns exist`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<CampaignListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `initial state is WithData when campaigns exist`() = runTest(testDispatcher) {
+        repository.save(Campaign("1", "Campaign 1", RuleSet.DND5E))
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val body = assertIs<CampaignListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(expected = 1, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `silentRefresh updates state with fresh data without showing Loading`() = runTest(testDispatcher) {
+        repository.save(Campaign("1", "Campaign 1", RuleSet.DND5E))
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        repository.save(Campaign("2", "Campaign 2", RuleSet.PATHFINDER_2E))
+
+        val emittedBodies = mutableListOf<CampaignListState.Body>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { emittedBodies.add(it.body) }
+        }
+
+        viewModel.silentRefresh()
+        advanceUntilIdle()
+
+        assertTrue(emittedBodies.none { it is CampaignListState.Body.Loading })
+        val body = assertIs<CampaignListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(expected = 2, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `silentRefresh does nothing when state is already Loading`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        assertIs<CampaignListState.Body.Loading>(viewModel.state.value.body)
+
+        viewModel.silentRefresh()
+
+        assertIs<CampaignListState.Body.Loading>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `silentRefresh keeps existing state when repository throws`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel(FailsOnSecondCallCampaignRepository())
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<CampaignListState.Body.Empty>(viewModel.state.value.body)
+
+        viewModel.silentRefresh()
+        advanceUntilIdle()
+
+        assertIs<CampaignListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `filterByQuery updates searchQuery in state`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.filterByQuery("dnd")
+        advanceUntilIdle()
+
+        assertEquals(expected = "dnd", actual = viewModel.state.value.searchQuery)
+    }
+
+    @Test
+    fun `openCampaignDetail delegates to router`() = runTest(testDispatcher) {
+        val trackingRouter = TrackingCampaignRouter()
+        val campaign = Campaign("1", "Campaign 1", RuleSet.DND5E)
+        repository.save(campaign)
+
+        val viewModel = buildViewModel(router = trackingRouter)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.openCampaignDetail(campaign)
+
+        assertTrue(trackingRouter.openedCampaigns.contains(campaign))
+    }
+}
+
+private class NoOpCampaignRouter : CampaignRouter {
+    override fun navigateUp() = Unit
+    override fun openCampaignDetail(campaign: Campaign) = Unit
+    override fun openCreateCampaign() = Unit
+}
+
+private class TrackingCampaignRouter : CampaignRouter {
+    val openedCampaigns = mutableListOf<Campaign>()
+
+    override fun navigateUp() = Unit
+    override fun openCampaignDetail(campaign: Campaign) { openedCampaigns.add(campaign) }
+    override fun openCreateCampaign() = Unit
+}
+
+private class TestCampaignRepository : CampaignRepository {
+    private val campaigns = mutableListOf<Campaign>()
+
+    override suspend fun getAll(filter: CampaignFilter?): List<Campaign> {
+        filter ?: return campaigns
+        val query = filter.query
+        return if (query.isBlank()) campaigns else campaigns.filter { it.name.contains(query, ignoreCase = true) }
+    }
+
+    override suspend fun get(id: String): Campaign? = campaigns.find { it.id == id }
+    override suspend fun save(campaign: Campaign) { campaigns.add(campaign) }
+    override suspend fun delete(id: String) { campaigns.removeAll { it.id == id } }
+}
+
+private class FailingCampaignRepository : CampaignRepository {
+    override suspend fun getAll(filter: CampaignFilter?): List<Campaign> = error("Repository error")
+    override suspend fun get(id: String): Campaign? = error("Repository error")
+    override suspend fun save(campaign: Campaign) = error("Repository error")
+    override suspend fun delete(id: String) = error("Repository error")
+}
+
+private class FailsOnSecondCallCampaignRepository : CampaignRepository {
+    private var callCount = 0
+
+    override suspend fun getAll(filter: CampaignFilter?): List<Campaign> {
+        if (callCount++ == 0) return emptyList()
+        error("Repository error")
+    }
+
+    override suspend fun get(id: String): Campaign? = null
+    override suspend fun save(campaign: Campaign) = Unit
+    override suspend fun delete(id: String) = Unit
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModelTest.kt
@@ -183,6 +183,16 @@ class CampaignListViewModelTest {
 
         assertTrue(trackingRouter.openedCampaigns.contains(campaign))
     }
+
+    @Test
+    fun `openCreateCampaign delegates to router`() = runTest(testDispatcher) {
+        val trackingRouter = TrackingCampaignRouter()
+        val viewModel = buildViewModel(router = trackingRouter)
+
+        viewModel.openCreateCampaign()
+
+        assertTrue(trackingRouter.createCampaignCalled)
+    }
 }
 
 private class NoOpCampaignRouter : CampaignRouter {
@@ -193,10 +203,11 @@ private class NoOpCampaignRouter : CampaignRouter {
 
 private class TrackingCampaignRouter : CampaignRouter {
     val openedCampaigns = mutableListOf<Campaign>()
+    var createCampaignCalled = false
 
     override fun navigateUp() = Unit
     override fun openCampaignDetail(campaign: Campaign) { openedCampaigns.add(campaign) }
-    override fun openCreateCampaign() = Unit
+    override fun openCreateCampaign() { createCampaignCalled = true }
 }
 
 private class TestCampaignRepository : CampaignRepository {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -40,8 +40,10 @@ class CharacterListViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun buildViewModel(repo: CharacterRepository = repository) =
-        CharacterListViewModel(router, repo)
+    private fun buildViewModel(
+        repo: CharacterRepository = repository,
+        router: CharacterRouter = this.router,
+    ) = CharacterListViewModel(router, repo)
 
     @Test
     fun `initial state is Loading before coroutines run`() = runTest(testDispatcher) {
@@ -123,31 +125,6 @@ class CharacterListViewModelTest {
     }
 
     @Test
-    fun `silentRefresh does not show Loading when data is present`() = runTest(testDispatcher) {
-        val character = SampleCharacterRepository.getAll().first()
-        repository.save(character)
-
-        val viewModel = buildViewModel()
-
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            viewModel.state.collect {}
-        }
-
-        advanceUntilIdle()
-        assertIs<CharacterListState.Body.WithData>(viewModel.state.value.body)
-
-        val emittedBodies = mutableListOf<CharacterListState.Body>()
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            viewModel.state.collect { emittedBodies.add(it.body) }
-        }
-
-        viewModel.silentRefresh()
-        advanceUntilIdle()
-
-        assertTrue(emittedBodies.none { it is CharacterListState.Body.Loading })
-    }
-
-    @Test
     fun `silentRefresh does nothing when state is already Loading`() = runTest(testDispatcher) {
         val viewModel = buildViewModel()
 
@@ -157,11 +134,55 @@ class CharacterListViewModelTest {
 
         assertIs<CharacterListState.Body.Loading>(viewModel.state.value.body)
     }
+
+    @Test
+    fun `onSearchQueryChanged updates searchQuery in state`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.onSearchQueryChanged("fire")
+        advanceUntilIdle()
+
+        assertEquals(expected = "fire", actual = viewModel.state.value.searchQuery)
+    }
+
+    @Test
+    fun `openCharacterDetail delegates to router`() = runTest(testDispatcher) {
+        val trackingRouter = TrackingCharacterRouter()
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel(router = trackingRouter)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.openCharacterDetail(character)
+
+        assertTrue(trackingRouter.openedCharacters.contains(character))
+    }
 }
 
 private class NoOpCharacterRouter : CharacterRouter {
     override fun navigateUp() = Unit
     override fun openCharacterDetail(character: Character) = Unit
+    override fun openCreateCharacter() = Unit
+    override fun openPresetGallery() = Unit
+}
+
+private class TrackingCharacterRouter : CharacterRouter {
+    val openedCharacters = mutableListOf<Character>()
+
+    override fun navigateUp() = Unit
+    override fun openCharacterDetail(character: Character) { openedCharacters.add(character) }
     override fun openCreateCharacter() = Unit
     override fun openPresetGallery() = Unit
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -136,6 +136,24 @@ class CharacterListViewModelTest {
     }
 
     @Test
+    fun `silentRefresh keeps existing state when repository throws`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel(FailsOnSecondCallCharacterRepository())
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<CharacterListState.Body.Empty>(viewModel.state.value.body)
+
+        viewModel.silentRefresh()
+        advanceUntilIdle()
+
+        assertIs<CharacterListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
     fun `filterByQuery updates searchQuery in state`() = runTest(testDispatcher) {
         val viewModel = buildViewModel()
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -136,7 +136,7 @@ class CharacterListViewModelTest {
     }
 
     @Test
-    fun `onSearchQueryChanged updates searchQuery in state`() = runTest(testDispatcher) {
+    fun `filterByQuery updates searchQuery in state`() = runTest(testDispatcher) {
         val viewModel = buildViewModel()
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -145,7 +145,7 @@ class CharacterListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.onSearchQueryChanged("fire")
+        viewModel.filterByQuery("fire")
         advanceUntilIdle()
 
         assertEquals(expected = "fire", actual = viewModel.state.value.searchQuery)

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -1,0 +1,175 @@
+package com.cyrillrx.rpg.character.presentation.viewmodel
+
+import com.cyrillrx.rpg.character.data.RamCharacterRepository
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.character.domain.CharacterFilter
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.character.presentation.CharacterListState
+import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CharacterListViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = RamCharacterRepository()
+    private val router = NoOpCharacterRouter()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun buildViewModel(repo: CharacterRepository = repository) =
+        CharacterListViewModel(router, repo)
+
+    @Test
+    fun `initial state is Loading before coroutines run`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        assertIs<CharacterListState.Body.Loading>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `state is Error when repository throws`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel(FailingCharacterRepository())
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<CharacterListState.Body.Error>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `initial state is Empty when no characters exist`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        assertIs<CharacterListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `initial state is WithData when characters exist`() = runTest(testDispatcher) {
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val body = assertIs<CharacterListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(expected = 1, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `silentRefresh updates state with fresh data without showing Loading`() = runTest(testDispatcher) {
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val newCharacter = SampleCharacterRepository.getAll().last()
+        repository.save(newCharacter)
+
+        val emittedBodies = mutableListOf<CharacterListState.Body>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { emittedBodies.add(it.body) }
+        }
+
+        viewModel.silentRefresh()
+        advanceUntilIdle()
+
+        assertTrue(emittedBodies.none { it is CharacterListState.Body.Loading })
+        val body = assertIs<CharacterListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(expected = 2, actual = body.searchResults.size)
+    }
+
+    @Test
+    fun `silentRefresh does not show Loading when data is present`() = runTest(testDispatcher) {
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+        assertIs<CharacterListState.Body.WithData>(viewModel.state.value.body)
+
+        val emittedBodies = mutableListOf<CharacterListState.Body>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { emittedBodies.add(it.body) }
+        }
+
+        viewModel.silentRefresh()
+        advanceUntilIdle()
+
+        assertTrue(emittedBodies.none { it is CharacterListState.Body.Loading })
+    }
+
+    @Test
+    fun `silentRefresh does nothing when state is already Loading`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel()
+
+        assertIs<CharacterListState.Body.Loading>(viewModel.state.value.body)
+
+        viewModel.silentRefresh()
+
+        assertIs<CharacterListState.Body.Loading>(viewModel.state.value.body)
+    }
+}
+
+private class NoOpCharacterRouter : CharacterRouter {
+    override fun navigateUp() = Unit
+    override fun openCharacterDetail(character: Character) = Unit
+    override fun openCreateCharacter() = Unit
+    override fun openPresetGallery() = Unit
+}
+
+private class FailingCharacterRepository : CharacterRepository {
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> = error("Repository error")
+    override suspend fun get(id: String): Character? = error("Repository error")
+    override suspend fun getByIds(ids: List<String>): List<Character> = error("Repository error")
+    override suspend fun save(character: Character) = error("Repository error")
+    override suspend fun delete(id: String) = error("Repository error")
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -187,6 +187,26 @@ class CharacterListViewModelTest {
 
         assertTrue(trackingRouter.openedCharacters.contains(character))
     }
+
+    @Test
+    fun `openCreateCharacter delegates to router`() = runTest(testDispatcher) {
+        val trackingRouter = TrackingCharacterRouter()
+        val viewModel = buildViewModel(router = trackingRouter)
+
+        viewModel.openCreateCharacter()
+
+        assertTrue(trackingRouter.createCharacterCalled)
+    }
+
+    @Test
+    fun `openPresetGallery delegates to router`() = runTest(testDispatcher) {
+        val trackingRouter = TrackingCharacterRouter()
+        val viewModel = buildViewModel(router = trackingRouter)
+
+        viewModel.openPresetGallery()
+
+        assertTrue(trackingRouter.presetGalleryCalled)
+    }
 }
 
 private class NoOpCharacterRouter : CharacterRouter {
@@ -198,11 +218,13 @@ private class NoOpCharacterRouter : CharacterRouter {
 
 private class TrackingCharacterRouter : CharacterRouter {
     val openedCharacters = mutableListOf<Character>()
+    var createCharacterCalled = false
+    var presetGalleryCalled = false
 
     override fun navigateUp() = Unit
     override fun openCharacterDetail(character: Character) { openedCharacters.add(character) }
-    override fun openCreateCharacter() = Unit
-    override fun openPresetGallery() = Unit
+    override fun openCreateCharacter() { createCharacterCalled = true }
+    override fun openPresetGallery() { presetGalleryCalled = true }
 }
 
 private class FailingCharacterRepository : CharacterRepository {
@@ -211,4 +233,18 @@ private class FailingCharacterRepository : CharacterRepository {
     override suspend fun getByIds(ids: List<String>): List<Character> = error("Repository error")
     override suspend fun save(character: Character) = error("Repository error")
     override suspend fun delete(id: String) = error("Repository error")
+}
+
+private class FailsOnSecondCallCharacterRepository : CharacterRepository {
+    private var callCount = 0
+
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> {
+        if (callCount++ == 0) return emptyList()
+        error("Repository error")
+    }
+
+    override suspend fun get(id: String): Character? = null
+    override suspend fun getByIds(ids: List<String>): List<Character> = emptyList()
+    override suspend fun save(character: Character) = Unit
+    override suspend fun delete(id: String) = Unit
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterDetailViewModelTest.kt
@@ -22,8 +22,8 @@ import kotlin.test.assertIs
 class MonsterDetailViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
-    val repository = SampleMonsterRepository()
-    val monster = SampleMonsterRepository.getFirst()
+    private val repository = SampleMonsterRepository()
+    private val monster = SampleMonsterRepository.getFirst()
 
     @BeforeTest
     fun setUp() {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
@@ -98,7 +98,7 @@ class MonsterListViewModelTest {
     }
 
     @Test
-    fun `onSearchQueryChanged filters monsters by name`() = runTest(testDispatcher) {
+    fun `filterByQuery filters monsters by name`() = runTest(testDispatcher) {
         val viewModel = MonsterListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -107,7 +107,7 @@ class MonsterListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.onSearchQueryChanged(goblin.resolveTranslation("en").name)
+        viewModel.filterByQuery(goblin.resolveTranslation("en").name)
 
         advanceUntilIdle()
 
@@ -153,7 +153,7 @@ class MonsterListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.onSearchQueryChanged("no_match")
+        viewModel.filterByQuery("no_match")
 
         advanceUntilIdle()
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -97,7 +97,7 @@ class MagicalItemListViewModelTest {
     }
 
     @Test
-    fun `onSearchQueryChanged filters items by title`() = runTest(testDispatcher) {
+    fun `filterByQuery filters items by title`() = runTest(testDispatcher) {
         val viewModel = MagicalItemListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -107,7 +107,7 @@ class MagicalItemListViewModelTest {
         advanceUntilIdle()
 
         val itemName = item.resolveTranslation("en").name
-        viewModel.onSearchQueryChanged(itemName)
+        viewModel.filterByQuery(itemName)
 
         advanceUntilIdle()
 
@@ -153,7 +153,7 @@ class MagicalItemListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.onSearchQueryChanged("no_match")
+        viewModel.filterByQuery("no_match")
 
         advanceUntilIdle()
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
@@ -116,7 +116,7 @@ class SpellListViewModelTest {
     }
 
     @Test
-    fun `onSearchQueryChanged filters spells by title`() = runTest(testDispatcher) {
+    fun `filterByQuery filters spells by title`() = runTest(testDispatcher) {
         val viewModel = SpellListViewModel(router, repository)
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -126,7 +126,7 @@ class SpellListViewModelTest {
         advanceUntilIdle()
 
         val spellName = requireNotNull(spell.translations["en"]).name
-        viewModel.onSearchQueryChanged(spellName)
+        viewModel.filterByQuery(spellName)
 
         advanceUntilIdle()
 
@@ -172,7 +172,7 @@ class SpellListViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.onSearchQueryChanged("no_match")
+        viewModel.filterByQuery("no_match")
 
         advanceUntilIdle()
 

--- a/docs/conventions/kmp-conventions.md
+++ b/docs/conventions/kmp-conventions.md
@@ -29,9 +29,29 @@ The application follows a **Clean Architecture** and **Layered** approach adapte
 - **Use Model-View-ViewModel (MVVM)**.
 - **Follow Unidirectional Data Flow (UDF)**:
     - State flows down: ViewModels expose a single `StateFlow<ViewState>`.
-    - Events flow up: Composables pass user actions to the ViewModel via specific functions (e.g., `viewModel::onActionClicked`).
+    - Events flow up: Composables pass user actions to the ViewModel via lambda callbacks (e.g., `onCreateCampaignClicked = viewModel::openCreateCampaign`).
 - **Keep ViewModels platform-agnostic** using `lifecycle-viewmodel-compose` from JetBrains.
 - **Do not pass ViewModels down the Composable tree**. Pass state and lambda callbacks instead.
+
+### ViewModel Method Naming
+
+ViewModel public methods must reflect **behavior** (what the app does), not the UI event that triggered them. Composable callback parameters keep the UI-event convention because they are generic lambda slots.
+
+| Context                       | Convention                     | Examples                                           |
+|-------------------------------|--------------------------------|----------------------------------------------------|
+| Composable callback parameter | `onXxxClicked`, `onXxxChanged` | `onCreateCampaignClicked`, `onSearchQueryChanged`  |
+| ViewModel public method       | Functional verb phrase         | `openCreateCampaign`, `filterByQuery`, `silentRefresh` |
+
+```kotlin
+// ✅ Correct — callback param name ≠ ViewModel method name
+fun CampaignListScreen(viewModel: CampaignListViewModel, router: CampaignRouter) {
+    CampaignListScreen(
+        onSearchQueryChanged = viewModel::filterByQuery,
+        onCampaignClicked = viewModel::openCampaignDetail,
+        onCreateCampaignClicked = viewModel::openCreateCampaign,
+    )
+}
+```
 
 ### Domain & Data Layers
 

--- a/docs/conventions/kmp-conventions.md
+++ b/docs/conventions/kmp-conventions.md
@@ -57,6 +57,42 @@ The project enforces code formatting using **ktlint**.
 - **Previews**: Write `@Preview` functions for all UI components. Use `androidx.compose.ui.tooling.preview.Preview` from `org.jetbrains.compose.ui:ui-tooling-preview` module for Multiplatform previews.
 - **Resources**: Use the generated KMP resources (`Res.string.xxx`, `Res.drawable.xxx`).
 
+### Lifecycle-aware Refresh
+
+Screens that display mutable data (persisted in a repository) must refresh when the user returns to the screen via `LifecycleEventEffect(Lifecycle.Event.ON_RESUME)`. Use `silentRefresh()` — never the full load function — to avoid a flicker when data is already visible.
+
+**ViewModel** — every ViewModel with `ON_RESUME` refresh must expose two distinct operations:
+
+| Method                     | Sets `Loading` | Purpose                                                                                           |
+|----------------------------|----------------|---------------------------------------------------------------------------------------------------|
+| `loadXxx()` (private)      | ✅ Yes         | Initial load from `init`, or after an explicit user action (search query change, pull-to-refresh) |
+| `silentRefresh()` (public) | ❌ No          | Called by the screen on `ON_RESUME`; no-ops when state is already `Loading`                       |
+
+```kotlin
+fun silentRefresh() {
+    if (state.value.body is XxxState.Body.Loading) return
+    viewModelScope.launch {
+        try {
+            fetchAndUpdate()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Keep existing state on refresh failure
+        }
+    }
+}
+```
+
+**Screen** — wire `silentRefresh()` to `ON_RESUME`:
+
+```kotlin
+LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+    viewModel.silentRefresh()
+}
+```
+
+Never call a load function (e.g., `onSearchQueryChanged`) from `ON_RESUME`: the `init` block already handles the initial load, so doing so causes a redundant double fetch and an unnecessary `Loading` flash on every back-navigation.
+
 ## 4. Testing
 
 ### Rules


### PR DESCRIPTION
## 📝 Description

After adding a character via the preset gallery, the list was not refreshing until the app was restarted. The `CharacterListViewModel` loaded characters once in its `init` block, but the existing ViewModel was reused on navigation back — so the new character never appeared.

The fix introduces a `silentRefresh()` method on `CharacterListViewModel`, following the pattern already established in `UserListsViewModel` and `ListDetailViewModel`. `LifecycleEventEffect(ON_RESUME)` in `CharacterListScreen` triggers `silentRefresh()` instead of the full load, avoiding the double-fetch on initial launch and the `Loading` flash on back-navigation.

This PR also takes the opportunity to align the ViewModel public APIs and test coverage across list ViewModels:

- **Renamed** `onCharacterClicked` / `onCreateCharacterClicked` / `onQuickCreateClicked` → `openCharacterDetail` / `openCreateCharacter` / `openPresetGallery` — ViewModel methods now expose behavior, not UI events (consistent with `UserListsViewModel.openList`)
- **Renamed** `onSearchQueryChanged` → `filterByQuery` across all 5 list ViewModels and their screens
- **Added** `CharacterListViewModelTest` with full coverage (Loading, Error, Empty, WithData, silentRefresh ×4, filterByQuery, router delegation)
- **Aligned** `CampaignListViewModel` on the same pattern: `silentRefresh()`, `loadCampaigns` / `fetchAndUpdateCampaigns` split, initial state set to `Loading`, method renames (`openCampaignDetail`, `openCreateCampaign`)
- **Fixed** `CampaignListScreen`: moved `LifecycleEventEffect(ON_RESUME)` to the ViewModel-aware overload, calling `silentRefresh()` instead of `filterByQuery`
- **Added** `CampaignListViewModelTest` with full coverage (Loading, Error, Empty, WithData, silentRefresh ×3, filterByQuery, router delegation)
- **Fixed** missing `private` visibility on fields in `MonsterDetailViewModelTest`
- **Documented** the lifecycle-aware refresh convention and ViewModel method naming convention in `docs/conventions/kmp-conventions.md`

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed