### PR TITLE
feat(character): add initiative block in combat row

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -28,6 +28,7 @@
     <string name="label_cha">CHA</string>
     <string name="label_combat">Combat</string>
     <string name="label_ac">CA</string>
+    <string name="label_initiative">Initiative</string>
     <string name="label_max_hp">PV max</string>
     <string name="label_walk_speed">Vitesse (ft)</string>
     <string name="label_languages">Langues</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -28,6 +28,7 @@
     <string name="label_cha">CHA</string>
     <string name="label_combat">Combat</string>
     <string name="label_ac">AC</string>
+    <string name="label_initiative">Initiative</string>
     <string name="label_max_hp">Max HP</string>
     <string name="label_walk_speed">Walk speed (ft)</string>
     <string name="label_languages">Languages</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -174,6 +174,7 @@ fun CharacterDetailScreen(
 
             CombatRow(
                 armorClass = state.armorClass,
+                dexterity = state.dexterity,
                 maxHitPoints = state.maxHitPoints,
                 onAcTapped = { onFieldTapped(EditingField.ArmorClass) },
                 onMaxHpTapped = { onFieldTapped(EditingField.MaxHitPoints) },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -34,6 +32,7 @@ import rpg_companion.composeapp.generated.resources.label_ac
 import rpg_companion.composeapp.generated.resources.label_cha
 import rpg_companion.composeapp.generated.resources.label_con
 import rpg_companion.composeapp.generated.resources.label_dex
+import rpg_companion.composeapp.generated.resources.label_initiative
 import rpg_companion.composeapp.generated.resources.label_int
 import rpg_companion.composeapp.generated.resources.label_languages
 import rpg_companion.composeapp.generated.resources.label_max_hp
@@ -164,6 +163,7 @@ private fun AbilityCard(
 @Composable
 internal fun CombatRow(
     armorClass: Int,
+    dexterity: Int,
     maxHitPoints: Int,
     onAcTapped: () -> Unit,
     onMaxHpTapped: () -> Unit,
@@ -179,6 +179,11 @@ internal fun CombatRow(
             modifier = Modifier.weight(1f),
         )
         StatCard(
+            label = stringResource(Res.string.label_initiative),
+            value = Ability(dexterity).getModifier().toSignedString(),
+            modifier = Modifier.weight(1f),
+        )
+        StatCard(
             label = stringResource(Res.string.label_max_hp),
             value = maxHitPoints.toString(),
             onClick = onMaxHpTapped,
@@ -191,13 +196,10 @@ internal fun CombatRow(
 private fun StatCard(
     label: String,
     value: String,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
-    ElevatedCard(
-        onClick = onClick,
-        modifier = modifier,
-    ) {
+    val cardContent: @Composable () -> Unit = {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
@@ -215,6 +217,11 @@ private fun StatCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+    if (onClick == null) {
+        ElevatedCard(modifier = modifier, content = { cardContent() })
+    } else {
+        ElevatedCard(onClick = onClick, modifier = modifier, content = { cardContent() })
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.cyrillrx.rpg.character.domain.Language
+import com.cyrillrx.rpg.core.domain.toSignedString
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth
@@ -129,8 +130,7 @@ private fun AbilityCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val abilityModifier = Ability(score).getModifier()
-    val modifierText = if (abilityModifier >= 0) "+$abilityModifier" else "$abilityModifier"
+    val modifierText = Ability(score).getModifier().toSignedString()
 
     ElevatedCard(
         onClick = onClick,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.character.presentation.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -199,7 +200,7 @@ private fun StatCard(
     onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
-    val cardContent: @Composable () -> Unit = {
+    val cardContent: @Composable ColumnScope.() -> Unit = {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
@@ -219,9 +220,9 @@ private fun StatCard(
         }
     }
     if (onClick == null) {
-        ElevatedCard(modifier = modifier, content = { cardContent() })
+        ElevatedCard(modifier = modifier, content = cardContent)
     } else {
-        ElevatedCard(onClick = onClick, modifier = modifier, content = { cardContent() })
+        ElevatedCard(onClick = onClick, modifier = modifier, content = cardContent)
     }
 }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/domain/NumberExt.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/domain/NumberExt.kt
@@ -1,0 +1,3 @@
+package com.cyrillrx.rpg.core.domain
+
+fun Int.toSignedString(): String = if (this >= 0) "+$this" else "$this"

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.creature.domain
 
+import com.cyrillrx.rpg.core.domain.toSignedString
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -9,15 +10,10 @@ data class Ability(
 ) {
     fun getModifier(): Int = computeModifier(value)
 
-    fun getValueWithModifier(): String = "$value (${getSignedModifier(value)})"
+    fun getValueWithModifier(): String = "$value (${getModifier().toSignedString()})"
 
     companion object {
         const val DEFAULT_VALUE = 10
-
-        private fun getSignedModifier(abilityValue: Int): String {
-            val modifier = computeModifier(abilityValue)
-            return if (modifier >= 0) "+$modifier" else "$modifier"
-        }
 
         private fun computeModifier(abilityValue: Int): Int = when {
             abilityValue < 4 -> -4

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/core/domain/NumberExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/core/domain/NumberExtTest.kt
@@ -1,0 +1,22 @@
+package com.cyrillrx.rpg.core.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NumberExtTest {
+
+    @Test
+    fun `toSignedString prefixes positive number with plus`() {
+        assertEquals(expected = "+2", actual = 2.toSignedString())
+    }
+
+    @Test
+    fun `toSignedString prefixes zero with plus`() {
+        assertEquals(expected = "+0", actual = 0.toSignedString())
+    }
+
+    @Test
+    fun `toSignedString keeps minus sign for negative number`() {
+        assertEquals(expected = "-1", actual = (-1).toSignedString())
+    }
+}


### PR DESCRIPTION
## 📝 Description

Adds a read-only Initiative block between AC and Max HP in the Combat section of the character sheet.

Initiative is automatically derived from the Dexterity modifier and displayed as a signed value (e.g. `+2`, `-1`, `0`).

This PR also extracts the signed modifier formatting logic into a shared `Int.toSignedString()` extension, removing duplication between `Ability.getValueWithModifier()` and `AbilityCard`.

## 🖼️ Media

<img width="406" height="632" alt="image" src="https://github.com/user-attachments/assets/748a7fb0-abf9-40a2-b137-2cdf4ee7417d" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed