### PR TITLE
docs(agents): improve address-review skill reply endpoint and review note

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -87,16 +87,19 @@ Wait for the user to confirm, adjust, or override each recommendation before pro
 
 For each thread, apply the outcome and post a reply via the GitHub REST API.
 
-For **inline** review comments (attached to a file and line):
+For **inline** review comments (attached to a file and line), use `in_reply_to`:
 
 ```bash
-gh api repos/<OWNER>/<REPO>/pulls/comments/<COMMENT_DATABASE_ID>/replies \
-  -X POST -f body="<reply>"
+gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments \
+  -X POST -f body="<reply>" -F in_reply_to=<COMMENT_DATABASE_ID>
 ```
 
 Use the `databaseId` of the **first** comment in the thread as `<COMMENT_DATABASE_ID>`.
 
-For **general** PR comments (no associated file/line — the above endpoint returns 404):
+> Do **not** use `POST /pulls/comments/{id}/replies` — it returns 404 for comments
+> created by bots (Gemini, CodeRabbit, etc.) and is unreliable in general.
+
+For **general** PR comments (no associated file/line):
 
 ```bash
 gh api repos/<OWNER>/<REPO>/issues/<PR_NUMBER>/comments \
@@ -143,7 +146,10 @@ mutation($threadId:ID!) {
 
 ### Step 7 — Re-run /review
 
-Invoke the `/review` skill with the same PR number to verify the state of the PR after fixes:
+Invoke the `/review` skill with the same PR number to verify the state of the PR after fixes.
+
+> `/review` reads the full diff and all touched files — run it in a **fresh context**
+> (`/clear` first) to avoid stale context inflating token usage.
 
 ```
 /review <PR_NUMBER>

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -146,10 +146,11 @@ mutation($threadId:ID!) {
 
 ### Step 7 — Re-run /review
 
-Invoke the `/review` skill with the same PR number to verify the state of the PR after fixes.
+Before invoking `/review`, suggest to the user that they run `/clear` first to start a
+fresh context — `/review` reads the full diff and all touched files, so stale context
+inflates token usage unnecessarily. Do **not** run `/clear` yourself.
 
-> `/review` reads the full diff and all touched files — run it in a **fresh context**
-> (`/clear` first) to avoid stale context inflating token usage.
+Then invoke the `/review` skill with the same PR number:
 
 ```
 /review <PR_NUMBER>


### PR DESCRIPTION
## 📝 Description

Two improvements to the `/address-review` skill based on real-world friction encountered during PR #107.

**Reply endpoint (Step 4)**
Replace `POST /pulls/comments/{id}/replies` with `in_reply_to` via `POST /pulls/{pr}/comments`.
The old endpoint returns 404 for comments created by bots (Gemini, CodeRabbit, etc.) and is unreliable in general.
The `in_reply_to` approach works consistently for all comment types.

**Fresh context for /review (Step 7)**
Add an instruction for the agent to *suggest* `/clear` to the user before running `/review` — not to run it itself.
`/review` reads the full diff and all touched files; a fresh context avoids stale context inflating token usage unnecessarily.
The agent cannot call `/clear` autonomously (not in `allowed-tools`) and doing so mid-task would reset the conversation.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed