### PR TITLE
docs: update roadmap and PRD-002 with character sheet progress

### DIFF
--- a/docs/prd/prd-002-character-sheet.md
+++ b/docs/prd/prd-002-character-sheet.md
@@ -37,18 +37,18 @@ Campaign integration (attaching sheets to a campaign, sharing with other players
 ### Phase 1 — MVP (Offline)
 
 **General Info**
-- [ ] Character name
-- [ ] Race / Ancestry
-- [ ] Class(es) and level
-- [ ] Background
-- [ ] Alignment
+- [x] Character name
+- [x] Race / Ancestry
+- [x] Class(es) and level
+- [x] Background
+- [x] Alignment
 
 **Ability Scores & Modifiers**
-- [ ] The six core stats: Strength, Dexterity, Constitution, Intelligence, Wisdom, Charisma
-- [ ] Auto-calculated modifiers from scores
+- [x] The six core stats: Strength, Dexterity, Constitution, Intelligence, Wisdom, Charisma
+- [x] Auto-calculated modifiers from scores
 
 **Combat Stats**
-- [ ] Armor Class (AC)
+- [x] Armor Class (AC)
 - [ ] Initiative (calculated from DEX modifier by default; trait/feat bonuses handled in a later phase)
 - [ ] Speed
 - [ ] Current HP, Maximum HP, Temporary HP

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,11 +50,15 @@ For detailed feature specifications, see the [PRDs](prd/).
   - [x] Basic character info (name, race, class, background, alignment)
   - [x] Ability scores
   - [ ] Combat stats
-  - [ ] Speed (base speed, in feets and meters)
+    - [x] Max hit points
+    - [x] Armor class
+    - [ ] Initiative
+    - [ ] Speed (base speed, in feet and meters)
+    - [ ] Current hit points
   - [ ] Skills
   - [ ] Combat actions
   - [ ] Inventory
-- [x] Persist `Character` with SQLDelight (currently RAM only)
+- [x] Persist `Character` with SQLDelight
 - [ ] Sync character sheets with backend
 
 ## Phase 6 - Notes

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,14 @@ For detailed feature specifications, see the [PRDs](prd/).
 > Allow users to create and manage character sheets. - [PRD-002](prd/prd-002-character-sheet.md)
 
 - [ ] Create, list and edit character sheets
-- [ ] Persist `Character` with SQLDelight (currently RAM only)
+  - [x] Basic character info (name, race, class, background, alignment)
+  - [x] Ability scores
+  - [ ] Combat stats
+  - [ ] Speed (base speed, in feets and meters)
+  - [ ] Skills
+  - [ ] Combat actions
+  - [ ] Inventory
+- [x] Persist `Character` with SQLDelight (currently RAM only)
 - [ ] Sync character sheets with backend
 
 ## Phase 6 - Notes


### PR DESCRIPTION
## 📝 Description

Updates the roadmap and PRD-002 to reflect the character sheet work completed in #105, #106, and #107.

**`docs/prd/prd-002-character-sheet.md`** — Mark as completed:
- General Info: character name, race, class, background, alignment
- Ability Scores: six core stats and auto-calculated modifiers
- Combat Stats: Armor Class (AC)

**`docs/roadmap.md`** — Break down "Create, list and edit character sheets" into granular subtasks:
- Basic character info ✓, ability scores ✓, SQLDelight persistence ✓
- Combat stats expanded into sub-items: max HP ✓, AC ✓, initiative ☐, speed ☐, current HP ☐
- Speed entry moved under Combat stats and typo fixed (`feets` → `feet`)
- Stale note `(currently RAM only)` removed from SQLDelight entry

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed