### PR TITLE
feat(character): add SwipeToDelete with undo snackbar on character list

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -3,6 +3,8 @@
 <resources>
     <!-- Character list -->
     <string name="title_character_list">Personnages</string>
+    <string name="snackbar_character_deleted">« %1$s » a été supprimé</string>
+    <string name="snackbar_error_deleting_character">Erreur lors de la suppression de « %1$s ».</string>
     <string name="title_preset_gallery">Création rapide</string>
     <string name="tab_player_characters">Personnages</string>
     <string name="tab_non_player_characters">PNJ</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -3,6 +3,8 @@
 <resources>
     <!-- Character list -->
     <string name="title_character_list">Characters</string>
+    <string name="snackbar_character_deleted">'%1$s' was deleted</string>
+    <string name="snackbar_error_deleting_character">Error deleting '%1$s'.</string>
     <string name="title_preset_gallery">Quick Create</string>
     <string name="tab_player_characters">Characters</string>
     <string name="tab_non_player_characters">NPCs</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -120,19 +120,21 @@ fun CharacterListScreen(
         }
     }
 
-    fun onDeleteCharacter(character: Character) {
-        val pending = onDeleteCharacterOptimistically(character) ?: return
+    val onDeleteCharacter: (Character) -> Unit = remember(onDeleteCharacterOptimistically, onUndoDeletion, onCommitDeletion) {
+        handler@{ character ->
+            val pending = onDeleteCharacterOptimistically(character) ?: return@handler
 
-        coroutineScope.launch {
-            val deletedMessage = getString(Res.string.snackbar_character_deleted, character.name)
-            val result = snackbarHostState.showSnackbar(
-                message = deletedMessage,
-                actionLabel = undoLabel,
-                duration = SnackbarDuration.Short,
-            )
-            when (result) {
-                SnackbarResult.ActionPerformed -> onUndoDeletion(pending)
-                SnackbarResult.Dismissed -> onCommitDeletion(pending)
+            coroutineScope.launch {
+                val deletedMessage = getString(Res.string.snackbar_character_deleted, character.name)
+                val result = snackbarHostState.showSnackbar(
+                    message = deletedMessage,
+                    actionLabel = undoLabel,
+                    duration = SnackbarDuration.Short,
+                )
+                when (result) {
+                    SnackbarResult.ActionPerformed -> onUndoDeletion(pending)
+                    SnackbarResult.Dismissed -> onCommitDeletion(pending)
+                }
             }
         }
     }
@@ -186,7 +188,7 @@ fun CharacterListScreen(
                         CharacterList(
                             characters = body.searchResults,
                             onCharacterClicked = onCharacterClicked,
-                            onDeleteCharacter = ::onDeleteCharacter,
+                            onDeleteCharacter = onDeleteCharacter,
                         )
                 }
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -18,9 +18,16 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
@@ -36,12 +43,17 @@ import com.cyrillrx.rpg.core.presentation.component.EmptySearch
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -49,6 +61,9 @@ import rpg_companion.composeapp.generated.resources.btn_new_character
 import rpg_companion.composeapp.generated.resources.btn_new_character_subtitle
 import rpg_companion.composeapp.generated.resources.btn_quick_create
 import rpg_companion.composeapp.generated.resources.btn_quick_create_subtitle
+import rpg_companion.composeapp.generated.resources.btn_undo
+import rpg_companion.composeapp.generated.resources.snackbar_character_deleted
+import rpg_companion.composeapp.generated.resources.snackbar_error_deleting_character
 import rpg_companion.composeapp.generated.resources.title_character_list
 
 @Composable
@@ -64,21 +79,64 @@ fun CharacterListScreen(
 
     CharacterListScreen(
         state = state,
+        events = viewModel.events,
         onNavigateUpClicked = router::navigateUp,
         onCharacterClicked = viewModel::openCharacterDetail,
         onNewCharacterClicked = viewModel::openCreateCharacter,
         onQuickCreateClicked = viewModel::openPresetGallery,
+        onDeleteCharacterOptimistically = viewModel::deleteCharacterOptimistically,
+        onUndoDeletion = viewModel::undoDeletion,
+        onCommitDeletion = viewModel::commitDeletion,
     )
 }
 
 @Composable
 fun CharacterListScreen(
     state: CharacterListState,
+    events: SharedFlow<CharacterListViewModel.Event>,
     onNavigateUpClicked: () -> Unit,
     onCharacterClicked: (Character) -> Unit,
     onNewCharacterClicked: () -> Unit,
     onQuickCreateClicked: () -> Unit,
+    onDeleteCharacterOptimistically: (Character) -> CharacterListViewModel.PendingDeletion?,
+    onUndoDeletion: (CharacterListViewModel.PendingDeletion) -> Unit,
+    onCommitDeletion: (CharacterListViewModel.PendingDeletion) -> Unit,
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    val undoLabel = stringResource(Res.string.btn_undo)
+
+    LaunchedEffect(events) {
+        events.collect { event ->
+            when (event) {
+                is CharacterListViewModel.Event.DeletionError -> {
+                    val errorMessage = getString(Res.string.snackbar_error_deleting_character, event.character.name)
+                    snackbarHostState.showSnackbar(
+                        message = errorMessage,
+                        duration = SnackbarDuration.Short,
+                    )
+                }
+            }
+        }
+    }
+
+    fun onDeleteCharacter(character: Character) {
+        val pending = onDeleteCharacterOptimistically(character) ?: return
+
+        coroutineScope.launch {
+            val deletedMessage = getString(Res.string.snackbar_character_deleted, character.name)
+            val result = snackbarHostState.showSnackbar(
+                message = deletedMessage,
+                actionLabel = undoLabel,
+                duration = SnackbarDuration.Short,
+            )
+            when (result) {
+                SnackbarResult.ActionPerformed -> onUndoDeletion(pending)
+                SnackbarResult.Dismissed -> onCommitDeletion(pending)
+            }
+        }
+    }
+
     Scaffold(
         topBar = {
             SimpleTopBar(
@@ -86,6 +144,7 @@ fun CharacterListScreen(
                 onNavigateUpClicked = onNavigateUpClicked,
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         Column(
             modifier =
@@ -127,6 +186,7 @@ fun CharacterListScreen(
                         CharacterList(
                             characters = body.searchResults,
                             onCharacterClicked = onCharacterClicked,
+                            onDeleteCharacter = ::onDeleteCharacter,
                         )
                 }
             }
@@ -181,6 +241,7 @@ private fun CharacterActionCard(
 private fun CharacterList(
     characters: List<Character>,
     onCharacterClicked: (Character) -> Unit,
+    onDeleteCharacter: (Character) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -189,11 +250,13 @@ private fun CharacterList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(characters, key = { it.id }) { character ->
-            CharacterListItem(
-                character = character,
-                onClick = { onCharacterClicked(character) },
-                modifier = Modifier.fillMaxWidth(),
-            )
+            SwipeToDelete(onSwiped = { onDeleteCharacter(character) }) {
+                CharacterListItem(
+                    character = character,
+                    onClick = { onCharacterClicked(character) },
+                    modifier = Modifier.fillMaxWidth().animateItem(),
+                )
+            }
         }
     }
 }
@@ -218,9 +281,13 @@ private fun CharacterListScreenPreview() {
                 searchQuery = "",
                 body = CharacterListState.Body.WithData(SampleCharacterRepository.getAll()),
             ),
+        events = MutableSharedFlow(),
         onNavigateUpClicked = {},
         onCharacterClicked = {},
         onNewCharacterClicked = {},
         onQuickCreateClicked = {},
+        onDeleteCharacterOptimistically = { null },
+        onUndoDeletion = {},
+        onCommitDeletion = {},
     )
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -21,13 +21,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
@@ -44,6 +42,7 @@ import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
+import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth
@@ -52,7 +51,6 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -61,7 +59,6 @@ import rpg_companion.composeapp.generated.resources.btn_new_character
 import rpg_companion.composeapp.generated.resources.btn_new_character_subtitle
 import rpg_companion.composeapp.generated.resources.btn_quick_create
 import rpg_companion.composeapp.generated.resources.btn_quick_create_subtitle
-import rpg_companion.composeapp.generated.resources.btn_undo
 import rpg_companion.composeapp.generated.resources.snackbar_character_deleted
 import rpg_companion.composeapp.generated.resources.snackbar_error_deleting_character
 import rpg_companion.composeapp.generated.resources.title_character_list
@@ -103,8 +100,6 @@ fun CharacterListScreen(
     onCommitDeletion: (CharacterListViewModel.PendingDeletion) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
-    val coroutineScope = rememberCoroutineScope()
-    val undoLabel = stringResource(Res.string.btn_undo)
 
     LaunchedEffect(events) {
         events.collect { event ->
@@ -120,24 +115,13 @@ fun CharacterListScreen(
         }
     }
 
-    val onDeleteCharacter: (Character) -> Unit = remember(onDeleteCharacterOptimistically, onUndoDeletion, onCommitDeletion) {
-        handler@{ character ->
-            val pending = onDeleteCharacterOptimistically(character) ?: return@handler
-
-            coroutineScope.launch {
-                val deletedMessage = getString(Res.string.snackbar_character_deleted, character.name)
-                val result = snackbarHostState.showSnackbar(
-                    message = deletedMessage,
-                    actionLabel = undoLabel,
-                    duration = SnackbarDuration.Short,
-                )
-                when (result) {
-                    SnackbarResult.ActionPerformed -> onUndoDeletion(pending)
-                    SnackbarResult.Dismissed -> onCommitDeletion(pending)
-                }
-            }
-        }
-    }
+    val onDeleteCharacter = rememberOptimisticDeleteHandler(
+        snackbarHostState = snackbarHostState,
+        onDeleteOptimistically = onDeleteCharacterOptimistically,
+        onUndo = onUndoDeletion,
+        onCommit = onCommitDeletion,
+        getMessage = { character -> getString(Res.string.snackbar_character_deleted, character.name) },
+    )
 
     Scaffold(
         topBar = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -250,11 +250,14 @@ private fun CharacterList(
         verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         items(characters, key = { it.id }) { character ->
-            SwipeToDelete(onSwiped = { onDeleteCharacter(character) }) {
+            SwipeToDelete(
+                onSwiped = { onDeleteCharacter(character) },
+                modifier = Modifier.fillMaxWidth().animateItem(),
+            ) {
                 CharacterListItem(
                     character = character,
                     onClick = { onCharacterClicked(character) },
-                    modifier = Modifier.fillMaxWidth().animateItem(),
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -72,6 +73,10 @@ fun CharacterListScreen(
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.silentRefresh()
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.commitAllPendingDeletions() }
     }
 
     CharacterListScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -47,11 +47,6 @@ class CharacterListViewModel(
         loadCharacters(query = "")
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        commitAllPendingDeletions()
-    }
-
     fun filterByQuery(query: String) {
         activeJob?.cancel()
         activeJob = loadCharacters(query)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -7,8 +7,14 @@ import com.cyrillrx.rpg.character.domain.CharacterFilter
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.presentation.CharacterListState
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -19,13 +25,31 @@ import kotlin.coroutines.cancellation.CancellationException
 class CharacterListViewModel(
     private val router: CharacterRouter,
     private val repository: CharacterRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
-    private var activeJob: Job? = null
+
     val state: StateFlow<CharacterListState>
         field = MutableStateFlow(CharacterListState(searchQuery = "", body = CharacterListState.Body.Loading))
 
+    val events: SharedFlow<Event>
+        field = MutableSharedFlow<Event>()
+
+    data class PendingDeletion(val character: Character, val index: Int)
+
+    sealed interface Event {
+        data class DeletionError(val character: Character) : Event
+    }
+
+    private val pendingDeletions: MutableList<PendingDeletion> = mutableListOf()
+    private var activeJob: Job? = null
+
     init {
         loadCharacters(query = "")
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        commitAllPendingDeletions()
     }
 
     fun filterByQuery(query: String) {
@@ -49,6 +73,64 @@ class CharacterListViewModel(
 
     fun openPresetGallery() {
         router.openPresetGallery()
+    }
+
+    fun deleteCharacterOptimistically(character: Character): PendingDeletion? {
+        val currentState = state.value.body as? CharacterListState.Body.WithData ?: return null
+
+        val index = currentState.searchResults.indexOf(character)
+        if (index == -1) return null
+
+        val pending = PendingDeletion(character, index)
+        pendingDeletions.add(pending)
+        val updatedList = currentState.searchResults - character
+        val newBody = if (updatedList.isEmpty()) {
+            CharacterListState.Body.Empty
+        } else {
+            CharacterListState.Body.WithData(updatedList)
+        }
+        state.update { it.copy(body = newBody) }
+        return pending
+    }
+
+    fun undoDeletion(pending: PendingDeletion) {
+        if (!pendingDeletions.remove(pending)) return
+
+        val currentList = when (val body = state.value.body) {
+            is CharacterListState.Body.WithData -> body.searchResults
+            is CharacterListState.Body.Empty -> emptyList()
+            else -> return
+        }
+        val restoredList = currentList.toMutableList().apply { add(pending.index.coerceAtMost(size), pending.character) }
+        state.update { it.copy(body = CharacterListState.Body.WithData(restoredList)) }
+    }
+
+    fun commitDeletion(pending: PendingDeletion) {
+        if (!pendingDeletions.remove(pending)) return
+
+        viewModelScope.launch {
+            try {
+                repository.delete(pending.character.id)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                pendingDeletions.add(pending)
+                undoDeletion(pending)
+                events.emit(Event.DeletionError(pending.character))
+            }
+        }
+    }
+
+    internal fun commitAllPendingDeletions() {
+        val toCommit = pendingDeletions.toList()
+        pendingDeletions.clear()
+        if (toCommit.isEmpty()) return
+
+        CoroutineScope(ioDispatcher).launch {
+            toCommit.forEach { pending ->
+                repository.delete(pending.character.id)
+            }
+        }
     }
 
     private fun refreshCharacters(): Job =

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -7,8 +7,8 @@ import com.cyrillrx.rpg.character.domain.CharacterFilter
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.presentation.CharacterListState
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import com.cyrillrx.rpg.core.presentation.commitAllPending
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
@@ -101,7 +101,8 @@ class CharacterListViewModel(
             is CharacterListState.Body.Empty -> emptyList()
             else -> return
         }
-        val restoredList = currentList.toMutableList().apply { add(pending.index.coerceAtMost(size), pending.character) }
+        val restoredList = currentList.toMutableList()
+            .apply { add(pending.index.coerceAtMost(size), pending.character) }
         state.update { it.copy(body = CharacterListState.Body.WithData(restoredList)) }
     }
 
@@ -122,20 +123,8 @@ class CharacterListViewModel(
     }
 
     internal fun commitAllPendingDeletions() {
-        val toCommit = pendingDeletions.toList()
-        pendingDeletions.clear()
-        if (toCommit.isEmpty()) return
-
-        CoroutineScope(ioDispatcher).launch {
-            toCommit.forEach { pending ->
-                try {
-                    repository.delete(pending.character.id)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Best-effort; ViewModel is cleared so the UI cannot be recovered
-                }
-            }
+        pendingDeletions.commitAllPending(ioDispatcher) { pending ->
+            repository.delete(pending.character.id)
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -128,7 +128,13 @@ class CharacterListViewModel(
 
         CoroutineScope(ioDispatcher).launch {
             toCommit.forEach { pending ->
-                repository.delete(pending.character.id)
+                try {
+                    repository.delete(pending.character.id)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Best-effort; ViewModel is cleared so the UI cannot be recovered
+                }
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelFactory.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelFactory.kt
@@ -5,14 +5,18 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlin.reflect.KClass
 
 class CharacterListViewModelFactory(
     private val router: CharacterRouter,
     private val repository: CharacterRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
-        return CharacterListViewModel(router, repository) as T
+        return CharacterListViewModel(router, repository, ioDispatcher) as T
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/MutableListExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/MutableListExt.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.rpg.core.presentation
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -13,7 +14,7 @@ internal fun <T> MutableList<T>.commitAllPending(
     clear()
     if (toCommit.isEmpty()) return
 
-    CoroutineScope(dispatcher).launch {
+    CoroutineScope(SupervisorJob() + dispatcher).launch {
         toCommit.forEach { item ->
             try {
                 block(item)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/MutableListExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/MutableListExt.kt
@@ -1,0 +1,27 @@
+package com.cyrillrx.rpg.core.presentation
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+
+internal fun <T> MutableList<T>.commitAllPending(
+    dispatcher: CoroutineDispatcher,
+    block: suspend (T) -> Unit,
+) {
+    val toCommit = toList()
+    clear()
+    if (toCommit.isEmpty()) return
+
+    CoroutineScope(dispatcher).launch {
+        toCommit.forEach { item ->
+            try {
+                block(item)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Best-effort; ViewModel is cleared so the UI cannot be recovered
+            }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/OptimisticDeleteHandler.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/OptimisticDeleteHandler.kt
@@ -21,7 +21,7 @@ fun <Item, Pending> rememberOptimisticDeleteHandler(
 ): (Item) -> Unit {
     val coroutineScope = rememberCoroutineScope()
     val undoLabel = stringResource(Res.string.btn_undo)
-    return remember(onDeleteOptimistically, onUndo, onCommit) {
+    return remember(onDeleteOptimistically, onUndo, onCommit, undoLabel) {
         handler@{ item ->
             val pending = onDeleteOptimistically(item) ?: return@handler
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/OptimisticDeleteHandler.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/OptimisticDeleteHandler.kt
@@ -1,0 +1,41 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_undo
+
+@Composable
+fun <Item, Pending> rememberOptimisticDeleteHandler(
+    snackbarHostState: SnackbarHostState,
+    onDeleteOptimistically: (Item) -> Pending?,
+    onUndo: (Pending) -> Unit,
+    onCommit: (Pending) -> Unit,
+    getMessage: suspend (Item) -> String,
+): (Item) -> Unit {
+    val coroutineScope = rememberCoroutineScope()
+    val undoLabel = stringResource(Res.string.btn_undo)
+    return remember(onDeleteOptimistically, onUndo, onCommit) {
+        handler@{ item ->
+            val pending = onDeleteOptimistically(item) ?: return@handler
+
+            coroutineScope.launch {
+                val result = snackbarHostState.showSnackbar(
+                    message = getMessage(item),
+                    actionLabel = undoLabel,
+                    duration = SnackbarDuration.Short,
+                )
+                when (result) {
+                    SnackbarResult.ActionPerformed -> onUndo(pending)
+                    SnackbarResult.Dismissed -> onCommit(pending)
+                }
+            }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -110,20 +110,22 @@ fun <T> ListDetailScreen(
         }
     }
 
-    fun onRemoveItem(item: T) {
-        val pending = onRemoveItemOptimistically(itemProvider.getId(item), item) ?: return
+    val onRemoveItem: (T) -> Unit = remember(onRemoveItemOptimistically, onUndoRemoval, onCommitRemoval, itemProvider) {
+        handler@{ item ->
+            val pending = onRemoveItemOptimistically(itemProvider.getId(item), item) ?: return@handler
 
-        coroutineScope.launch {
-            val displayName = itemProvider.getDisplayName(item, currentLocale())
-            val removedMessage = getString(Res.string.snackbar_removed_from_list, displayName)
-            val result = snackbarHostState.showSnackbar(
-                message = removedMessage,
-                actionLabel = undoLabel,
-                duration = SnackbarDuration.Short,
-            )
-            when (result) {
-                SnackbarResult.ActionPerformed -> onUndoRemoval(pending)
-                SnackbarResult.Dismissed -> onCommitRemoval(pending)
+            coroutineScope.launch {
+                val displayName = itemProvider.getDisplayName(item, currentLocale())
+                val removedMessage = getString(Res.string.snackbar_removed_from_list, displayName)
+                val result = snackbarHostState.showSnackbar(
+                    message = removedMessage,
+                    actionLabel = undoLabel,
+                    duration = SnackbarDuration.Short,
+                )
+                when (result) {
+                    SnackbarResult.ActionPerformed -> onUndoRemoval(pending)
+                    SnackbarResult.Dismissed -> onCommitRemoval(pending)
+                }
             }
         }
     }
@@ -166,7 +168,7 @@ fun <T> ListDetailScreen(
                 is ListDetailState.Body.WithData -> EntityDetailList(
                     items = body.items,
                     uiProvider = itemProvider,
-                    onRemoveItem = ::onRemoveItem,
+                    onRemoveItem = onRemoveItem,
                 )
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -62,6 +63,10 @@ fun <T> ListDetailScreen(
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.silentRefresh()
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.commitAllPendingRemovals() }
     }
 
     ListDetailScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -16,13 +16,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +31,7 @@ import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
+import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.component.dialog.RenameListDialog
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
@@ -45,13 +44,11 @@ import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_rename_list
-import rpg_companion.composeapp.generated.resources.btn_undo
 import rpg_companion.composeapp.generated.resources.snackbar_error_removing_from_list
 import rpg_companion.composeapp.generated.resources.snackbar_removed_from_list
 
@@ -91,8 +88,6 @@ fun <T> ListDetailScreen(
     onCommitRemoval: (ListDetailViewModel.PendingRemoval<T>) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
-    val coroutineScope = rememberCoroutineScope()
-    val undoLabel = stringResource(Res.string.btn_undo)
     var showRenameDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(events) {
@@ -110,25 +105,16 @@ fun <T> ListDetailScreen(
         }
     }
 
-    val onRemoveItem: (T) -> Unit = remember(onRemoveItemOptimistically, onUndoRemoval, onCommitRemoval, itemProvider) {
-        handler@{ item ->
-            val pending = onRemoveItemOptimistically(itemProvider.getId(item), item) ?: return@handler
-
-            coroutineScope.launch {
-                val displayName = itemProvider.getDisplayName(item, currentLocale())
-                val removedMessage = getString(Res.string.snackbar_removed_from_list, displayName)
-                val result = snackbarHostState.showSnackbar(
-                    message = removedMessage,
-                    actionLabel = undoLabel,
-                    duration = SnackbarDuration.Short,
-                )
-                when (result) {
-                    SnackbarResult.ActionPerformed -> onUndoRemoval(pending)
-                    SnackbarResult.Dismissed -> onCommitRemoval(pending)
-                }
-            }
-        }
-    }
+    val onRemoveItem = rememberOptimisticDeleteHandler<T, ListDetailViewModel.PendingRemoval<T>>(
+        snackbarHostState = snackbarHostState,
+        onDeleteOptimistically = { item -> onRemoveItemOptimistically(itemProvider.getId(item), item) },
+        onUndo = onUndoRemoval,
+        onCommit = onCommitRemoval,
+        getMessage = { item ->
+            val displayName = itemProvider.getDisplayName(item, currentLocale())
+            getString(Res.string.snackbar_removed_from_list, displayName)
+        },
+    )
 
     if (showRenameDialog) {
         RenameListDialog(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -107,19 +107,21 @@ fun UserListsScreen(
         }
     }
 
-    fun onDeleteList(list: UserList) {
-        val pending = onDeleteListOptimistically(list) ?: return
+    val onDeleteList: (UserList) -> Unit = remember(onDeleteListOptimistically, onUndoDeletion, onCommitDeletion) {
+        handler@{ list ->
+            val pending = onDeleteListOptimistically(list) ?: return@handler
 
-        coroutineScope.launch {
-            val deletedMessage = getString(Res.string.snackbar_list_deleted, list.name)
-            val result = snackbarHostState.showSnackbar(
-                message = deletedMessage,
-                actionLabel = undoLabel,
-                duration = SnackbarDuration.Short,
-            )
-            when (result) {
-                SnackbarResult.ActionPerformed -> onUndoDeletion(pending)
-                SnackbarResult.Dismissed -> onCommitDeletion(pending)
+            coroutineScope.launch {
+                val deletedMessage = getString(Res.string.snackbar_list_deleted, list.name)
+                val result = snackbarHostState.showSnackbar(
+                    message = deletedMessage,
+                    actionLabel = undoLabel,
+                    duration = SnackbarDuration.Short,
+                )
+                when (result) {
+                    SnackbarResult.ActionPerformed -> onUndoDeletion(pending)
+                    SnackbarResult.Dismissed -> onCommitDeletion(pending)
+                }
             }
         }
     }
@@ -154,7 +156,7 @@ fun UserListsScreen(
                 is UserListsState.Body.WithData -> UserLists(
                     lists = body.lists,
                     onListClicked = onListClicked,
-                    onDeleteList = ::onDeleteList,
+                    onDeleteList = onDeleteList,
                 )
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -16,13 +16,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +31,7 @@ import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
+import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.component.dialog.CreateListDialog
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
@@ -44,13 +43,11 @@ import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouter
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.UserListsViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_create_list
-import rpg_companion.composeapp.generated.resources.btn_undo
 import rpg_companion.composeapp.generated.resources.no_result_found
 import rpg_companion.composeapp.generated.resources.snackbar_error_deleting_list
 import rpg_companion.composeapp.generated.resources.snackbar_list_deleted
@@ -90,8 +87,6 @@ fun UserListsScreen(
 ) {
     var showCreateDialog by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
-    val coroutineScope = rememberCoroutineScope()
-    val undoLabel = stringResource(Res.string.btn_undo)
 
     LaunchedEffect(events) {
         events.collect { event ->
@@ -107,24 +102,13 @@ fun UserListsScreen(
         }
     }
 
-    val onDeleteList: (UserList) -> Unit = remember(onDeleteListOptimistically, onUndoDeletion, onCommitDeletion) {
-        handler@{ list ->
-            val pending = onDeleteListOptimistically(list) ?: return@handler
-
-            coroutineScope.launch {
-                val deletedMessage = getString(Res.string.snackbar_list_deleted, list.name)
-                val result = snackbarHostState.showSnackbar(
-                    message = deletedMessage,
-                    actionLabel = undoLabel,
-                    duration = SnackbarDuration.Short,
-                )
-                when (result) {
-                    SnackbarResult.ActionPerformed -> onUndoDeletion(pending)
-                    SnackbarResult.Dismissed -> onCommitDeletion(pending)
-                }
-            }
-        }
-    }
+    val onDeleteList = rememberOptimisticDeleteHandler(
+        snackbarHostState = snackbarHostState,
+        onDeleteOptimistically = onDeleteListOptimistically,
+        onUndo = onUndoDeletion,
+        onCommit = onCommitDeletion,
+        getMessage = { list -> getString(Res.string.snackbar_list_deleted, list.name) },
+    )
 
     Scaffold(
         topBar = {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,6 +59,10 @@ fun UserListsScreen(viewModel: UserListsViewModel, router: UserListRouter, title
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.silentRefresh()
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.commitAllPendingDeletions() }
     }
 
     UserListsScreen(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -3,19 +3,19 @@ package com.cyrillrx.rpg.userlist.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.domain.EntityRepository
+import com.cyrillrx.rpg.core.presentation.commitAllPending
 import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_user_list
@@ -114,20 +114,8 @@ class ListDetailViewModel<T>(
     }
 
     internal fun commitAllPendingRemovals() {
-        val toCommit = pendingRemovals.toList()
-        pendingRemovals.clear()
-        if (toCommit.isEmpty()) return
-
-        CoroutineScope(ioDispatcher).launch {
-            toCommit.forEach { pending ->
-                try {
-                    userListRepository.removeFromList(listId, pending.itemId)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Best-effort; ViewModel is cleared so the UI cannot be recovered
-                }
-            }
+        pendingRemovals.commitAllPending(ioDispatcher) { pending ->
+            userListRepository.removeFromList(listId, pending.itemId)
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -49,12 +49,6 @@ class ListDetailViewModel<T>(
         activeJob = loadDetail()
     }
 
-    override fun onCleared() {
-        super.onCleared()
-
-        commitAllPendingRemovals()
-    }
-
     fun renameList(newName: String) {
         val list = currentList ?: return
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModel.kt
@@ -120,7 +120,13 @@ class ListDetailViewModel<T>(
 
         CoroutineScope(ioDispatcher).launch {
             toCommit.forEach { pending ->
-                userListRepository.removeFromList(listId, pending.itemId)
+                try {
+                    userListRepository.removeFromList(listId, pending.itemId)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Best-effort; ViewModel is cleared so the UI cannot be recovered
+                }
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -129,7 +129,13 @@ class UserListsViewModel(
 
         CoroutineScope(ioDispatcher).launch {
             toCommit.forEach { pending ->
-                userListRepository.delete(pending.list.id)
+                try {
+                    userListRepository.delete(pending.list.id)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Best-effort; ViewModel is cleared so the UI cannot be recovered
+                }
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -50,12 +50,6 @@ class UserListsViewModel(
         activeJob = loadLists()
     }
 
-    override fun onCleared() {
-        super.onCleared()
-
-        commitAllPendingDeletions()
-    }
-
     @OptIn(ExperimentalUuidApi::class)
     fun createList(name: String) {
         viewModelScope.launch {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -2,20 +2,20 @@ package com.cyrillrx.rpg.userlist.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.core.presentation.commitAllPending
 import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.UserListsState
 import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRouter
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_user_lists
@@ -123,20 +123,8 @@ class UserListsViewModel(
     }
 
     internal fun commitAllPendingDeletions() {
-        val toCommit = pendingDeletions.toList()
-        pendingDeletions.clear()
-        if (toCommit.isEmpty()) return
-
-        CoroutineScope(ioDispatcher).launch {
-            toCommit.forEach { pending ->
-                try {
-                    userListRepository.delete(pending.list.id)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Best-effort; ViewModel is cleared so the UI cannot be recovered
-                }
-            }
+        pendingDeletions.commitAllPending(ioDispatcher) { pending ->
+            userListRepository.delete(pending.list.id)
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -43,7 +43,7 @@ class CharacterListViewModelTest {
     private fun buildViewModel(
         repo: CharacterRepository = repository,
         router: CharacterRouter = this.router,
-    ) = CharacterListViewModel(router, repo)
+    ) = CharacterListViewModel(router, repo, testDispatcher)
 
     @Test
     fun `initial state is Loading before coroutines run`() = runTest(testDispatcher) {
@@ -206,6 +206,84 @@ class CharacterListViewModelTest {
         viewModel.openPresetGallery()
 
         assertTrue(trackingRouter.presetGalleryCalled)
+    }
+
+    @Test
+    fun `deleteCharacterOptimistically removes the character from UI`() = runTest(testDispatcher) {
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.deleteCharacterOptimistically(character)
+
+        assertIs<CharacterListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
+    fun `undoDeletion restores the character`() = runTest(testDispatcher) {
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val pending = requireNotNull(viewModel.deleteCharacterOptimistically(character))
+        viewModel.undoDeletion(pending)
+
+        val restoredBody = assertIs<CharacterListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(character, restoredBody.searchResults.first())
+    }
+
+    @Test
+    fun `commitDeletion removes the character from repository`() = runTest(testDispatcher) {
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val pending = requireNotNull(viewModel.deleteCharacterOptimistically(character))
+        viewModel.commitDeletion(pending)
+        advanceUntilIdle()
+
+        assertTrue(repository.getAll(null).isEmpty())
+    }
+
+    @Test
+    fun `commitAllPendingDeletions commits pending deletions`() = runTest(testDispatcher) {
+        val character = SampleCharacterRepository.getAll().first()
+        repository.save(character)
+
+        val viewModel = buildViewModel()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        viewModel.deleteCharacterOptimistically(character) // no commit
+        viewModel.commitAllPendingDeletions() // simulate onCleared
+        advanceUntilIdle()
+
+        assertTrue(repository.getAll(null).isEmpty())
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -267,6 +267,35 @@ class CharacterListViewModelTest {
     }
 
     @Test
+    fun `commitDeletion restores character and emits error when repository throws`() = runTest(testDispatcher) {
+        val failingRepo = FailsOnDeleteCharacterRepository()
+        val character = SampleCharacterRepository.getAll().first()
+        failingRepo.save(character)
+
+        val viewModel = buildViewModel(repo = failingRepo)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val receivedEvents = mutableListOf<CharacterListViewModel.Event>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.events.collect { receivedEvents.add(it) }
+        }
+
+        val pending = requireNotNull(viewModel.deleteCharacterOptimistically(character))
+        viewModel.commitDeletion(pending)
+        advanceUntilIdle()
+
+        val body = assertIs<CharacterListState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(character, body.searchResults.first())
+        assertEquals(1, receivedEvents.size)
+        assertIs<CharacterListViewModel.Event.DeletionError>(receivedEvents.first())
+    }
+
+    @Test
     fun `commitAllPendingDeletions commits pending deletions`() = runTest(testDispatcher) {
         val character = SampleCharacterRepository.getAll().first()
         repository.save(character)
@@ -304,6 +333,15 @@ private class FailingCharacterRepository : CharacterRepository {
     override suspend fun getByIds(ids: List<String>): List<Character> = error("Repository error")
     override suspend fun save(character: Character) = error("Repository error")
     override suspend fun delete(id: String) = error("Repository error")
+}
+
+private class FailsOnDeleteCharacterRepository : CharacterRepository {
+    private val delegate = RamCharacterRepository()
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> = delegate.getAll(filter)
+    override suspend fun get(id: String): Character? = delegate.get(id)
+    override suspend fun getByIds(ids: List<String>): List<Character> = delegate.getByIds(ids)
+    override suspend fun save(character: Character) = delegate.save(character)
+    override suspend fun delete(id: String) = error("Delete failed")
 }
 
 private class FailsOnSecondCallCharacterRepository : CharacterRepository {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModelTest.kt
@@ -296,7 +296,7 @@ class CharacterListViewModelTest {
     }
 
     @Test
-    fun `commitAllPendingDeletions commits pending deletions`() = runTest(testDispatcher) {
+    fun `commitAllPendingDeletions commits pending deletions that were never confirmed`() = runTest(testDispatcher) {
         val character = SampleCharacterRepository.getAll().first()
         repository.save(character)
 
@@ -309,7 +309,7 @@ class CharacterListViewModelTest {
         advanceUntilIdle()
 
         viewModel.deleteCharacterOptimistically(character) // no commit
-        viewModel.commitAllPendingDeletions() // simulate onCleared
+        viewModel.commitAllPendingDeletions()
         advanceUntilIdle()
 
         assertTrue(repository.getAll(null).isEmpty())

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -286,6 +286,35 @@ class ListDetailViewModelTest {
     }
 
     @Test
+    fun `commitRemoval restores item and emits error when repository returns failure`() = runTest(testDispatcher) {
+        val failingRepo = FailsOnRemoveUserListRepository()
+        val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
+        failingRepo.save(list)
+
+        val viewModel = buildViewModel(TEST_LIST_ID, failingRepo)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val receivedEvents = mutableListOf<ListDetailViewModel.Event<Spell>>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.events.collect { receivedEvents.add(it) }
+        }
+
+        val pending = requireNotNull(viewModel.removeItemOptimistically(spell.id, spell))
+        viewModel.commitRemoval(pending)
+        advanceUntilIdle()
+
+        val body = assertIs<ListDetailState.Body.WithData<Spell>>(viewModel.state.value.body)
+        assertEquals(spell, body.items.first())
+        assertEquals(1, receivedEvents.size)
+        assertIs<ListDetailViewModel.Event.RemovalError<Spell>>(receivedEvents.first())
+    }
+
+    @Test
     fun `onCleared commits pending removals that were never confirmed`() = runTest(testDispatcher) {
         val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
@@ -304,4 +333,14 @@ class ListDetailViewModelTest {
         val updatedList = userListRepository.get(TEST_LIST_ID)!!
         assertTrue(updatedList.itemIds.none { it == spell.id })
     }
+}
+
+private class FailsOnRemoveUserListRepository : UserListRepository {
+    private val delegate = RamUserListRepository()
+    override suspend fun getAll(type: UserList.Type): List<UserList> = delegate.getAll(type)
+    override suspend fun get(id: String): UserList? = delegate.get(id)
+    override suspend fun save(list: UserList) = delegate.save(list)
+    override suspend fun delete(id: String) = delegate.delete(id)
+    override suspend fun removeFromList(listId: String, itemId: String): UserListRepository.Result =
+        UserListRepository.Result.Error("Simulated failure")
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/ListDetailViewModelTest.kt
@@ -315,7 +315,7 @@ class ListDetailViewModelTest {
     }
 
     @Test
-    fun `onCleared commits pending removals that were never confirmed`() = runTest(testDispatcher) {
+    fun `commitAllPendingRemovals commits pending removals that were never confirmed`() = runTest(testDispatcher) {
         val list = UserList(TEST_LIST_ID, LIST_NAME, UserList.Type.SPELL, listOf(spell.id))
         userListRepository.save(list)
 
@@ -327,7 +327,7 @@ class ListDetailViewModelTest {
         advanceUntilIdle()
 
         viewModel.removeItemOptimistically(spell.id, spell) // no commit
-        viewModel.commitAllPendingRemovals() // simulate navigation away
+        viewModel.commitAllPendingRemovals()
         advanceUntilIdle()
 
         val updatedList = userListRepository.get(TEST_LIST_ID)!!

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -161,6 +161,37 @@ class UserListsViewModelTest {
     }
 
     @Test
+    fun `commitDeletion restores list and emits error when repository throws`() = runTest(testDispatcher) {
+        val failingRepo = FailsOnDeleteUserListRepository()
+        val viewModel = UserListsViewModel(UserList.Type.SPELL, router, failingRepo, testDispatcher)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+        viewModel.createList(LIST_NAME)
+        advanceUntilIdle()
+
+        val body = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
+        val list = body.lists.first()
+
+        val receivedEvents = mutableListOf<UserListsViewModel.Event>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.events.collect { receivedEvents.add(it) }
+        }
+
+        val pending = requireNotNull(viewModel.deleteListOptimistically(list))
+        viewModel.commitDeletion(pending)
+        advanceUntilIdle()
+
+        val restoredBody = assertIs<UserListsState.Body.WithData>(viewModel.state.value.body)
+        assertEquals(list, restoredBody.lists.first())
+        assertEquals(1, receivedEvents.size)
+        assertIs<UserListsViewModel.Event.DeletionError>(receivedEvents.first())
+    }
+
+    @Test
     fun `commitAllPendingDeletions commits pending deletions`() = runTest(testDispatcher) {
         val viewModel = buildViewModel()
 
@@ -263,6 +294,14 @@ class UserListsViewModelTest {
 
         assertTrue(trackingRouter.openedLists.contains(list))
     }
+}
+
+private class FailsOnDeleteUserListRepository : UserListRepository {
+    private val delegate = RamUserListRepository()
+    override suspend fun getAll(type: UserList.Type): List<UserList> = delegate.getAll(type)
+    override suspend fun get(id: String): UserList? = delegate.get(id)
+    override suspend fun save(list: UserList) = delegate.save(list)
+    override suspend fun delete(id: String) = error("Delete failed")
 }
 
 private class NoOpUserListRouter : UserListRouter {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -192,7 +192,7 @@ class UserListsViewModelTest {
     }
 
     @Test
-    fun `commitAllPendingDeletions commits pending deletions`() = runTest(testDispatcher) {
+    fun `commitAllPendingDeletions commits pending deletions that were never confirmed`() = runTest(testDispatcher) {
         val viewModel = buildViewModel()
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -207,7 +207,7 @@ class UserListsViewModelTest {
         val list = body.lists.first()
 
         viewModel.deleteListOptimistically(list) // no commit
-        viewModel.commitAllPendingDeletions() // simulate onCleared
+        viewModel.commitAllPendingDeletions()
         advanceUntilIdle()
 
         assertTrue(repository.getAll(UserList.Type.SPELL).isEmpty())


### PR DESCRIPTION
## 📝 Description

Adds a swipe-to-delete gesture on the character list screen, exclusively for user-created characters (preset characters live in a separate screen and are not affected).

The implementation follows the existing `UserLists` pattern:
- **Optimistic update**: the character is removed from the UI immediately on swipe
- **Undo snackbar**: a `SnackbarDuration.Short` snackbar appears with an "Undo" action
- **Commit on dismiss**: if the snackbar is dismissed without undoing, the deletion is persisted to the SQLDelight repository
- **Lifecycle safety**: `DisposableEffect.onDispose` in the screen's ViewModel overload commits any pending deletions when the composable leaves the composition (back navigation). ViewModels are Activity-scoped in this app (no `rememberViewModelStoreNavEntryDecorator` in `NavDisplay`), so `onCleared()` only fires on process death and is not a reliable hook for back navigation.
- **Error recovery**: if the repository throws, the character is restored in the UI and an error snackbar is shown

Along the way, the `UserListsScreen` and `ListDetailScreen` were refactored to use the same pattern:
- `rememberOptimisticDeleteHandler` composable helper extracted to `core/presentation/component/` to avoid duplicating the snackbar/undo/commit coroutine block across all three screens
- `MutableList<T>.commitAllPending` extension extracted to `core/presentation/` to deduplicate the fire-and-forget commit loop in all three ViewModels

## 🖼️ Media

<img width="1080" height="2400" alt="videoframe_14436" src="https://github.com/user-attachments/assets/da38cd84-3d22-4212-b253-f00516ed722f" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed