### PR TITLE
feat(character): inline name editing with BasicTextField and auto-focus

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterEditState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CharacterEditState.kt
@@ -32,7 +32,6 @@ sealed interface CharacterEditState {
         val editingField: EditingField? = null,
     ) : CharacterEditState {
         sealed interface EditingField {
-            data object Name : EditingField
             data object Race : EditingField
             data object Clazz : EditingField
             data object Level : EditingField

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -140,7 +140,7 @@ fun CharacterDetailScreen(
                 level = state.level,
                 background = state.background,
                 alignment = state.alignment,
-                onNameTapped = { onFieldTapped(EditingField.Name) },
+                onNameConfirmed = onNameConfirmed,
                 onClassTapped = { onFieldTapped(EditingField.Clazz) },
                 onRaceTapped = { onFieldTapped(EditingField.Race) },
                 onLevelTapped = { onFieldTapped(EditingField.Level) },
@@ -192,7 +192,6 @@ fun CharacterDetailScreen(
 
     CharacterEditDialog(
         state = state,
-        onNameConfirmed = onNameConfirmed,
         onRaceConfirmed = onRaceConfirmed,
         onClassConfirmed = onClassConfirmed,
         onLevelConfirmed = onLevelConfirmed,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.character.presentation.component
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +17,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
 import com.cyrillrx.rpg.character.domain.Character
@@ -125,10 +128,12 @@ fun CharacterDetailScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
+        val focusManager = LocalFocusManager.current
         Column(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
+                .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
                 .verticalScroll(rememberScrollState())
                 .padding(spacingCommon),
             verticalArrangement = Arrangement.spacedBy(spacingMedium),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -133,7 +133,7 @@ fun CharacterDetailScreen(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
-                .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
+                .pointerInput(focusManager) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
                 .verticalScroll(rememberScrollState())
                 .padding(spacingCommon),
             verticalArrangement = Arrangement.spacedBy(spacingMedium),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -133,7 +133,7 @@ fun CharacterDetailScreen(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
-                .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
+                .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
                 .verticalScroll(rememberScrollState())
                 .padding(spacingCommon),
             verticalArrangement = Arrangement.spacedBy(spacingMedium),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -44,7 +44,6 @@ import rpg_companion.composeapp.generated.resources.label_int
 import rpg_companion.composeapp.generated.resources.label_languages
 import rpg_companion.composeapp.generated.resources.label_level
 import rpg_companion.composeapp.generated.resources.label_max_hp
-import rpg_companion.composeapp.generated.resources.label_name
 import rpg_companion.composeapp.generated.resources.label_race
 import rpg_companion.composeapp.generated.resources.label_str
 import rpg_companion.composeapp.generated.resources.label_walk_speed
@@ -53,7 +52,6 @@ import rpg_companion.composeapp.generated.resources.label_wis
 @Composable
 internal fun CharacterEditDialog(
     state: CharacterEditState.Loaded,
-    onNameConfirmed: (String) -> Unit,
     onRaceConfirmed: (Race) -> Unit,
     onClassConfirmed: (Character.Class) -> Unit,
     onLevelConfirmed: (Int) -> Unit,
@@ -74,14 +72,6 @@ internal fun CharacterEditDialog(
     val field = state.editingField ?: return
 
     when (field) {
-        EditingField.Name -> TextEditDialog(
-            title = stringResource(Res.string.label_name),
-            initialValue = state.name,
-            onConfirm = onNameConfirmed,
-            onDismiss = onDismiss,
-            isValid = { it.isNotBlank() },
-        )
-
         EditingField.Background -> TextEditDialog(
             title = stringResource(Res.string.label_background),
             initialValue = state.background,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -12,6 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material.icons.filled.Warning
@@ -19,13 +22,22 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextDecoration
 import coil3.compose.AsyncImage
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
@@ -59,7 +71,7 @@ internal fun CharacterHeader(
     level: Int,
     background: String,
     alignment: Creature.Alignment,
-    onNameTapped: () -> Unit,
+    onNameConfirmed: (String) -> Unit,
     onClassTapped: () -> Unit,
     onRaceTapped: () -> Unit,
     onLevelTapped: () -> Unit,
@@ -74,11 +86,11 @@ internal fun CharacterHeader(
     ) {
         ClassIconBox(clazz = clazz, onClick = onClassTapped)
         Column(modifier = Modifier.weight(1f)) {
-            Text(
+            InlineEditableText(
                 text = name,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.clickable(onClick = onNameTapped),
+                onConfirmed = onNameConfirmed,
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.fillMaxWidth(),
             )
             Spacer(Modifier.height(spacingSmall))
             Row(
@@ -176,6 +188,49 @@ internal suspend fun resolveClassIconState(
 }
 
 @Composable
+private fun InlineEditableText(
+    text: String,
+    onConfirmed: (String) -> Unit,
+    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    modifier: Modifier = Modifier,
+) {
+    var isEditing by remember { mutableStateOf(false) }
+    var draft by remember(text) { mutableStateOf(text) }
+    val focusRequester = remember { FocusRequester() }
+
+    fun commit() {
+        val trimmed = draft.trim()
+        if (trimmed.isNotBlank()) onConfirmed(trimmed) else draft = text
+        isEditing = false
+    }
+
+    if (isEditing) {
+        var hasFocused by remember { mutableStateOf(false) }
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+        BasicTextField(
+            value = draft,
+            onValueChange = { draft = it },
+            textStyle = style.copy(color = MaterialTheme.colorScheme.onSurface),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { commit() }),
+            modifier = modifier
+                .focusRequester(focusRequester)
+                .onFocusChanged { fs ->
+                    if (fs.isFocused) hasFocused = true
+                    else if (hasFocused) commit()
+                },
+        )
+    } else {
+        Text(
+            text = text,
+            style = style,
+            modifier = modifier.clickable { isEditing = true },
+        )
+    }
+}
+
+@Composable
 private fun SubtitleChip(text: String, onClick: () -> Unit) {
     Text(
         text = text,
@@ -219,7 +274,7 @@ private fun CharacterHeaderPreview() {
         level = state.level,
         background = state.background,
         alignment = state.alignment,
-        onNameTapped = {},
+        onNameConfirmed = {},
         onClassTapped = {},
         onRaceTapped = {},
         onLevelTapped = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -199,7 +199,10 @@ private fun InlineEditableText(
 ) {
     var isEditing by remember { mutableStateOf(false) }
     var draft by remember(text) { mutableStateOf(TextFieldValue(text, TextRange(text.length))) }
+    var hasFocused by remember(isEditing) { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(isEditing) { if (isEditing) focusRequester.requestFocus() }
 
     fun commit() {
         if (!isEditing) return
@@ -210,8 +213,6 @@ private fun InlineEditableText(
     }
 
     if (isEditing) {
-        var hasFocused by remember { mutableStateOf(false) }
-        LaunchedEffect(Unit) { focusRequester.requestFocus() }
         BasicTextField(
             value = draft,
             onValueChange = { draft = it },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -198,11 +198,16 @@ private fun InlineEditableText(
     modifier: Modifier = Modifier,
 ) {
     var isEditing by remember { mutableStateOf(false) }
-    var draft by remember(text) { mutableStateOf(TextFieldValue(text, TextRange(text.length))) }
+    var draft by remember { mutableStateOf(TextFieldValue(text, TextRange(text.length))) }
     var hasFocused by remember(isEditing) { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
 
-    LaunchedEffect(isEditing) { if (isEditing) focusRequester.requestFocus() }
+    LaunchedEffect(isEditing) {
+        if (isEditing) {
+            draft = TextFieldValue(text, TextRange(text.length))
+            focusRequester.requestFocus()
+        }
+    }
 
     fun commit() {
         if (!isEditing) return

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -194,7 +194,7 @@ internal suspend fun resolveClassIconState(
 private fun InlineEditableText(
     text: String,
     onConfirmed: (String) -> Unit,
-    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    style: TextStyle,
     modifier: Modifier = Modifier,
 ) {
     var isEditing by remember { mutableStateOf(false) }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -201,9 +201,11 @@ private fun InlineEditableText(
     val focusRequester = remember { FocusRequester() }
 
     fun commit() {
-        val trimmed = draft.text.trim()
-        if (trimmed.isNotBlank()) onConfirmed(trimmed) else draft = TextFieldValue(text, TextRange(text.length))
+        if (!isEditing) return
+
         isEditing = false
+        val trimmed = draft.text.trim()
+        if (trimmed.isNotBlank() && trimmed != text) onConfirmed(trimmed)
     }
 
     if (isEditing) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -215,13 +216,14 @@ private fun InlineEditableText(
             value = draft,
             onValueChange = { draft = it },
             textStyle = style.copy(color = MaterialTheme.colorScheme.onSurface),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(onDone = { commit() }),
             modifier = modifier
                 .focusRequester(focusRequester)
-                .onFocusChanged { fs ->
-                    if (fs.isFocused) hasFocused = true
+                .onFocusChanged { focusState ->
+                    if (focusState.isFocused) hasFocused = true
                     else if (hasFocused) commit()
                 },
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -35,9 +35,11 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 import coil3.compose.AsyncImage
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
@@ -195,12 +197,12 @@ private fun InlineEditableText(
     modifier: Modifier = Modifier,
 ) {
     var isEditing by remember { mutableStateOf(false) }
-    var draft by remember(text) { mutableStateOf(text) }
+    var draft by remember(text) { mutableStateOf(TextFieldValue(text, TextRange(text.length))) }
     val focusRequester = remember { FocusRequester() }
 
     fun commit() {
-        val trimmed = draft.trim()
-        if (trimmed.isNotBlank()) onConfirmed(trimmed) else draft = text
+        val trimmed = draft.text.trim()
+        if (trimmed.isNotBlank()) onConfirmed(trimmed) else draft = TextFieldValue(text, TextRange(text.length))
         isEditing = false
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
@@ -105,7 +105,6 @@ class CharacterEditViewModelTest {
         viewModel.saveName("   ")
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
         assertEquals(fighter.name, loaded.name)
-        assertNull(loaded.editingField)
     }
 
     @Test

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
@@ -99,10 +99,9 @@ class CharacterEditViewModelTest {
     // ─── saveName ──────────────────────────────────────────────────────────────
 
     @Test
-    fun `saveName with blank input cancels editing without updating name`() = runTest(testDispatcher) {
+    fun `saveName with blank input does not update name`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        viewModel.editField(EditingField.Race)
         viewModel.saveName("   ")
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
         assertEquals(fighter.name, loaded.name)

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
@@ -81,16 +81,16 @@ class CharacterEditViewModelTest {
     fun `editField sets editingField`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        viewModel.editField(EditingField.Name)
+        viewModel.editField(EditingField.Race)
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
-        assertEquals(EditingField.Name, loaded.editingField)
+        assertEquals(EditingField.Race, loaded.editingField)
     }
 
     @Test
     fun `cancelEditing clears editingField`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        viewModel.editField(EditingField.Name)
+        viewModel.editField(EditingField.Race)
         viewModel.cancelEditing()
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
         assertNull(loaded.editingField)
@@ -102,7 +102,7 @@ class CharacterEditViewModelTest {
     fun `saveName with blank input cancels editing without updating name`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        viewModel.editField(EditingField.Name)
+        viewModel.editField(EditingField.Race)
         viewModel.saveName("   ")
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
         assertEquals(fighter.name, loaded.name)

--- a/docs/conventions/coding-conventions.md
+++ b/docs/conventions/coding-conventions.md
@@ -48,6 +48,7 @@ Refer to `../../AGENTS.md` for overall project guidelines.
 - **Automated Formatting**: Rely 100% on formatters (`ktlint`, `rustfmt`). If the CI pipeline passes, the formatting is correct. No debates.
 - **Newspaper Metaphor**: Put high-level concepts at the top of the file, increasing detail as you read downward.
 - **Keep Related Code Close**: Group related concepts vertically. Declare local variables right before their first use.
+- **Early Return Spacing**: Always leave a blank line after an early return (guard clause) to visually separate the guard from the function body.
 
 ## 7. Objects and Data Structures
 


### PR DESCRIPTION
## 📝 Description

Replace the `EditingField.Name → AlertDialog` flow with in-place editing directly inside `CharacterHeader`.

**What changes:**
- Tapping the character name activates a new private `InlineEditableText` composable backed by `BasicTextField`
- Auto-focuses on entry (`FocusRequester` + `LaunchedEffect`)
- Cursor is placed at the end of the existing text (`TextFieldValue` + `TextRange(text.length)`)
- Commits on `ImeAction.Done` or focus loss; reverts silently if the input is blank
- Tapping anywhere outside clears focus via `detectTapGestures` + `focusManager.clearFocus()` on the parent `Column`, which also dismisses the IME
- `EditingField.Name` removed from the sealed interface; the `Name → TextEditDialog` branch removed from `CharacterEditDialog`

## 🖼️ Media

https://github.com/user-attachments/assets/a84d87a4-67b8-4059-8071-fe15150808f6

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [ ] Documentation updated if public APIs or architecture decisions changed