### PR TITLE
feat(settings): add settings page navigation and user preferences infrastructure

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_settings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!--  Settings  -->
+    <string name="title_settings">Paramètres</string>
+</resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!--  Settings  -->
+    <string name="title_settings">Settings</string>
+</resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavKey
@@ -88,6 +89,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
         val fileReader = ComposeFileReader()
         val userListRepository = remember(dbDriverFactory) { SQLDelightUserListRepository(dbDriverFactory) }
         val prefsRepository = remember(dbDriverFactory) { SqlDelightUserPreferencesRepository(dbDriverFactory) }
+        LaunchedEffect(prefsRepository) { prefsRepository.initialize() }
 
         NavDisplay(
             backStack = backStack,
@@ -133,7 +135,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
                 handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
 
-                handleSettingsRoutes(backStack, prefsRepository)
+                handleSettingsRoutes(backStack)
             },
         )
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -46,6 +46,7 @@ import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouterImpl
 import com.cyrillrx.rpg.spell.presentation.navigation.handleSpellRoutes
 import com.cyrillrx.rpg.spell.presentation.navigation.registerSpellRoutes
 import com.cyrillrx.rpg.settings.data.SqlDelightUserPreferencesRepository
+import com.cyrillrx.rpg.settings.domain.UserPreferencesRepository
 import com.cyrillrx.rpg.settings.presentation.navigation.handleSettingsRoutes
 import com.cyrillrx.rpg.settings.presentation.navigation.registerSettingsRoutes
 import com.cyrillrx.rpg.userlist.data.SQLDelightUserListRepository
@@ -88,7 +89,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
         val fileReader = ComposeFileReader()
         val userListRepository = remember(dbDriverFactory) { SQLDelightUserListRepository(dbDriverFactory) }
-        val prefsRepository = remember(dbDriverFactory) { SqlDelightUserPreferencesRepository(dbDriverFactory) }
+        val prefsRepository: UserPreferencesRepository = remember(dbDriverFactory) { SqlDelightUserPreferencesRepository(dbDriverFactory) }
         LaunchedEffect(prefsRepository) { prefsRepository.initialize() }
 
         NavDisplay(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -44,6 +44,9 @@ import com.cyrillrx.rpg.spell.data.JsonSpellRepository
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouterImpl
 import com.cyrillrx.rpg.spell.presentation.navigation.handleSpellRoutes
 import com.cyrillrx.rpg.spell.presentation.navigation.registerSpellRoutes
+import com.cyrillrx.rpg.settings.data.SqlDelightUserPreferencesRepository
+import com.cyrillrx.rpg.settings.presentation.navigation.handleSettingsRoutes
+import com.cyrillrx.rpg.settings.presentation.navigation.registerSettingsRoutes
 import com.cyrillrx.rpg.userlist.data.SQLDelightUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouterImpl
 import com.cyrillrx.rpg.userlist.presentation.navigation.handleUserListRoutes
@@ -65,6 +68,8 @@ private val navSavedStateConfig = SavedStateConfiguration {
             registerMonsterRoutes()
 
             registerUserListRoutes()
+
+            registerSettingsRoutes()
         }
     }
 }
@@ -82,6 +87,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
         val fileReader = ComposeFileReader()
         val userListRepository = remember(dbDriverFactory) { SQLDelightUserListRepository(dbDriverFactory) }
+        val prefsRepository = remember(dbDriverFactory) { SqlDelightUserPreferencesRepository(dbDriverFactory) }
 
         NavDisplay(
             backStack = backStack,
@@ -126,6 +132,8 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 )
 
                 handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
+
+                handleSettingsRoutes(backStack, prefsRepository)
             },
         )
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -10,15 +10,19 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Diamond
 import androidx.compose.material.icons.filled.Pets
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
-import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -34,23 +38,29 @@ import rpg_companion.composeapp.generated.resources.btn_my_spell_lists
 import rpg_companion.composeapp.generated.resources.btn_spell_book
 import rpg_companion.composeapp.generated.resources.section_compendium
 import rpg_companion.composeapp.generated.resources.section_my_lists
+import rpg_companion.composeapp.generated.resources.title_settings
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(router: HomeRouter) {
-    Scaffold { paddingValues ->
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.app_name)) },
+                actions = {
+                    IconButton(onClick = router::openSettings) {
+                        Icon(Icons.Filled.Settings, contentDescription = stringResource(Res.string.title_settings))
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
+            )
+        },
+    ) { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
-            Text(
-                text = stringResource(Res.string.app_name),
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier
-                    .padding(spacingLarge)
-                    .align(alignment = Alignment.CenterHorizontally),
-            )
-
             HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
             HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheetList)
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -129,13 +129,23 @@ fun HomeScreen(router: HomeRouter) {
     }
 }
 
+private object PreviewHomeRouter : HomeRouter {
+    override fun openCampaignList() {}
+    override fun openCharacterSheetList() {}
+    override fun openSpellCompendium() {}
+    override fun openMagicalItemCompendium() {}
+    override fun openMonsterCompendium() {}
+    override fun openMySpellLists() {}
+    override fun openMyMagicalItemLists() {}
+    override fun openMyMonsterLists() {}
+    override fun openSettings() {}
+}
+
 @Preview
 @Composable
 private fun PreviewHomeScreenLight() {
     AppThemePreview(darkTheme = false) {
-        HomeScreen(object : HomeRouter {
-            override fun openSettings() {}
-        })
+        HomeScreen(PreviewHomeRouter)
     }
 }
 
@@ -143,8 +153,6 @@ private fun PreviewHomeScreenLight() {
 @Composable
 private fun PreviewHomeScreenDark() {
     AppThemePreview(darkTheme = true) {
-        HomeScreen(object : HomeRouter {
-            override fun openSettings() {}
-        })
+        HomeScreen(PreviewHomeRouter)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -133,7 +133,9 @@ fun HomeScreen(router: HomeRouter) {
 @Composable
 private fun PreviewHomeScreenLight() {
     AppThemePreview(darkTheme = false) {
-        HomeScreen(object : HomeRouter {})
+        HomeScreen(object : HomeRouter {
+            override fun openSettings() {}
+        })
     }
 }
 
@@ -141,6 +143,8 @@ private fun PreviewHomeScreenLight() {
 @Composable
 private fun PreviewHomeScreenDark() {
     AppThemePreview(darkTheme = true) {
-        HomeScreen(object : HomeRouter {})
+        HomeScreen(object : HomeRouter {
+            override fun openSettings() {}
+        })
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -6,6 +6,7 @@ import com.cyrillrx.rpg.campaign.navigation.CampaignRoute
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRoute
 import com.cyrillrx.rpg.creature.presentation.navigation.MonsterRoute
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRoute
+import com.cyrillrx.rpg.settings.presentation.navigation.SettingsRoute
 import com.cyrillrx.rpg.spell.presentation.navigation.SpellRoute
 import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRoute
 
@@ -18,6 +19,7 @@ interface HomeRouter {
     fun openMySpellLists() {}
     fun openMyMagicalItemLists() {}
     fun openMyMonsterLists() {}
+    fun openSettings() {}
 }
 
 class HomeRouterImpl(private val backStack: NavBackStack<NavKey>) : HomeRouter {
@@ -51,5 +53,9 @@ class HomeRouterImpl(private val backStack: NavBackStack<NavKey>) : HomeRouter {
 
     override fun openMyMonsterLists() {
         backStack.add(UserListRoute.Creature)
+    }
+
+    override fun openSettings() {
+        backStack.add(SettingsRoute.Main)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -11,14 +11,14 @@ import com.cyrillrx.rpg.spell.presentation.navigation.SpellRoute
 import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRoute
 
 interface HomeRouter {
-    fun openCampaignList() {}
-    fun openCharacterSheetList() {}
-    fun openSpellCompendium() {}
-    fun openMagicalItemCompendium() {}
-    fun openMonsterCompendium() {}
-    fun openMySpellLists() {}
-    fun openMyMagicalItemLists() {}
-    fun openMyMonsterLists() {}
+    fun openCampaignList()
+    fun openCharacterSheetList()
+    fun openSpellCompendium()
+    fun openMagicalItemCompendium()
+    fun openMonsterCompendium()
+    fun openMySpellLists()
+    fun openMyMagicalItemLists()
+    fun openMyMonsterLists()
     fun openSettings()
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -19,7 +19,7 @@ interface HomeRouter {
     fun openMySpellLists() {}
     fun openMyMagicalItemLists() {}
     fun openMyMonsterLists() {}
-    fun openSettings() {}
+    fun openSettings()
 }
 
 class HomeRouterImpl(private val backStack: NavBackStack<NavKey>) : HomeRouter {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/SettingsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/SettingsScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.settings.presentation.navigation.SettingsRouter
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.title_settings
 
@@ -26,7 +28,26 @@ fun SettingsScreen(router: SettingsRouter) {
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
-            // Settings content added in subsequent PRs
         }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSettingsScreenLight() {
+    AppThemePreview(darkTheme = false) {
+        SettingsScreen(router = object : SettingsRouter {
+            override fun navigateUp() {}
+        })
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSettingsScreenDark() {
+    AppThemePreview(darkTheme = true) {
+        SettingsScreen(router = object : SettingsRouter {
+            override fun navigateUp() {}
+        })
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/SettingsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/SettingsScreen.kt
@@ -1,0 +1,32 @@
+package com.cyrillrx.rpg.settings.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.settings.presentation.navigation.SettingsRouter
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.title_settings
+
+@Composable
+fun SettingsScreen(router: SettingsRouter) {
+    Scaffold(
+        topBar = {
+            SimpleTopBar(
+                titleResource = Res.string.title_settings,
+                onNavigateUpClicked = router::navigateUp,
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        ) {
+            // Settings content added in subsequent PRs
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/navigation/SettingsRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/navigation/SettingsRoute.kt
@@ -3,7 +3,6 @@ package com.cyrillrx.rpg.settings.presentation.navigation
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
-import com.cyrillrx.rpg.settings.domain.UserPreferencesRepository
 import com.cyrillrx.rpg.settings.presentation.SettingsScreen
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
@@ -19,7 +18,6 @@ fun PolymorphicModuleBuilder<NavKey>.registerSettingsRoutes() {
 
 fun EntryProviderScope<NavKey>.handleSettingsRoutes(
     backStack: NavBackStack<NavKey>,
-    prefsRepository: UserPreferencesRepository,
 ) {
     entry<SettingsRoute.Main> {
         SettingsScreen(router = SettingsRouterImpl(backStack))

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/navigation/SettingsRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/navigation/SettingsRoute.kt
@@ -1,0 +1,27 @@
+package com.cyrillrx.rpg.settings.presentation.navigation
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.settings.domain.UserPreferencesRepository
+import com.cyrillrx.rpg.settings.presentation.SettingsScreen
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+
+sealed interface SettingsRoute {
+    @Serializable
+    data object Main : NavKey
+}
+
+fun PolymorphicModuleBuilder<NavKey>.registerSettingsRoutes() {
+    subclass(SettingsRoute.Main::class, SettingsRoute.Main.serializer())
+}
+
+fun EntryProviderScope<NavKey>.handleSettingsRoutes(
+    backStack: NavBackStack<NavKey>,
+    prefsRepository: UserPreferencesRepository,
+) {
+    entry<SettingsRoute.Main> {
+        SettingsScreen(router = SettingsRouterImpl(backStack))
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/navigation/SettingsRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/navigation/SettingsRouter.kt
@@ -1,0 +1,15 @@
+package com.cyrillrx.rpg.settings.presentation.navigation
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import com.cyrillrx.rpg.core.navigation.navigateUp
+
+interface SettingsRouter {
+    fun navigateUp()
+}
+
+class SettingsRouterImpl(private val backStack: NavBackStack<NavKey>) : SettingsRouter {
+    override fun navigateUp() {
+        backStack.navigateUp()
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/build.gradle.kts
+++ b/cmp-ttrpg-companion/shared/core/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            api(libs.kotlinx.coroutines.core)
             api(libs.kotlinx.serialization.core)
             api(libs.kotlinx.serialization.json)
             api(libs.kotlinx.datetime)

--- a/cmp-ttrpg-companion/shared/core/build.gradle.kts
+++ b/cmp-ttrpg-companion/shared/core/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     alias(libs.plugins.ktlint)
@@ -10,6 +11,11 @@ plugins {
 }
 
 kotlin {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xexplicit-backing-fields")
+    }
+
     android {
         namespace = "com.cyrillrx.rpg.core"
         compileSdk = Version.COMPILE_SDK

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -83,15 +83,15 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     }
 
     fun getUserPreferences(): UserPreferences =
-        dbQuery.getUserPreferences { _, themeMode, distanceUnit ->
+        dbQuery.getUserPreferences { _, theme, distanceUnit ->
             UserPreferences(
-                theme = Theme.entries.find { it.name.equals(themeMode, ignoreCase = true) } ?: Theme.AUTO,
+                theme = Theme.entries.find { it.name.equals(theme, ignoreCase = true) } ?: Theme.SYSTEM,
                 distanceUnit = DistanceUnit.entries.find { it.name.equals(distanceUnit, ignoreCase = true) } ?: DistanceUnit.FEET,
             )
         }.executeAsOneOrNull() ?: UserPreferences()
 
     fun updateTheme(theme: Theme) {
-        dbQuery.updateThemeMode(theme.name.lowercase())
+        dbQuery.updateTheme(theme.name.lowercase())
     }
 
     fun updateDistanceUnit(distanceUnit: DistanceUnit) {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -6,6 +6,9 @@ import com.cyrillrx.rpg.cache.AppDatabase
 import com.cyrillrx.rpg.campaign.domain.Campaign
 import com.cyrillrx.rpg.campaign.domain.RuleSet
 import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.settings.domain.DistanceUnit
+import com.cyrillrx.rpg.settings.domain.Theme
+import com.cyrillrx.rpg.settings.domain.UserPreferences
 import com.cyrillrx.rpg.userlist.domain.UserList
 import kotlinx.datetime.Instant
 
@@ -73,6 +76,26 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
 
     fun deleteUserList(id: String) {
         dbQuery.deleteUserList(id)
+    }
+
+    fun initUserPreferences() {
+        dbQuery.initUserPreferences()
+    }
+
+    fun getUserPreferences(): UserPreferences =
+        dbQuery.getUserPreferences { _, themeMode, distanceUnit ->
+            UserPreferences(
+                theme = Theme.valueOf(themeMode.uppercase()),
+                distanceUnit = DistanceUnit.valueOf(distanceUnit.uppercase()),
+            )
+        }.executeAsOneOrNull() ?: UserPreferences()
+
+    fun updateTheme(theme: Theme) {
+        dbQuery.updateThemeMode(theme.name.lowercase())
+    }
+
+    fun updateDistanceUnit(unit: DistanceUnit) {
+        dbQuery.updateDistanceUnit(unit.name.lowercase())
     }
 
     private fun mapUserListSelecting(id: String, name: String, type: String, itemIds: String, lastModified: Long): UserList =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -85,8 +85,8 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     fun getUserPreferences(): UserPreferences =
         dbQuery.getUserPreferences { _, themeMode, distanceUnit ->
             UserPreferences(
-                theme = Theme.valueOf(themeMode.uppercase()),
-                distanceUnit = DistanceUnit.valueOf(distanceUnit.uppercase()),
+                theme = Theme.entries.find { it.name.equals(themeMode, ignoreCase = true) } ?: Theme.AUTO,
+                distanceUnit = DistanceUnit.entries.find { it.name.equals(distanceUnit, ignoreCase = true) } ?: DistanceUnit.FEET,
             )
         }.executeAsOneOrNull() ?: UserPreferences()
 
@@ -94,8 +94,8 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
         dbQuery.updateThemeMode(theme.name.lowercase())
     }
 
-    fun updateDistanceUnit(unit: DistanceUnit) {
-        dbQuery.updateDistanceUnit(unit.name.lowercase())
+    fun updateDistanceUnit(distanceUnit: DistanceUnit) {
+        dbQuery.updateDistanceUnit(distanceUnit.name.lowercase())
     }
 
     private fun mapUserListSelecting(id: String, name: String, type: String, itemIds: String, lastModified: Long): UserList =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
@@ -1,0 +1,28 @@
+package com.cyrillrx.rpg.settings.data
+
+import com.cyrillrx.rpg.core.data.cache.Database
+import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
+import com.cyrillrx.rpg.settings.domain.DistanceUnit
+import com.cyrillrx.rpg.settings.domain.Theme
+import com.cyrillrx.rpg.settings.domain.UserPreferences
+import com.cyrillrx.rpg.settings.domain.UserPreferencesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) : UserPreferencesRepository {
+    private val db = Database(driverFactory).also { it.initUserPreferences() }
+    private val _preferences = MutableStateFlow(db.getUserPreferences())
+
+    override val preferences: StateFlow<UserPreferences> = _preferences.asStateFlow()
+
+    override suspend fun setTheme(theme: Theme) {
+        db.updateTheme(theme)
+        _preferences.value = _preferences.value.copy(theme = theme)
+    }
+
+    override suspend fun setDistanceUnit(unit: DistanceUnit) {
+        db.updateDistanceUnit(unit)
+        _preferences.value = _preferences.value.copy(distanceUnit = unit)
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
@@ -10,30 +10,29 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
 class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) : UserPreferencesRepository {
     private val db = Database(driverFactory)
-    private val _preferences = MutableStateFlow(UserPreferences())
 
-    override val preferences: StateFlow<UserPreferences> = _preferences.asStateFlow()
+    override val preferences: StateFlow<UserPreferences>
+        field = MutableStateFlow(UserPreferences())
 
     suspend fun initialize() {
         withContext(Dispatchers.IO) {
             db.initUserPreferences()
-            _preferences.value = db.getUserPreferences()
+            preferences.value = db.getUserPreferences()
         }
     }
 
     override suspend fun setTheme(theme: Theme) {
         withContext(Dispatchers.IO) { db.updateTheme(theme) }
-        _preferences.update { it.copy(theme = theme) }
+        preferences.update { it.copy(theme = theme) }
     }
 
     override suspend fun setDistanceUnit(distanceUnit: DistanceUnit) {
         withContext(Dispatchers.IO) { db.updateDistanceUnit(distanceUnit) }
-        _preferences.update { it.copy(distanceUnit = distanceUnit) }
+        preferences.update { it.copy(distanceUnit = distanceUnit) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
@@ -19,7 +19,7 @@ class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) 
     override val preferences: StateFlow<UserPreferences>
         field = MutableStateFlow(UserPreferences())
 
-    suspend fun initialize() {
+    override suspend fun initialize() {
         withContext(Dispatchers.IO) {
             db.initUserPreferences()
             preferences.value = db.getUserPreferences()
@@ -27,12 +27,16 @@ class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) 
     }
 
     override suspend fun setTheme(theme: Theme) {
-        withContext(Dispatchers.IO) { db.updateTheme(theme) }
-        preferences.update { it.copy(theme = theme) }
+        withContext(Dispatchers.IO) {
+            db.updateTheme(theme)
+            preferences.update { it.copy(theme = theme) }
+        }
     }
 
     override suspend fun setDistanceUnit(distanceUnit: DistanceUnit) {
-        withContext(Dispatchers.IO) { db.updateDistanceUnit(distanceUnit) }
-        preferences.update { it.copy(distanceUnit = distanceUnit) }
+        withContext(Dispatchers.IO) {
+            db.updateDistanceUnit(distanceUnit)
+            preferences.update { it.copy(distanceUnit = distanceUnit) }
+        }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
@@ -6,24 +6,34 @@ import com.cyrillrx.rpg.settings.domain.DistanceUnit
 import com.cyrillrx.rpg.settings.domain.Theme
 import com.cyrillrx.rpg.settings.domain.UserPreferences
 import com.cyrillrx.rpg.settings.domain.UserPreferencesRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
 
 class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) : UserPreferencesRepository {
-    private val db = Database(driverFactory).also { it.initUserPreferences() }
-    private val _preferences = MutableStateFlow(db.getUserPreferences())
+    private val db = Database(driverFactory)
+    private val _preferences = MutableStateFlow(UserPreferences())
 
     override val preferences: StateFlow<UserPreferences> = _preferences.asStateFlow()
 
+    suspend fun initialize() {
+        withContext(Dispatchers.IO) {
+            db.initUserPreferences()
+            _preferences.value = db.getUserPreferences()
+        }
+    }
+
     override suspend fun setTheme(theme: Theme) {
-        db.updateTheme(theme)
+        withContext(Dispatchers.IO) { db.updateTheme(theme) }
         _preferences.update { it.copy(theme = theme) }
     }
 
     override suspend fun setDistanceUnit(distanceUnit: DistanceUnit) {
-        db.updateDistanceUnit(distanceUnit)
+        withContext(Dispatchers.IO) { db.updateDistanceUnit(distanceUnit) }
         _preferences.update { it.copy(distanceUnit = distanceUnit) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
@@ -9,6 +9,7 @@ import com.cyrillrx.rpg.settings.domain.UserPreferencesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) : UserPreferencesRepository {
     private val db = Database(driverFactory).also { it.initUserPreferences() }
@@ -18,11 +19,11 @@ class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) 
 
     override suspend fun setTheme(theme: Theme) {
         db.updateTheme(theme)
-        _preferences.value = _preferences.value.copy(theme = theme)
+        _preferences.update { it.copy(theme = theme) }
     }
 
-    override suspend fun setDistanceUnit(unit: DistanceUnit) {
-        db.updateDistanceUnit(unit)
-        _preferences.value = _preferences.value.copy(distanceUnit = unit)
+    override suspend fun setDistanceUnit(distanceUnit: DistanceUnit) {
+        db.updateDistanceUnit(distanceUnit)
+        _preferences.update { it.copy(distanceUnit = distanceUnit) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/DistanceUnit.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/DistanceUnit.kt
@@ -1,0 +1,5 @@
+package com.cyrillrx.rpg.settings.domain
+
+enum class DistanceUnit {
+    FEET, METERS
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/Theme.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/Theme.kt
@@ -1,0 +1,5 @@
+package com.cyrillrx.rpg.settings.domain
+
+enum class Theme {
+    LIGHT, DARK, AUTO
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/Theme.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/Theme.kt
@@ -1,5 +1,5 @@
 package com.cyrillrx.rpg.settings.domain
 
 enum class Theme {
-    LIGHT, DARK, AUTO
+    LIGHT, DARK, SYSTEM
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferences.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferences.kt
@@ -1,0 +1,6 @@
+package com.cyrillrx.rpg.settings.domain
+
+data class UserPreferences(
+    val theme: Theme = Theme.AUTO,
+    val distanceUnit: DistanceUnit = DistanceUnit.FEET,
+)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferences.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferences.kt
@@ -1,6 +1,6 @@
 package com.cyrillrx.rpg.settings.domain
 
 data class UserPreferences(
-    val theme: Theme = Theme.AUTO,
+    val theme: Theme = Theme.SYSTEM,
     val distanceUnit: DistanceUnit = DistanceUnit.FEET,
 )

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferencesRepository.kt
@@ -1,0 +1,9 @@
+package com.cyrillrx.rpg.settings.domain
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface UserPreferencesRepository {
+    val preferences: StateFlow<UserPreferences>
+    suspend fun setTheme(theme: Theme)
+    suspend fun setDistanceUnit(unit: DistanceUnit)
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/UserPreferencesRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface UserPreferencesRepository {
     val preferences: StateFlow<UserPreferences>
+    suspend fun initialize()
     suspend fun setTheme(theme: Theme)
     suspend fun setDistanceUnit(unit: DistanceUnit)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/2.sqm
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/2.sqm
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS UserPreferencesEntity (
     id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
-    theme_mode TEXT NOT NULL DEFAULT 'auto',
+    theme TEXT NOT NULL DEFAULT 'system',
     distance_unit TEXT NOT NULL DEFAULT 'feet'
 );
 INSERT OR IGNORE INTO UserPreferencesEntity (id) VALUES (1);

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/2.sqm
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/2.sqm
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS UserPreferencesEntity (
+    id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
+    theme_mode TEXT NOT NULL DEFAULT 'auto',
+    distance_unit TEXT NOT NULL DEFAULT 'feet'
+);
+INSERT OR IGNORE INTO UserPreferencesEntity (id) VALUES (1);

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/2.sqm
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/2.sqm
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS UserPreferencesEntity (
+CREATE TABLE UserPreferencesEntity (
     id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
     theme TEXT NOT NULL DEFAULT 'system',
     distance_unit TEXT NOT NULL DEFAULT 'feet'

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
@@ -39,7 +39,7 @@ DELETE FROM Character WHERE id = ?;
 
 CREATE TABLE UserPreferencesEntity (
     id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
-    theme_mode TEXT NOT NULL DEFAULT 'auto',
+    theme TEXT NOT NULL DEFAULT 'system',
     distance_unit TEXT NOT NULL DEFAULT 'feet'
 );
 
@@ -49,8 +49,8 @@ INSERT OR IGNORE INTO UserPreferencesEntity (id) VALUES (1);
 getUserPreferences:
 SELECT * FROM UserPreferencesEntity WHERE id = 1;
 
-updateThemeMode:
-UPDATE UserPreferencesEntity SET theme_mode = ? WHERE id = 1;
+updateTheme:
+UPDATE UserPreferencesEntity SET theme = ? WHERE id = 1;
 
 updateDistanceUnit:
 UPDATE UserPreferencesEntity SET distance_unit = ? WHERE id = 1;

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/sqldelight/com/cyrillrx/rpg/core/data/cache/AppDatabase.sq
@@ -37,6 +37,24 @@ SELECT Character.* FROM Character WHERE id IN ?;
 deleteCharacter:
 DELETE FROM Character WHERE id = ?;
 
+CREATE TABLE UserPreferencesEntity (
+    id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
+    theme_mode TEXT NOT NULL DEFAULT 'auto',
+    distance_unit TEXT NOT NULL DEFAULT 'feet'
+);
+
+initUserPreferences:
+INSERT OR IGNORE INTO UserPreferencesEntity (id) VALUES (1);
+
+getUserPreferences:
+SELECT * FROM UserPreferencesEntity WHERE id = 1;
+
+updateThemeMode:
+UPDATE UserPreferencesEntity SET theme_mode = ? WHERE id = 1;
+
+updateDistanceUnit:
+UPDATE UserPreferencesEntity SET distance_unit = ? WHERE id = 1;
+
 CREATE TABLE UserList (
     id TEXT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,

--- a/cmp-ttrpg-companion/shared/core/src/jvmMain/kotlin/com/cyrillrx/rpg/core/data/cache/DesktopDatabaseDriverFactory.kt
+++ b/cmp-ttrpg-companion/shared/core/src/jvmMain/kotlin/com/cyrillrx/rpg/core/data/cache/DesktopDatabaseDriverFactory.kt
@@ -23,7 +23,7 @@ class DesktopDatabaseDriverFactory : DatabaseDriverFactory {
                 try {
                     AppDatabase.Schema.create(driver)
                 } catch (e: Exception) {
-                    // Existing unversioned DB: treat as v1, run remaining migrations
+                    println("WARNING: DB creation failed (existing unversioned DB?), migrating from v1: ${e.message}")
                     AppDatabase.Schema.migrate(driver, 1L, targetVersion)
                 }
                 driver.execute(null, "PRAGMA user_version = $targetVersion", 0)

--- a/cmp-ttrpg-companion/shared/core/src/jvmMain/kotlin/com/cyrillrx/rpg/core/data/cache/DesktopDatabaseDriverFactory.kt
+++ b/cmp-ttrpg-companion/shared/core/src/jvmMain/kotlin/com/cyrillrx/rpg/core/data/cache/DesktopDatabaseDriverFactory.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.core.data.cache
 
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.cyrillrx.rpg.cache.AppDatabase
@@ -8,12 +9,31 @@ import com.cyrillrx.rpg.core.data.cache.Database.Companion.DATABASE_NAME
 class DesktopDatabaseDriverFactory : DatabaseDriverFactory {
     override fun createDriver(): SqlDriver {
         val driver: SqlDriver = JdbcSqliteDriver(URL_PREFIX + DATABASE_NAME)
+        val targetVersion = AppDatabase.Schema.version
+        val storedVersion = driver.executeQuery(
+            identifier = null,
+            sql = "PRAGMA user_version",
+            mapper = { cursor -> QueryResult.Value(cursor.getLong(0) ?: 0L) },
+            parameters = 0,
+        ).value
 
-        try {
-            AppDatabase.Schema.create(driver)
-        } catch (e: Exception) {
-            // DB already exists 🤷‍♂️
+        when {
+            storedVersion == 0L -> {
+                // Fresh install or pre-migration DB (never had version stamped)
+                try {
+                    AppDatabase.Schema.create(driver)
+                } catch (e: Exception) {
+                    // Existing unversioned DB: treat as v1, run remaining migrations
+                    AppDatabase.Schema.migrate(driver, 1L, targetVersion)
+                }
+                driver.execute(null, "PRAGMA user_version = $targetVersion", 0)
+            }
+            storedVersion < targetVersion -> {
+                AppDatabase.Schema.migrate(driver, storedVersion, targetVersion)
+                driver.execute(null, "PRAGMA user_version = $targetVersion", 0)
+            }
         }
+
         return driver
     }
 


### PR DESCRIPTION
## 📝 Description

Adds the foundation for the user settings feature across 3 layers:

- **SQLDelight**: new `UserPreferencesEntity` table (single-row key-value) + migration `2.sqm`. Also fixes `DesktopDatabaseDriverFactory` which never ran migrations.
- **Domain/Data** (`shared/core`): `Theme`, `DistanceUnit`, `UserPreferences` types; `UserPreferencesRepository` interface (including `initialize()`); `SqlDelightUserPreferencesRepository` implementation backed by an explicit backing field `MutableStateFlow` for reactivity; all DB operations dispatched on `Dispatchers.IO`.
- **Presentation** (`composeApp`): `SettingsRoute`, `SettingsRouter`, empty `SettingsScreen` with back navigation (EN + FR strings).
- **Home**: `openSettings()` added to `HomeRouter`; all `HomeRouter` methods are now abstract (no default no-ops); `PreviewHomeRouter` named object added for previews; settings icon in the `HomeScreen` top bar.
- **App**: settings route registered; preferences repository typed as `UserPreferencesRepository` and initialized asynchronously via `LaunchedEffect`.

This PR is intentionally scope-limited to navigation and infrastructure. Theme and distance-unit settings will be added in subsequent PRs.

## 🖼️ Media

<img width="1080" height="2400" alt="Screenshot_20260522_122937" src="https://github.com/user-attachments/assets/2b21c745-f0e8-49a4-adf1-0465bf9ef9e1" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [ ] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed
