### PR TITLE
feat(character): replace RadioButton with check icon in single-choice dialogs

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -8,11 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -332,76 +329,6 @@ private fun FloatEditDialog(
                 Text(stringResource(Res.string.btn_confirm))
             }
         },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.btn_cancel))
-            }
-        },
-    )
-}
-
-@Composable
-private fun <T : Any> SingleChoiceDialog(
-    title: String,
-    selected: T?,
-    options: List<T>,
-    optionLabel: @Composable (T) -> String,
-    noneLabel: String? = null,
-    onConfirm: (T?) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(title) },
-        text = {
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                if (noneLabel != null) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onConfirm(null) }
-                            .padding(vertical = spacingMedium),
-                    ) {
-                        Text(
-                            text = noneLabel,
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.weight(1f),
-                        )
-                        if (selected == null) {
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                    }
-                }
-                options.forEach { option ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onConfirm(option) }
-                            .padding(vertical = spacingMedium),
-                    ) {
-                        Text(
-                            text = optionLabel(option),
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.weight(1f),
-                        )
-                        if (selected == option) {
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(Res.string.btn_cancel))

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -4,13 +4,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -23,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
@@ -354,22 +358,45 @@ private fun <T : Any> SingleChoiceDialog(
                 if (noneLabel != null) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth().clickable { onConfirm(null) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onConfirm(null) }
+                            .padding(vertical = spacingMedium),
                     ) {
-                        RadioButton(selected = selected == null, onClick = null)
-                        Text(text = noneLabel, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            text = noneLabel,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (selected == null) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
                     }
                 }
                 options.forEach { option ->
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth().clickable { onConfirm(option) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onConfirm(option) }
+                            .padding(vertical = spacingMedium),
                     ) {
-                        RadioButton(selected = selected == option, onClick = null)
                         Text(
                             text = optionLabel(option),
                             style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f),
                         )
+                        if (selected == option) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
                     }
                 }
             }
@@ -398,9 +425,12 @@ private fun LanguageSelectDialog(
                 Language.entries.forEach { language ->
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth().clickable {
-                            selected = if (language in selected) selected - language else selected + language
-                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                selected = if (language in selected) selected - language else selected + language
+                            }
+                            .padding(vertical = spacingMedium),
                     ) {
                         Checkbox(
                             checked = language in selected,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
@@ -357,7 +357,7 @@ private fun LanguageSelectDialog(
                             .clickable {
                                 selected = if (language in selected) selected - language else selected + language
                             }
-                            .padding(vertical = spacingMedium),
+                            .padding(vertical = spacingCommon),
                     ) {
                         Checkbox(
                             checked = language in selected,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
@@ -44,9 +44,9 @@ internal fun <T : Any> SingleChoiceDialog(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
                             .fillMaxWidth()
+                            .semantics { this.selected = selected == null }
                             .clickable { onConfirm(null) }
-                            .padding(vertical = spacingMedium)
-                            .semantics { this.selected = selected == null },
+                            .padding(vertical = spacingMedium),
                     ) {
                         Text(
                             text = noneLabel,
@@ -68,9 +68,9 @@ internal fun <T : Any> SingleChoiceDialog(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
                             .fillMaxWidth()
+                            .semantics { this.selected = isSelected }
                             .clickable { onConfirm(option) }
-                            .padding(vertical = spacingMedium)
-                            .semantics { this.selected = isSelected },
+                            .padding(vertical = spacingMedium),
                     ) {
                         Text(
                             text = optionLabel(option),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
@@ -43,7 +45,8 @@ internal fun <T : Any> SingleChoiceDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { onConfirm(null) }
-                            .padding(vertical = spacingMedium),
+                            .padding(vertical = spacingMedium)
+                            .semantics { this.selected = selected == null },
                     ) {
                         Text(
                             text = noneLabel,
@@ -60,19 +63,21 @@ internal fun <T : Any> SingleChoiceDialog(
                     }
                 }
                 options.forEach { option ->
+                    val isSelected = selected == option
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { onConfirm(option) }
-                            .padding(vertical = spacingMedium),
+                            .padding(vertical = spacingMedium)
+                            .semantics { this.selected = isSelected },
                     ) {
                         Text(
                             text = optionLabel(option),
                             style = MaterialTheme.typography.bodyMedium,
                             modifier = Modifier.weight(1f),
                         )
-                        if (selected == option) {
+                        if (isSelected) {
                             Icon(
                                 imageVector = Icons.Default.Check,
                                 contentDescription = null,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
@@ -1,0 +1,93 @@
+package com.cyrillrx.rpg.character.presentation.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_cancel
+
+@Composable
+internal fun <T : Any> SingleChoiceDialog(
+    title: String,
+    selected: T?,
+    options: List<T>,
+    optionLabel: @Composable (T) -> String,
+    noneLabel: String? = null,
+    onConfirm: (T?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                if (noneLabel != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onConfirm(null) }
+                            .padding(vertical = spacingMedium),
+                    ) {
+                        Text(
+                            text = noneLabel,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (selected == null) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
+                options.forEach { option ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onConfirm(option) }
+                            .padding(vertical = spacingMedium),
+                    ) {
+                        Text(
+                            text = optionLabel(option),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (selected == option) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.btn_cancel))
+            }
+        },
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/SingleChoiceDialog.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
-import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_cancel
@@ -46,7 +46,7 @@ internal fun <T : Any> SingleChoiceDialog(
                             .fillMaxWidth()
                             .semantics { this.selected = selected == null }
                             .clickable { onConfirm(null) }
-                            .padding(vertical = spacingMedium),
+                            .padding(vertical = spacingCommon),
                     ) {
                         Text(
                             text = noneLabel,
@@ -70,7 +70,7 @@ internal fun <T : Any> SingleChoiceDialog(
                             .fillMaxWidth()
                             .semantics { this.selected = isSelected }
                             .clickable { onConfirm(option) }
-                            .padding(vertical = spacingMedium),
+                            .padding(vertical = spacingCommon),
                     ) {
                         Text(
                             text = optionLabel(option),


### PR DESCRIPTION
## 📝 Description

Replace misleading `RadioButton` components in single-choice dialogs (Race, Class, Background, Alignment) with a trailing check icon for the selected item. Radio buttons imply that the user can change their selection before confirming, but these dialogs close immediately on tap — making the radio button semantically incorrect.

Also adds vertical padding to all dialog list rows (`SingleChoiceDialog` and `LanguageSelectDialog`) to meet the Material Design 48 dp minimum touch target.

`SingleChoiceDialog` is extracted into its own file in a follow-up commit.

**Changes:**
- Remove `RadioButton` from `SingleChoiceDialog`; show a trailing `Icons.Default.Check` (primary color) on the selected item instead
- Add `padding(vertical = spacingCommon)` to each row in `SingleChoiceDialog` and `LanguageSelectDialog` (≥ 48 dp touch target)
- Add `semantics { selected }` before `clickable` on each row so accessibility bounds cover the full touch target
- Extract `SingleChoiceDialog` from `CharacterEditDialogs.kt` into `SingleChoiceDialog.kt`

## 🖼️ Media

<!-- Screenshots to be added by reviewer or author after visual verification -->

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [ ] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed