### PR TITLE
feat(character): convert background from String to Background enum

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/pc-presets.json
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/files/pc-presets.json
@@ -7,7 +7,7 @@
     "level": 1,
     "size": "medium",
     "alignment": "lawful_good",
-    "background": "Acolyte",
+    "background": "acolyte",
     "abilities": {
       "str": 14,
       "dex": 8,
@@ -52,7 +52,7 @@
     "level": 1,
     "size": "medium",
     "alignment": "neutral",
-    "background": "Soldier",
+    "background": "soldier",
     "abilities": {
       "str": 16,
       "dex": 12,
@@ -93,7 +93,7 @@
     "level": 1,
     "size": "medium",
     "alignment": "chaotic_neutral",
-    "background": "Urchin",
+    "background": "urchin",
     "abilities": {
       "str": 8,
       "dex": 18,
@@ -139,7 +139,7 @@
     "level": 1,
     "size": "medium",
     "alignment": "neutral_good",
-    "background": "Sage",
+    "background": "sage",
     "abilities": {
       "str": 8,
       "dex": 14,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -46,6 +46,22 @@
     <string name="race_gnome">Gnome</string>
     <string name="race_tiefling">Tieffelin</string>
 
+    <!-- Character backgrounds -->
+    <string name="background_none">Aucun</string>
+    <string name="background_acolyte">Acolyte</string>
+    <string name="background_charlatan">Charlatan</string>
+    <string name="background_criminal">Criminel</string>
+    <string name="background_entertainer">Artiste</string>
+    <string name="background_folk_hero">Héros du peuple</string>
+    <string name="background_guild_artisan">Artisan de guilde</string>
+    <string name="background_hermit">Ermite</string>
+    <string name="background_noble">Noble</string>
+    <string name="background_outlander">Hors-la-loi</string>
+    <string name="background_sage">Sage</string>
+    <string name="background_sailor">Marin</string>
+    <string name="background_soldier">Soldat</string>
+    <string name="background_urchin">Enfant des rues</string>
+
     <!-- Languages -->
     <string name="language_abyssal">Abyssal</string>
     <string name="language_celestial">Céleste</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -46,6 +46,22 @@
     <string name="race_gnome">Gnome</string>
     <string name="race_tiefling">Tiefling</string>
 
+    <!-- Character backgrounds -->
+    <string name="background_none">None</string>
+    <string name="background_acolyte">Acolyte</string>
+    <string name="background_charlatan">Charlatan</string>
+    <string name="background_criminal">Criminal</string>
+    <string name="background_entertainer">Entertainer</string>
+    <string name="background_folk_hero">Folk Hero</string>
+    <string name="background_guild_artisan">Guild Artisan</string>
+    <string name="background_hermit">Hermit</string>
+    <string name="background_noble">Noble</string>
+    <string name="background_outlander">Outlander</string>
+    <string name="background_sage">Sage</string>
+    <string name="background_sailor">Sailor</string>
+    <string name="background_soldier">Soldier</string>
+    <string name="background_urchin">Urchin</string>
+
     <!-- Languages -->
     <string name="language_abyssal">Abyssal</string>
     <string name="language_celestial">Celestial</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -145,7 +145,7 @@ fun CharacterDetailScreen(
                 race = state.character.race,
                 clazz = state.character.clazz,
                 level = state.character.level,
-                background = state.character.background?.toFormattedString().orEmpty(),
+                background = state.character.background.toFormattedString(),
                 alignment = state.character.alignment,
                 onNameConfirmed = onNameConfirmed,
                 onClassTapped = { onFieldTapped(EditingField.Clazz) },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -21,9 +21,11 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
 import com.cyrillrx.rpg.character.domain.Race
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
@@ -104,7 +106,7 @@ fun CharacterDetailScreen(
     onRaceConfirmed: (Race) -> Unit,
     onClassConfirmed: (Character.Class) -> Unit,
     onLevelConfirmed: (Int) -> Unit,
-    onBackgroundConfirmed: (String) -> Unit,
+    onBackgroundConfirmed: (Background?) -> Unit,
     onStrengthConfirmed: (Int) -> Unit,
     onDexterityConfirmed: (Int) -> Unit,
     onConstitutionConfirmed: (Int) -> Unit,
@@ -143,7 +145,7 @@ fun CharacterDetailScreen(
                 race = state.character.race,
                 clazz = state.character.clazz,
                 level = state.character.level,
-                background = state.character.background.orEmpty(),
+                background = state.character.background?.toFormattedString().orEmpty(),
                 alignment = state.character.alignment,
                 onNameConfirmed = onNameConfirmed,
                 onClassTapped = { onFieldTapped(EditingField.Clazz) },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -281,7 +281,6 @@ private fun <T : Any> SingleChoiceDialog(
     onConfirm: (T?) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var current by remember { mutableStateOf(selected) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
@@ -290,18 +289,18 @@ private fun <T : Any> SingleChoiceDialog(
                 if (noneLabel != null) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth().clickable { current = null },
+                        modifier = Modifier.fillMaxWidth().clickable { onConfirm(null) },
                     ) {
-                        RadioButton(selected = current == null, onClick = null)
+                        RadioButton(selected = selected == null, onClick = null)
                         Text(text = noneLabel, style = MaterialTheme.typography.bodyMedium)
                     }
                 }
                 options.forEach { option ->
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth().clickable { current = option },
+                        modifier = Modifier.fillMaxWidth().clickable { onConfirm(option) },
                     ) {
-                        RadioButton(selected = current == option, onClick = null)
+                        RadioButton(selected = selected == option, onClick = null)
                         Text(
                             text = optionLabel(option),
                             style = MaterialTheme.typography.bodyMedium,
@@ -310,11 +309,7 @@ private fun <T : Any> SingleChoiceDialog(
                 }
             }
         },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(current) }) {
-                Text(stringResource(Res.string.btn_confirm))
-            }
-        },
+        confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(Res.string.btn_cancel))

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.character.presentation.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,11 +33,11 @@ import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.creature.domain.Creature
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.background_none
 import rpg_companion.composeapp.generated.resources.btn_cancel
 import rpg_companion.composeapp.generated.resources.btn_confirm
 import rpg_companion.composeapp.generated.resources.label_ac
 import rpg_companion.composeapp.generated.resources.label_alignment
-import rpg_companion.composeapp.generated.resources.background_none
 import rpg_companion.composeapp.generated.resources.label_background
 import rpg_companion.composeapp.generated.resources.label_cha
 import rpg_companion.composeapp.generated.resources.label_class
@@ -74,8 +75,12 @@ internal fun CharacterEditDialog(
     val field = state.editingField ?: return
 
     when (field) {
-        EditingField.Background -> BackgroundSelectDialog(
-            current = state.character.background,
+        EditingField.Background -> SingleChoiceDialog(
+            title = stringResource(Res.string.label_background),
+            selected = state.character.background,
+            options = Background.entries,
+            optionLabel = { it.toFormattedString() },
+            noneLabel = stringResource(Res.string.background_none),
             onConfirm = onBackgroundConfirmed,
             onDismiss = onDismiss,
         )
@@ -150,15 +155,21 @@ internal fun CharacterEditDialog(
             onDismiss = onDismiss,
         )
 
-        EditingField.Race -> RaceSelectDialog(
-            current = state.character.race,
-            onConfirm = onRaceConfirmed,
+        EditingField.Race -> SingleChoiceDialog(
+            title = stringResource(Res.string.label_race),
+            selected = state.character.race,
+            options = Race.entries,
+            optionLabel = { it.toFormattedString() },
+            onConfirm = { it?.let(onRaceConfirmed) },
             onDismiss = onDismiss,
         )
 
-        EditingField.Clazz -> ClassSelectDialog(
-            current = state.character.clazz,
-            onConfirm = onClassConfirmed,
+        EditingField.Clazz -> SingleChoiceDialog(
+            title = stringResource(Res.string.label_class),
+            selected = state.character.clazz,
+            options = Character.Class.entries,
+            optionLabel = { it.toFormattedString() },
+            onConfirm = { it?.let(onClassConfirmed) },
             onDismiss = onDismiss,
         )
 
@@ -168,9 +179,12 @@ internal fun CharacterEditDialog(
             onDismiss = onDismiss,
         )
 
-        EditingField.Alignment -> AlignmentSelectDialog(
-            current = state.character.alignment,
-            onConfirm = onAlignmentConfirmed,
+        EditingField.Alignment -> SingleChoiceDialog(
+            title = stringResource(Res.string.label_alignment),
+            selected = state.character.alignment,
+            options = Creature.Alignment.entries,
+            optionLabel = { it.toFormattedString() },
+            onConfirm = { it?.let(onAlignmentConfirmed) },
             onDismiss = onDismiss,
         )
     }
@@ -258,41 +272,38 @@ private fun NumberEditDialog(
 }
 
 @Composable
-private fun BackgroundSelectDialog(
-    current: Background?,
-    onConfirm: (Background?) -> Unit,
+private fun <T : Any> SingleChoiceDialog(
+    title: String,
+    selected: T?,
+    options: List<T>,
+    optionLabel: @Composable (T) -> String,
+    noneLabel: String? = null,
+    onConfirm: (T?) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var selected by remember { mutableStateOf(current) }
+    var current by remember { mutableStateOf(selected) }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.label_background)) },
+        title = { Text(title) },
         text = {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    RadioButton(
-                        selected = selected == null,
-                        onClick = { selected = null },
-                    )
-                    Text(
-                        text = stringResource(Res.string.background_none),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-                Background.entries.forEach { background ->
+                if (noneLabel != null) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth().clickable { current = null },
                     ) {
-                        RadioButton(
-                            selected = selected == background,
-                            onClick = { selected = background },
-                        )
+                        RadioButton(selected = current == null, onClick = null)
+                        Text(text = noneLabel, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+                options.forEach { option ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth().clickable { current = option },
+                    ) {
+                        RadioButton(selected = current == option, onClick = null)
                         Text(
-                            text = background.toFormattedString(),
+                            text = optionLabel(option),
                             style = MaterialTheme.typography.bodyMedium,
                         )
                     }
@@ -300,133 +311,7 @@ private fun BackgroundSelectDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(selected) }) {
-                Text(stringResource(Res.string.btn_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.btn_cancel))
-            }
-        },
-    )
-}
-
-@Composable
-private fun RaceSelectDialog(
-    current: Race,
-    onConfirm: (Race) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    var selected by remember { mutableStateOf(current) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.label_race)) },
-        text = {
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                Race.entries.forEach { race ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        RadioButton(
-                            selected = selected == race,
-                            onClick = { selected = race },
-                        )
-                        Text(
-                            text = race.toFormattedString(),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(selected) }) {
-                Text(stringResource(Res.string.btn_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.btn_cancel))
-            }
-        },
-    )
-}
-
-@Composable
-private fun ClassSelectDialog(
-    current: Character.Class,
-    onConfirm: (Character.Class) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    var selected by remember { mutableStateOf(current) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.label_class)) },
-        text = {
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                Character.Class.entries.forEach { clazz ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        RadioButton(
-                            selected = selected == clazz,
-                            onClick = { selected = clazz },
-                        )
-                        Text(
-                            text = clazz.toFormattedString(),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(selected) }) {
-                Text(stringResource(Res.string.btn_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.btn_cancel))
-            }
-        },
-    )
-}
-
-@Composable
-private fun AlignmentSelectDialog(
-    current: Creature.Alignment,
-    onConfirm: (Creature.Alignment) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    var selected by remember { mutableStateOf(current) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.label_alignment)) },
-        text = {
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                Creature.Alignment.entries.forEach { alignment ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        RadioButton(
-                            selected = selected == alignment,
-                            onClick = { selected = alignment },
-                        )
-                        Text(
-                            text = alignment.toFormattedString(),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(selected) }) {
+            TextButton(onClick = { onConfirm(current) }) {
                 Text(stringResource(Res.string.btn_confirm))
             }
         },
@@ -453,13 +338,13 @@ private fun LanguageSelectDialog(
                 Language.entries.forEach { language ->
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth().clickable {
+                            selected = if (language in selected) selected - language else selected + language
+                        },
                     ) {
                         Checkbox(
                             checked = language in selected,
-                            onCheckedChange = { checked ->
-                                selected = if (checked) selected + language else selected - language
-                            },
+                            onCheckedChange = null,
                         )
                         Text(
                             text = language.toFormattedString(),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
 import com.cyrillrx.rpg.character.domain.Race
@@ -35,6 +36,7 @@ import rpg_companion.composeapp.generated.resources.btn_cancel
 import rpg_companion.composeapp.generated.resources.btn_confirm
 import rpg_companion.composeapp.generated.resources.label_ac
 import rpg_companion.composeapp.generated.resources.label_alignment
+import rpg_companion.composeapp.generated.resources.background_none
 import rpg_companion.composeapp.generated.resources.label_background
 import rpg_companion.composeapp.generated.resources.label_cha
 import rpg_companion.composeapp.generated.resources.label_class
@@ -55,7 +57,7 @@ internal fun CharacterEditDialog(
     onRaceConfirmed: (Race) -> Unit,
     onClassConfirmed: (Character.Class) -> Unit,
     onLevelConfirmed: (Int) -> Unit,
-    onBackgroundConfirmed: (String) -> Unit,
+    onBackgroundConfirmed: (Background?) -> Unit,
     onStrengthConfirmed: (Int) -> Unit,
     onDexterityConfirmed: (Int) -> Unit,
     onConstitutionConfirmed: (Int) -> Unit,
@@ -72,12 +74,10 @@ internal fun CharacterEditDialog(
     val field = state.editingField ?: return
 
     when (field) {
-        EditingField.Background -> TextEditDialog(
-            title = stringResource(Res.string.label_background),
-            initialValue = state.character.background.orEmpty(),
+        EditingField.Background -> BackgroundSelectDialog(
+            current = state.character.background,
             onConfirm = onBackgroundConfirmed,
             onDismiss = onDismiss,
-            singleLine = false,
         )
 
         EditingField.Level -> NumberEditDialog(
@@ -246,6 +246,61 @@ private fun NumberEditDialog(
                 onClick = { parsedValue?.let(onConfirm) },
                 enabled = parsedValue != null,
             ) {
+                Text(stringResource(Res.string.btn_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.btn_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun BackgroundSelectDialog(
+    current: Background?,
+    onConfirm: (Background?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selected by remember { mutableStateOf(current) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.label_background)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    RadioButton(
+                        selected = selected == null,
+                        onClick = { selected = null },
+                    )
+                    Text(
+                        text = stringResource(Res.string.background_none),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                Background.entries.forEach { background ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        RadioButton(
+                            selected = selected == background,
+                            onClick = { selected = background },
+                        )
+                        Text(
+                            text = background.toFormattedString(),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selected) }) {
                 Text(stringResource(Res.string.btn_confirm))
             }
         },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -283,7 +283,7 @@ private fun CharacterHeaderPreview() {
         race = character.race,
         clazz = character.clazz,
         level = character.level,
-        background = character.background?.toFormattedString().orEmpty(),
+        background = character.background.toFormattedString(),
         alignment = character.alignment,
         onNameConfirmed = {},
         onClassTapped = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -283,7 +283,7 @@ private fun CharacterHeaderPreview() {
         race = character.race,
         clazz = character.clazz,
         level = character.level,
-        background = character.background.orEmpty(),
+        background = character.background?.toFormattedString().orEmpty(),
         alignment = character.alignment,
         onNameConfirmed = {},
         onClassTapped = {},

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.character.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.domain.Language
@@ -74,8 +75,8 @@ class CharacterEditViewModel(
         copy(character = character.copy(level = coerced), editingField = null)
     }
 
-    fun saveBackground(background: String) {
-        updateAndSave { copy(character = character.copy(background = background.trim().takeIf { it.isNotBlank() }), editingField = null) }
+    fun saveBackground(background: Background?) {
+        updateAndSave { copy(character = character.copy(background = background), editingField = null) }
     }
 
     fun saveStrength(value: Int) = saveAbility(value, Abilities::strength) { coerced -> copy(strength = strength.copy(value = coerced)) }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
@@ -1,11 +1,25 @@
 package com.cyrillrx.rpg.core.presentation.component.dnd
 
 import androidx.compose.runtime.Composable
+import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
 import com.cyrillrx.rpg.character.domain.Race
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.background_acolyte
+import rpg_companion.composeapp.generated.resources.background_charlatan
+import rpg_companion.composeapp.generated.resources.background_criminal
+import rpg_companion.composeapp.generated.resources.background_entertainer
+import rpg_companion.composeapp.generated.resources.background_folk_hero
+import rpg_companion.composeapp.generated.resources.background_guild_artisan
+import rpg_companion.composeapp.generated.resources.background_hermit
+import rpg_companion.composeapp.generated.resources.background_noble
+import rpg_companion.composeapp.generated.resources.background_outlander
+import rpg_companion.composeapp.generated.resources.background_sage
+import rpg_companion.composeapp.generated.resources.background_sailor
+import rpg_companion.composeapp.generated.resources.background_soldier
+import rpg_companion.composeapp.generated.resources.background_urchin
 import rpg_companion.composeapp.generated.resources.class_barbarian
 import rpg_companion.composeapp.generated.resources.class_bard
 import rpg_companion.composeapp.generated.resources.class_cleric
@@ -46,6 +60,26 @@ import rpg_companion.composeapp.generated.resources.race_half_orc
 import rpg_companion.composeapp.generated.resources.race_halfling
 import rpg_companion.composeapp.generated.resources.race_human
 import rpg_companion.composeapp.generated.resources.race_tiefling
+
+@Composable
+fun Background.toFormattedString(): String {
+    val stringRes = when (this) {
+        Background.ACOLYTE -> Res.string.background_acolyte
+        Background.CHARLATAN -> Res.string.background_charlatan
+        Background.CRIMINAL -> Res.string.background_criminal
+        Background.ENTERTAINER -> Res.string.background_entertainer
+        Background.FOLK_HERO -> Res.string.background_folk_hero
+        Background.GUILD_ARTISAN -> Res.string.background_guild_artisan
+        Background.HERMIT -> Res.string.background_hermit
+        Background.NOBLE -> Res.string.background_noble
+        Background.OUTLANDER -> Res.string.background_outlander
+        Background.SAGE -> Res.string.background_sage
+        Background.SAILOR -> Res.string.background_sailor
+        Background.SOLDIER -> Res.string.background_soldier
+        Background.URCHIN -> Res.string.background_urchin
+    }
+    return stringResource(stringRes)
+}
 
 fun Character.Class.toSvgPath(): String = when (this) {
     Character.Class.BARBARIAN -> "drawable/class_barbarian.svg"

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CharacterFormatExt.kt
@@ -62,7 +62,8 @@ import rpg_companion.composeapp.generated.resources.race_human
 import rpg_companion.composeapp.generated.resources.race_tiefling
 
 @Composable
-fun Background.toFormattedString(): String {
+fun Background?.toFormattedString(): String {
+    this ?: return ""
     val stringRes = when (this) {
         Background.ACOLYTE -> Res.string.background_acolyte
         Background.CHARLATAN -> Res.string.background_charlatan

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.character.presentation.viewmodel
 
 import com.cyrillrx.rpg.character.data.RamCharacterRepository
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.domain.Language
@@ -119,28 +120,19 @@ class CharacterEditViewModelTest {
     // ─── saveBackground ────────────────────────────────────────────────────────
 
     @Test
-    fun `saveBackground trims whitespace`() = runTest(testDispatcher) {
+    fun `saveBackground sets background value`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        viewModel.saveBackground("  Soldier  ")
+        viewModel.saveBackground(Background.SOLDIER)
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
-        assertEquals("Soldier", loaded.character.background)
+        assertEquals(Background.SOLDIER, loaded.character.background)
     }
 
     @Test
-    fun `saveBackground with blank input sets background to null`() = runTest(testDispatcher) {
+    fun `saveBackground with null clears background`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        viewModel.saveBackground("   ")
-        val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
-        assertNull(loaded.character.background)
-    }
-
-    @Test
-    fun `saveBackground with empty string sets background to null`() = runTest(testDispatcher) {
-        val viewModel = buildViewModel(repo = repoWithFighter())
-        advanceUntilIdle()
-        viewModel.saveBackground("")
+        viewModel.saveBackground(null)
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
         assertNull(loaded.character.background)
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -102,8 +102,7 @@ class JsonCharacterPresetRepository(
                     id = id,
                     name = name,
                     translations = translations,
-                    background = background?.toBackground()
-                        .also { if (it == null && background != null) println("WARNING: unknown background '$background' for $id") },
+                    background = background?.toBackground(),
                     race = race,
                     clazz = clazz,
                     level = level,
@@ -148,7 +147,9 @@ class JsonCharacterPresetRepository(
         }
 
         private fun String.toBackground(): Background? =
-            Background.entries.find { it.name.equals(this, ignoreCase = true) }
+            Background.entries
+                .find { it.name.equals(this, ignoreCase = true) }
+                .also { if (it == null) println("WARNING: unknown background '$this'") }
 
         private fun String.toRace(): Race? = Race.entries.find { it.name.equals(this, ignoreCase = true) }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -5,6 +5,7 @@ import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
 import com.cyrillrx.core.domain.partitionBy
 import com.cyrillrx.rpg.character.data.api.ApiCharacter
+import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.CharacterFilter
 import com.cyrillrx.rpg.character.domain.CharacterRepository
@@ -24,9 +25,10 @@ class JsonCharacterPresetRepository(
     private var cache: List<Character>? = null
 
     override suspend fun getAll(filter: CharacterFilter?): List<Character> {
-        val all = cache ?: loadFromFile()
-            .parse()
-            .also { cache = it }
+        val all =
+            cache ?: loadFromFile()
+                .parse()
+                .also { cache = it }
         return all.applyFilter(filter)
     }
 
@@ -57,51 +59,71 @@ class JsonCharacterPresetRepository(
         }
 
         private fun ApiCharacter.toCharacter(): Result<Character, CharacterImportError> {
-            val id = id
-                ?: return Result.Failure(CharacterImportError.MissingId)
-            val name = name
-                ?: return Result.Failure(CharacterImportError.MissingName(id))
-            val apiTranslations = translations
-                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
-            val translations = apiTranslations.toTranslations(id)
-                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
-            val level = level
-                ?: return Result.Failure(CharacterImportError.MissingLevel(id))
-            val apiSize = size
-                ?: return Result.Failure(CharacterImportError.MissingSize(id))
-            val size = apiSize.toSize()
-                ?: return Result.Failure(CharacterImportError.UnknownSize(id, apiSize))
-            val apiAlignment = alignment
-                ?: return Result.Failure(CharacterImportError.MissingAlignment(id))
-            val alignment = apiAlignment.toAlignment()
-                ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, apiAlignment))
-            val armorClass = armorClass
-                ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
-            val maxHitPoints = maxHitPoints
-                ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
+            val id =
+                id
+                    ?: return Result.Failure(CharacterImportError.MissingId)
+            val name =
+                name
+                    ?: return Result.Failure(CharacterImportError.MissingName(id))
+            val apiTranslations =
+                translations
+                    ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val translations =
+                apiTranslations.toTranslations(id)
+                    ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val level =
+                level
+                    ?: return Result.Failure(CharacterImportError.MissingLevel(id))
+            val apiSize =
+                size
+                    ?: return Result.Failure(CharacterImportError.MissingSize(id))
+            val size =
+                apiSize.toSize()
+                    ?: return Result.Failure(CharacterImportError.UnknownSize(id, apiSize))
+            val apiAlignment =
+                alignment
+                    ?: return Result.Failure(CharacterImportError.MissingAlignment(id))
+            val alignment =
+                apiAlignment.toAlignment()
+                    ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, apiAlignment))
+            val armorClass =
+                armorClass
+                    ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
+            val maxHitPoints =
+                maxHitPoints
+                    ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
             speeds?.walk
                 ?: return Result.Failure(CharacterImportError.MissingWalkSpeed(id))
-            val apiSkills = skills
-                ?: return Result.Failure(CharacterImportError.MissingSkills(id))
-            val apiRace = race
-                ?: return Result.Failure(CharacterImportError.MissingRace(id))
-            val race = apiRace.toRace()
-                ?: return Result.Failure(CharacterImportError.UnknownRace(id, apiRace))
-            val apiClazz = clazz
-                ?: return Result.Failure(CharacterImportError.MissingClass(id))
-            val clazz = apiClazz.toClass()
-                ?: return Result.Failure(CharacterImportError.UnknownClass(id, apiClazz))
+            val apiSkills =
+                skills
+                    ?: return Result.Failure(CharacterImportError.MissingSkills(id))
+            val apiRace =
+                race
+                    ?: return Result.Failure(CharacterImportError.MissingRace(id))
+            val race =
+                apiRace.toRace()
+                    ?: return Result.Failure(CharacterImportError.UnknownRace(id, apiRace))
+            val apiClazz =
+                clazz
+                    ?: return Result.Failure(CharacterImportError.MissingClass(id))
+            val clazz =
+                apiClazz.toClass()
+                    ?: return Result.Failure(CharacterImportError.UnknownClass(id, apiClazz))
             val (parsedLanguages, languageErrors) = languages.orEmpty().partitionBy { lang -> lang.toLanguage(id) }
             languageErrors.forEach { println("WARNING: character preset import error: $it") }
-            val languages = parsedLanguages.takeIf { languageErrors.isEmpty() }
-                ?: return Result.Failure(languageErrors.first())
+            val languages =
+                parsedLanguages.takeIf { languageErrors.isEmpty() }
+                    ?: return Result.Failure(languageErrors.first())
 
             return Result.Success(
                 Character(
                     id = id,
                     name = name,
                     translations = translations,
-                    background = background,
+                    background =
+                        background
+                            ?.toBackground()
+                            .also { if (it == null && background != null) println("WARNING: unknown background '$background' for $id") },
                     race = race,
                     clazz = clazz,
                     level = level,
@@ -118,9 +140,10 @@ class JsonCharacterPresetRepository(
         }
 
         private fun Map<String, ApiCharacter.Translation>.toTranslations(characterId: String): Map<String, Character.Translation>? {
-            val (parsedTranslations, translationErrors) = partitionBy { locale, t ->
-                t.toTranslation(characterId, locale)
-            }
+            val (parsedTranslations, translationErrors) =
+                partitionBy { locale, t ->
+                    t.toTranslation(characterId, locale)
+                }
             translationErrors.forEach { println("WARNING: character preset import error: $it") }
             return parsedTranslations.takeIf { it.isNotEmpty() }
         }
@@ -129,14 +152,16 @@ class JsonCharacterPresetRepository(
             characterId: String,
             locale: String,
         ): Result<Character.Translation, CharacterImportError> {
-            val shortDescription = shortDescription
-                ?: return Result.Failure(
-                    CharacterImportError.InvalidTranslation(characterId, locale, field = "shortDescription"),
-                )
-            val description = description
-                ?: return Result.Failure(
-                    CharacterImportError.InvalidTranslation(characterId, locale, field = "description"),
-                )
+            val shortDescription =
+                shortDescription
+                    ?: return Result.Failure(
+                        CharacterImportError.InvalidTranslation(characterId, locale, field = "shortDescription"),
+                    )
+            val description =
+                description
+                    ?: return Result.Failure(
+                        CharacterImportError.InvalidTranslation(characterId, locale, field = "description"),
+                    )
             return Result.Success(
                 Character.Translation(
                     shortDescription = shortDescription,
@@ -145,14 +170,16 @@ class JsonCharacterPresetRepository(
             )
         }
 
+        private fun String.toBackground(): Background? = Background.entries.find { it.name.equals(this, ignoreCase = true) }
+
         private fun String.toRace(): Race? = Race.entries.find { it.name.equals(this, ignoreCase = true) }
 
-        private fun String.toClass(): Character.Class? =
-            Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
+        private fun String.toClass(): Character.Class? = Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
 
         private fun String.toLanguage(id: String): Result<Language, CharacterImportError> {
-            val language = Language.entries.find { it.name.equals(this, ignoreCase = true) }
-                ?: return Result.Failure(CharacterImportError.UnknownLanguage(id, this))
+            val language =
+                Language.entries.find { it.name.equals(this, ignoreCase = true) }
+                    ?: return Result.Failure(CharacterImportError.UnknownLanguage(id, this))
 
             return Result.Success(language)
         }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -25,10 +25,9 @@ class JsonCharacterPresetRepository(
     private var cache: List<Character>? = null
 
     override suspend fun getAll(filter: CharacterFilter?): List<Character> {
-        val all =
-            cache ?: loadFromFile()
-                .parse()
-                .also { cache = it }
+        val all = cache ?: loadFromFile()
+            .parse()
+            .also { cache = it }
         return all.applyFilter(filter)
     }
 
@@ -59,71 +58,52 @@ class JsonCharacterPresetRepository(
         }
 
         private fun ApiCharacter.toCharacter(): Result<Character, CharacterImportError> {
-            val id =
-                id
-                    ?: return Result.Failure(CharacterImportError.MissingId)
-            val name =
-                name
-                    ?: return Result.Failure(CharacterImportError.MissingName(id))
-            val apiTranslations =
-                translations
-                    ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
-            val translations =
-                apiTranslations.toTranslations(id)
-                    ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
-            val level =
-                level
-                    ?: return Result.Failure(CharacterImportError.MissingLevel(id))
-            val apiSize =
-                size
-                    ?: return Result.Failure(CharacterImportError.MissingSize(id))
-            val size =
-                apiSize.toSize()
-                    ?: return Result.Failure(CharacterImportError.UnknownSize(id, apiSize))
-            val apiAlignment =
-                alignment
-                    ?: return Result.Failure(CharacterImportError.MissingAlignment(id))
-            val alignment =
-                apiAlignment.toAlignment()
-                    ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, apiAlignment))
-            val armorClass =
-                armorClass
-                    ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
-            val maxHitPoints =
-                maxHitPoints
-                    ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
+            val id = id
+                ?: return Result.Failure(CharacterImportError.MissingId)
+            val name = name
+                ?: return Result.Failure(CharacterImportError.MissingName(id))
+            val apiTranslations = translations
+                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val translations = apiTranslations.toTranslations(id)
+                ?: return Result.Failure(CharacterImportError.MissingTranslations(id))
+            val level = level
+                ?: return Result.Failure(CharacterImportError.MissingLevel(id))
+            val apiSize = size
+                ?: return Result.Failure(CharacterImportError.MissingSize(id))
+            val size = apiSize.toSize()
+                ?: return Result.Failure(CharacterImportError.UnknownSize(id, apiSize))
+            val apiAlignment = alignment
+                ?: return Result.Failure(CharacterImportError.MissingAlignment(id))
+            val alignment = apiAlignment.toAlignment()
+                ?: return Result.Failure(CharacterImportError.UnknownAlignment(id, apiAlignment))
+            val armorClass = armorClass
+                ?: return Result.Failure(CharacterImportError.MissingArmorClass(id))
+            val maxHitPoints = maxHitPoints
+                ?: return Result.Failure(CharacterImportError.MissingMaxHitPoints(id))
             speeds?.walk
                 ?: return Result.Failure(CharacterImportError.MissingWalkSpeed(id))
-            val apiSkills =
-                skills
-                    ?: return Result.Failure(CharacterImportError.MissingSkills(id))
-            val apiRace =
-                race
-                    ?: return Result.Failure(CharacterImportError.MissingRace(id))
-            val race =
-                apiRace.toRace()
-                    ?: return Result.Failure(CharacterImportError.UnknownRace(id, apiRace))
-            val apiClazz =
-                clazz
-                    ?: return Result.Failure(CharacterImportError.MissingClass(id))
-            val clazz =
-                apiClazz.toClass()
-                    ?: return Result.Failure(CharacterImportError.UnknownClass(id, apiClazz))
+            val apiSkills = skills
+                ?: return Result.Failure(CharacterImportError.MissingSkills(id))
+            val apiRace = race
+                ?: return Result.Failure(CharacterImportError.MissingRace(id))
+            val race = apiRace.toRace()
+                ?: return Result.Failure(CharacterImportError.UnknownRace(id, apiRace))
+            val apiClazz = clazz
+                ?: return Result.Failure(CharacterImportError.MissingClass(id))
+            val clazz = apiClazz.toClass()
+                ?: return Result.Failure(CharacterImportError.UnknownClass(id, apiClazz))
             val (parsedLanguages, languageErrors) = languages.orEmpty().partitionBy { lang -> lang.toLanguage(id) }
             languageErrors.forEach { println("WARNING: character preset import error: $it") }
-            val languages =
-                parsedLanguages.takeIf { languageErrors.isEmpty() }
-                    ?: return Result.Failure(languageErrors.first())
+            val languages = parsedLanguages.takeIf { languageErrors.isEmpty() }
+                ?: return Result.Failure(languageErrors.first())
 
             return Result.Success(
                 Character(
                     id = id,
                     name = name,
                     translations = translations,
-                    background =
-                        background
-                            ?.toBackground()
-                            .also { if (it == null && background != null) println("WARNING: unknown background '$background' for $id") },
+                    background = background?.toBackground()
+                        .also { if (it == null && background != null) println("WARNING: unknown background '$background' for $id") },
                     race = race,
                     clazz = clazz,
                     level = level,
@@ -140,10 +120,9 @@ class JsonCharacterPresetRepository(
         }
 
         private fun Map<String, ApiCharacter.Translation>.toTranslations(characterId: String): Map<String, Character.Translation>? {
-            val (parsedTranslations, translationErrors) =
-                partitionBy { locale, t ->
-                    t.toTranslation(characterId, locale)
-                }
+            val (parsedTranslations, translationErrors) = partitionBy { locale, t ->
+                t.toTranslation(characterId, locale)
+            }
             translationErrors.forEach { println("WARNING: character preset import error: $it") }
             return parsedTranslations.takeIf { it.isNotEmpty() }
         }
@@ -152,16 +131,14 @@ class JsonCharacterPresetRepository(
             characterId: String,
             locale: String,
         ): Result<Character.Translation, CharacterImportError> {
-            val shortDescription =
-                shortDescription
-                    ?: return Result.Failure(
-                        CharacterImportError.InvalidTranslation(characterId, locale, field = "shortDescription"),
-                    )
-            val description =
-                description
-                    ?: return Result.Failure(
-                        CharacterImportError.InvalidTranslation(characterId, locale, field = "description"),
-                    )
+            val shortDescription = shortDescription
+                ?: return Result.Failure(
+                    CharacterImportError.InvalidTranslation(characterId, locale, field = "shortDescription"),
+                )
+            val description = description
+                ?: return Result.Failure(
+                    CharacterImportError.InvalidTranslation(characterId, locale, field = "description"),
+                )
             return Result.Success(
                 Character.Translation(
                     shortDescription = shortDescription,
@@ -170,16 +147,17 @@ class JsonCharacterPresetRepository(
             )
         }
 
-        private fun String.toBackground(): Background? = Background.entries.find { it.name.equals(this, ignoreCase = true) }
+        private fun String.toBackground(): Background? =
+            Background.entries.find { it.name.equals(this, ignoreCase = true) }
 
         private fun String.toRace(): Race? = Race.entries.find { it.name.equals(this, ignoreCase = true) }
 
-        private fun String.toClass(): Character.Class? = Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
+        private fun String.toClass(): Character.Class? =
+            Character.Class.entries.find { it.name.equals(this, ignoreCase = true) }
 
         private fun String.toLanguage(id: String): Result<Language, CharacterImportError> {
-            val language =
-                Language.entries.find { it.name.equals(this, ignoreCase = true) }
-                    ?: return Result.Failure(CharacterImportError.UnknownLanguage(id, this))
+            val language = Language.entries.find { it.name.equals(this, ignoreCase = true) }
+                ?: return Result.Failure(CharacterImportError.UnknownLanguage(id, this))
 
             return Result.Success(language)
         }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Background.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Background.kt
@@ -1,0 +1,17 @@
+package com.cyrillrx.rpg.character.domain
+
+enum class Background {
+    ACOLYTE,
+    CHARLATAN,
+    CRIMINAL,
+    ENTERTAINER,
+    FOLK_HERO,
+    GUILD_ARTISAN,
+    HERMIT,
+    NOBLE,
+    OUTLANDER,
+    SAGE,
+    SAILOR,
+    SOLDIER,
+    URCHIN,
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -23,22 +23,24 @@ data class Character(
     val skills: Skills,
     val race: Race = Race.HUMAN,
     val translations: Map<String, Translation> = emptyMap(),
-    val background: String? = null,
+    val background: Background? = null,
     val currentHitPoints: Int = maxHitPoints,
     val temporaryHitPoints: Int = 0,
 ) : Creature() {
-    fun resolveTranslation(locale: String): Translation? = translations[locale]
-        ?: translations[FALLBACK_LOCALE]
-        ?: translations.values.firstOrNull()
+    fun resolveTranslation(locale: String): Translation? =
+        translations[locale]
+            ?: translations[FALLBACK_LOCALE]
+            ?: translations.values.firstOrNull()
 
-    fun proficiencyBonus(): Int = when (level) {
-        in 1..4 -> 2
-        in 5..8 -> 3
-        in 9..12 -> 4
-        in 13..16 -> 5
-        in 17..20 -> 6
-        else -> 0
-    }
+    fun proficiencyBonus(): Int =
+        when (level) {
+            in 1..4 -> 2
+            in 5..8 -> 3
+            in 9..12 -> 4
+            in 13..16 -> 5
+            in 17..20 -> 6
+            else -> 0
+        }
 
     @Serializable
     data class Translation(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -27,20 +27,18 @@ data class Character(
     val currentHitPoints: Int = maxHitPoints,
     val temporaryHitPoints: Int = 0,
 ) : Creature() {
-    fun resolveTranslation(locale: String): Translation? =
-        translations[locale]
-            ?: translations[FALLBACK_LOCALE]
-            ?: translations.values.firstOrNull()
+    fun resolveTranslation(locale: String): Translation? = translations[locale]
+        ?: translations[FALLBACK_LOCALE]
+        ?: translations.values.firstOrNull()
 
-    fun proficiencyBonus(): Int =
-        when (level) {
-            in 1..4 -> 2
-            in 5..8 -> 3
-            in 9..12 -> 4
-            in 13..16 -> 5
-            in 17..20 -> 6
-            else -> 0
-        }
+    fun proficiencyBonus(): Int = when (level) {
+        in 1..4 -> 2
+        in 5..8 -> 3
+        in 9..12 -> 4
+        in 13..16 -> 5
+        in 17..20 -> 6
+        else -> 0
+    }
 
     @Serializable
     data class Translation(


### PR DESCRIPTION
## 📝 Description

Converts `Character.background` from `String?` (free text) to `Background?` (enum), consistent with the pattern used for `Race`, `Character.Class`, `Language`, and `Alignment`.

- New `Background` enum with the 13 official D&D 5e backgrounds
- `Background.toFormattedString()` via localized string resources (EN + FR)
- `BackgroundSelectDialog` replaces the free-text edit dialog, with radio buttons and a "None" option to clear the field
- JSON preset parser uses `String.toBackground()` (case-insensitive, tolerant — unknown values produce a warning and fall back to `null`)
- `pc-presets.json` background values normalized to lowercase snake_case

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed