### PR TITLE
fix(character): unit-aware coerced value snackbar

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -44,5 +44,5 @@
     <string name="no_result_found">Aucun résultat trouvé.</string>
     <string name="no_result_found_for_query">Aucun résultat trouvé pour '%1$s'.</string>
 
-    <string name="info_value_coerced">Valeur adaptée : %1$d</string>
+    <string name="info_value_coerced">%1$s invalide, adapté à %2$s</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -48,5 +48,5 @@
     <string name="error_spell_not_found">Spell not found: %1$s</string>
     <string name="error_magical_item_not_found">Magical item not found: %1$s</string>
 
-    <string name="info_value_coerced">Value adapted: %1$d</string>
+    <string name="info_value_coerced">%1$s invalid, adapted to %2$s</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CoercedValue.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/CoercedValue.kt
@@ -1,0 +1,6 @@
+package com.cyrillrx.rpg.character.presentation
+
+sealed interface CoercedValue {
+    data class Numeric(val original: Int, val coerced: Int) : CoercedValue
+    data class Distance(val originalFeet: Int, val coercedFeet: Int) : CoercedValue
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
@@ -25,9 +26,12 @@ import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
 import com.cyrillrx.rpg.character.domain.Race
+import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
+import com.cyrillrx.rpg.core.presentation.component.dnd.toDistanceString
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
+import com.cyrillrx.rpg.character.presentation.CoercedValue
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
 import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterEditViewModel
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
@@ -54,9 +58,14 @@ fun CharacterDetailScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val coercedMessage = stringResource(Res.string.info_value_coerced)
+    val unit by rememberUpdatedState(LocalDistanceUnit.current)
     LaunchedEffect(viewModel) {
-        viewModel.coercedValueEvent.collect { coerced ->
-            snackbarHostState.showSnackbar(coercedMessage.format(coerced))
+        viewModel.coercedValueEvent.collect { event ->
+            val (from, to) = when (event) {
+                is CoercedValue.Numeric -> event.original.toString() to event.coerced.toString()
+                is CoercedValue.Distance -> event.originalFeet.toDistanceString(unit) to event.coercedFeet.toDistanceString(unit)
+            }
+            snackbarHostState.showSnackbar(coercedMessage.format(from, to))
         }
     }
     when (val s = state) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -58,12 +58,12 @@ fun CharacterDetailScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val coercedMessage = stringResource(Res.string.info_value_coerced)
-    val unit by rememberUpdatedState(LocalDistanceUnit.current)
+    val distanceUnit by rememberUpdatedState(LocalDistanceUnit.current)
     LaunchedEffect(viewModel) {
         viewModel.coercedValueEvent.collect { event ->
             val (from, to) = when (event) {
                 is CoercedValue.Numeric -> event.original.toString() to event.coerced.toString()
-                is CoercedValue.Distance -> event.originalFeet.toDistanceString(unit) to event.coercedFeet.toDistanceString(unit)
+                is CoercedValue.Distance -> event.originalFeet.toDistanceString(distanceUnit) to event.coercedFeet.toDistanceString(distanceUnit)
             }
             snackbarHostState.showSnackbar(coercedMessage.format(from, to))
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
@@ -16,6 +16,7 @@ import com.cyrillrx.rpg.character.domain.defaultWalkSpeed
 import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
+import com.cyrillrx.rpg.character.presentation.CoercedValue
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
@@ -36,8 +37,8 @@ class CharacterEditViewModel(
     val state: StateFlow<CharacterEditState>
         field = MutableStateFlow<CharacterEditState>(CharacterEditState.Loading)
 
-    val coercedValueEvent: SharedFlow<Int>
-        field = MutableSharedFlow<Int>(extraBufferCapacity = 1)
+    val coercedValueEvent: SharedFlow<CoercedValue>
+        field = MutableSharedFlow<CoercedValue>(extraBufferCapacity = 1)
 
     init {
         viewModelScope.launch {
@@ -99,8 +100,10 @@ class CharacterEditViewModel(
         copy(character = character.copy(maxHitPoints = coerced), editingField = null)
     }
 
-    fun saveWalkSpeed(value: Int) = updateAndSave(value, Int::coerceToValidWalkSpeedInFeet) { coerced ->
-        copy(character = character.copy(speeds = character.speeds.copy(walk = coerced)), editingField = null)
+    fun saveWalkSpeed(value: Int) {
+        val coerced = value.coerceToValidWalkSpeedInFeet()
+        if (coerced != value) coercedValueEvent.tryEmit(CoercedValue.Distance(value, coerced))
+        updateAndSave { copy(character = character.copy(speeds = character.speeds.copy(walk = coerced)), editingField = null) }
     }
 
     fun saveLanguages(languages: List<Language>) {
@@ -128,7 +131,7 @@ class CharacterEditViewModel(
 
     private fun updateAndSave(candidate: Int, coerce: (Int) -> Int, applyEdit: Loaded.(Int) -> Loaded) {
         val coerced = coerce(candidate)
-        if (coerced != candidate) coercedValueEvent.tryEmit(coerced)
+        if (coerced != candidate) coercedValueEvent.tryEmit(CoercedValue.Numeric(candidate, coerced))
         updateAndSave { applyEdit(coerced) }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
@@ -9,6 +9,7 @@ import com.cyrillrx.rpg.character.domain.Language
 import com.cyrillrx.rpg.character.domain.Race
 import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
+import com.cyrillrx.rpg.character.presentation.CoercedValue
 import com.cyrillrx.rpg.creature.domain.Creature
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -24,6 +25,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CharacterEditViewModelTest {
@@ -229,15 +231,15 @@ class CharacterEditViewModelTest {
     // ─── coercedValueEvent ────────────────────────────────────────────────────
 
     @Test
-    fun `coercedValueEvent emits coerced value when input is out of range`() = runTest(testDispatcher) {
+    fun `coercedValueEvent emits Numeric when level is out of range`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        val events = mutableListOf<Int>()
+        val events = mutableListOf<CoercedValue>()
         val job = launch { viewModel.coercedValueEvent.collect { events.add(it) } }
         advanceUntilIdle()
         viewModel.saveLevel(25)  // max is 20, coerced to 20
         advanceUntilIdle()
-        assertEquals(listOf(20), events)
+        assertEquals(listOf<CoercedValue>(CoercedValue.Numeric(25, 20)), events)
         job.cancel()
     }
 
@@ -245,12 +247,25 @@ class CharacterEditViewModelTest {
     fun `coercedValueEvent does not emit when input is already valid`() = runTest(testDispatcher) {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
-        val events = mutableListOf<Int>()
+        val events = mutableListOf<CoercedValue>()
         val job = launch { viewModel.coercedValueEvent.collect { events.add(it) } }
         advanceUntilIdle()
         viewModel.saveLevel(5)  // valid, no coercion
         advanceUntilIdle()
-        assertEquals(emptyList<Int>(), events)
+        assertTrue(events.isEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `coercedValueEvent emits Distance when walk speed is invalid`() = runTest(testDispatcher) {
+        val viewModel = buildViewModel(repo = repoWithFighter())
+        advanceUntilIdle()
+        val events = mutableListOf<CoercedValue>()
+        val job = launch { viewModel.coercedValueEvent.collect { events.add(it) } }
+        advanceUntilIdle()
+        viewModel.saveWalkSpeed(27)  // not a multiple of 5, coerced to 25
+        advanceUntilIdle()
+        assertEquals(listOf<CoercedValue>(CoercedValue.Distance(27, 25)), events)
         job.cancel()
     }
 


### PR DESCRIPTION
## 📝 Description

The `coercedValueEvent` channel previously emitted a raw `Int` (feet) for all fields. In meters mode, the snackbar was showing a feet value, which was confusing.

- **`CoercedValue` sealed interface**: two variants — `Numeric(original, coerced)` for unit-less fields (level, abilities, AC, HP) and `Distance(originalFeet, coercedFeet)` for walk speed.
- **ViewModel**: `updateAndSave` emits `CoercedValue.Numeric`; `saveWalkSpeed` emits `CoercedValue.Distance` directly so the event type matches the semantic of the field.
- **`CharacterDetailScreen`**: uses `rememberUpdatedState` to always read the latest `LocalDistanceUnit` without restarting the effect; dispatches on event type and formats distances via `toDistanceString`.
- **String resources**: `info_value_coerced` updated to `"%1$s invalid, adapted to %2$s"` / `"%1$s invalide, adapté à %2$s"` — shows both the original and the coerced value.
- **Tests**: existing tests updated to assert on `CoercedValue.Numeric`; new dedicated test for `saveWalkSpeed` asserting `CoercedValue.Distance` — guards against the regression where dialog pre-coercion silenced the event.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [ ] Documentation updated if public APIs or architecture decisions changed