### PR TITLE
chore(ktlint): configure rules — enforce import ordering, max-line-length 120, and adopt formatting rules

### DIFF
--- a/cmp-ttrpg-companion/.editorconfig
+++ b/cmp-ttrpg-companion/.editorconfig
@@ -10,6 +10,8 @@ ktlint_standard_blank-line-before-declaration = disabled
 ktlint_standard_no-empty-first-line-in-class-body = disabled
 ktlint_standard_function-expression-body = disabled
 ktlint_standard_chain-method-continuation = disabled
+ktlint_standard_function-naming = disabled
+ktlint_standard_filename = disabled
 
 [**/generated/**/*]
 ktlint = disabled

--- a/cmp-ttrpg-companion/.editorconfig
+++ b/cmp-ttrpg-companion/.editorconfig
@@ -1,5 +1,5 @@
 [*.{kt,kts}]
-max_line_length = 160
+max_line_length = 120
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 

--- a/cmp-ttrpg-companion/.editorconfig
+++ b/cmp-ttrpg-companion/.editorconfig
@@ -1,6 +1,17 @@
 [*.{kt,kts}]
+max_line_length = 160
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
+
+ktlint_standard_multiline-expression-wrapping = disabled
+ktlint_standard_class-signature = disabled
+ktlint_standard_function-signature = disabled
+ktlint_standard_blank-line-before-declaration = disabled
+ktlint_standard_no-empty-first-line-in-class-body = disabled
+ktlint_standard_function-expression-body = disabled
+ktlint_standard_no-multi-spaces = disabled
+ktlint_standard_chain-method-continuation = disabled
+ktlint_standard_enum-wrapping = disabled
 
 [**/generated/**/*]
 ktlint = disabled

--- a/cmp-ttrpg-companion/.editorconfig
+++ b/cmp-ttrpg-companion/.editorconfig
@@ -11,7 +11,6 @@ ktlint_standard_no-empty-first-line-in-class-body = disabled
 ktlint_standard_function-expression-body = disabled
 ktlint_standard_chain-method-continuation = disabled
 ktlint_standard_function-naming = disabled
-ktlint_standard_filename = disabled
 
 [**/generated/**/*]
 ktlint = disabled

--- a/cmp-ttrpg-companion/.editorconfig
+++ b/cmp-ttrpg-companion/.editorconfig
@@ -9,7 +9,6 @@ ktlint_standard_function-signature = disabled
 ktlint_standard_blank-line-before-declaration = disabled
 ktlint_standard_no-empty-first-line-in-class-body = disabled
 ktlint_standard_function-expression-body = disabled
-ktlint_standard_no-multi-spaces = disabled
 ktlint_standard_chain-method-continuation = disabled
 
 [**/generated/**/*]

--- a/cmp-ttrpg-companion/.editorconfig
+++ b/cmp-ttrpg-companion/.editorconfig
@@ -11,7 +11,6 @@ ktlint_standard_no-empty-first-line-in-class-body = disabled
 ktlint_standard_function-expression-body = disabled
 ktlint_standard_no-multi-spaces = disabled
 ktlint_standard_chain-method-continuation = disabled
-ktlint_standard_enum-wrapping = disabled
 
 [**/generated/**/*]
 ktlint = disabled

--- a/cmp-ttrpg-companion/androidApp/build.gradle.kts
+++ b/cmp-ttrpg-companion/androidApp/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -33,7 +34,6 @@ import com.cyrillrx.rpg.character.presentation.navigation.handleCharacterRoutes
 import com.cyrillrx.rpg.character.presentation.navigation.registerCharacterRoutes
 import com.cyrillrx.rpg.core.data.ComposeFileReader
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
-import androidx.compose.runtime.CompositionLocalProvider
 import com.cyrillrx.rpg.core.navigation.navigateUp
 import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
 import com.cyrillrx.rpg.core.presentation.theme.AppTheme
@@ -90,7 +90,9 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
             .components { add(SvgDecoder.Factory()) }
             .build()
     }
-    val prefsRepository: UserPreferencesRepository = remember(dbDriverFactory) { SqlDelightUserPreferencesRepository(dbDriverFactory) }
+    val prefsRepository: UserPreferencesRepository = remember(dbDriverFactory) {
+        SqlDelightUserPreferencesRepository(dbDriverFactory)
+    }
     var prefsInitialized by remember { mutableStateOf(false) }
     LaunchedEffect(prefsRepository) {
         prefsRepository.initialize()
@@ -102,58 +104,62 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
     AppTheme(theme = prefs.theme) {
         CompositionLocalProvider(LocalDistanceUnit provides prefs.distanceUnit) {
-        val backStack = rememberNavBackStack(navSavedStateConfig, MainRoute.Home)
+            val backStack = rememberNavBackStack(navSavedStateConfig, MainRoute.Home)
 
-        val fileReader = ComposeFileReader()
-        val userListRepository = remember(dbDriverFactory) { SQLDelightUserListRepository(dbDriverFactory) }
+            val fileReader = ComposeFileReader()
+            val userListRepository = remember(dbDriverFactory) { SQLDelightUserListRepository(dbDriverFactory) }
 
-        NavDisplay(
-            backStack = backStack,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
-            onBack = backStack::navigateUp,
-            transitionSpec = {
-                slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
-                    slideOutHorizontally(targetOffsetX = { -it }) + fadeOut()
-            },
-            popTransitionSpec = {
-                slideInHorizontally(initialOffsetX = { -it }) + fadeIn() togetherWith
-                    slideOutHorizontally(targetOffsetX = { it }) + fadeOut()
-            },
-            entryProvider = entryProvider {
-                val homeRouter = HomeRouterImpl(backStack)
-                entry<MainRoute.Home> { HomeScreen(homeRouter) }
+            NavDisplay(
+                backStack = backStack,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
+                onBack = backStack::navigateUp,
+                transitionSpec = {
+                    slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
+                        slideOutHorizontally(targetOffsetX = { -it }) + fadeOut()
+                },
+                popTransitionSpec = {
+                    slideInHorizontally(initialOffsetX = { -it }) + fadeIn() togetherWith
+                        slideOutHorizontally(targetOffsetX = { it }) + fadeOut()
+                },
+                entryProvider = entryProvider {
+                    val homeRouter = HomeRouterImpl(backStack)
+                    entry<MainRoute.Home> { HomeScreen(homeRouter) }
 
-                handleCampaignRoutes(backStack, remember(dbDriverFactory) { SQLDelightCampaignRepository(dbDriverFactory) })
-                handleCharacterRoutes(
-                    backStack = backStack,
-                    characterRepository = remember(dbDriverFactory) { SQLDelightCharacterRepository(dbDriverFactory) },
-                    pcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/pc-presets.json"),
-                    npcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/npc-presets.json"),
-                )
-
-                handleSpellRoutes(
-                    router = SpellRouterImpl(backStack),
-                    spellRepository = JsonSpellRepository(fileReader),
-                    userListRepository = userListRepository,
-                )
-                handleMagicalItemRoutes(
-                    router = MagicalItemRouterImpl(backStack),
-                    repository = JsonMagicalItemRepository(fileReader),
-                    userListRepository = userListRepository,
-                )
-                handleMonsterRoutes(
-                    router = MonsterRouterImpl(backStack),
-                    repository = JsonMonsterRepository(fileReader),
-                    userListRepository = userListRepository,
-                )
-
-                handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
-
-                handleSettingsRoutes(backStack, prefsRepository)
-            },
-        )
+                    handleCampaignRoutes(
+                        backStack = backStack,
+                        repository = remember(dbDriverFactory) {
+                            SQLDelightCampaignRepository(dbDriverFactory)
+                        },
+                    )
+                    handleCharacterRoutes(
+                        backStack = backStack,
+                        characterRepository = remember(dbDriverFactory) {
+                            SQLDelightCharacterRepository(dbDriverFactory)
+                        },
+                        pcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/pc-presets.json"),
+                        npcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/npc-presets.json"),
+                    )
+                    handleSpellRoutes(
+                        router = SpellRouterImpl(backStack),
+                        spellRepository = JsonSpellRepository(fileReader),
+                        userListRepository = userListRepository,
+                    )
+                    handleMagicalItemRoutes(
+                        router = MagicalItemRouterImpl(backStack),
+                        repository = JsonMagicalItemRepository(fileReader),
+                        userListRepository = userListRepository,
+                    )
+                    handleMonsterRoutes(
+                        router = MonsterRouterImpl(backStack),
+                        repository = JsonMonsterRepository(fileReader),
+                        userListRepository = userListRepository,
+                    )
+                    handleUserListRoutes(UserListRouterImpl(backStack), userListRepository)
+                    handleSettingsRoutes(backStack, prefsRepository)
+                },
+            )
         } // CompositionLocalProvider
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -86,7 +86,8 @@ private val navSavedStateConfig = SavedStateConfiguration {
 @Preview
 fun App(dbDriverFactory: DatabaseDriverFactory) {
     setSingletonImageLoaderFactory { context ->
-        ImageLoader.Builder(context)
+        ImageLoader
+            .Builder(context)
             .components { add(SvgDecoder.Factory()) }
             .build()
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/CreateCampaignScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/CreateCampaignScreen.kt
@@ -99,14 +99,7 @@ fun CreateCampaignScreen(
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { paddingValues ->
-        val localizedRuleSets = RuleSet.entries
-            .mapNotNull {
-                if (it == RuleSet.UNDEFINED || it == RuleSet.OTHER) return@mapNotNull null
-                LocalizedRuleSet(it, stringResource(it.getName()))
-            }
-            .sortedBy { it.localizedName } + LocalizedRuleSet(
-            RuleSet.OTHER, stringResource(Res.string.ruleset_other),
-        )
+        val localizedRuleSets = getLocalizedRuleSets()
 
         Column(
             Modifier.padding(
@@ -192,6 +185,18 @@ fun ChooseRuleSetButton(
             }
         }
     }
+}
+
+@Composable
+private fun getLocalizedRuleSets(): List<LocalizedRuleSet> {
+    val localizedRuleSets = RuleSet.entries
+        .mapNotNull {
+            if (it == RuleSet.UNDEFINED || it == RuleSet.OTHER) return@mapNotNull null
+            LocalizedRuleSet(it, stringResource(it.getName()))
+        }
+        .sortedBy { it.localizedName }
+
+    return localizedRuleSets + LocalizedRuleSet(RuleSet.OTHER, stringResource(Res.string.ruleset_other))
 }
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModel.kt
@@ -20,9 +20,10 @@ class CreateCampaignViewModel(
     sealed interface NavigationEvent {
         data object NavigateUp : NavigationEvent
     }
-
     val state: StateFlow<CreateCampaignState>
-        field = MutableStateFlow(CreateCampaignState(campaignName = "", selectedRuleSet = RuleSet.UNDEFINED, error = null))
+        field = MutableStateFlow(
+            CreateCampaignState(campaignName = "", selectedRuleSet = RuleSet.UNDEFINED, error = null),
+        )
 
     val navigationEvents: SharedFlow<NavigationEvent>
         field = MutableSharedFlow(extraBufferCapacity = 1)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModel.kt
@@ -56,7 +56,9 @@ class CampaignListViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                state.update { it.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign)) }
+                state.update {
+                    it.copy(body = CampaignListState.Body.Error(errorMessage = Res.string.error_while_loading_campaign))
+                }
             }
         }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -26,17 +26,17 @@ import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
 import com.cyrillrx.rpg.character.domain.Race
-import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
-import com.cyrillrx.rpg.core.presentation.component.dnd.toDistanceString
-import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
 import com.cyrillrx.rpg.character.presentation.CoercedValue
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
 import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterEditViewModel
+import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
+import com.cyrillrx.rpg.core.presentation.component.dnd.toDistanceString
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
@@ -63,7 +63,9 @@ fun CharacterDetailScreen(
         viewModel.coercedValueEvent.collect { event ->
             val (from, to) = when (event) {
                 is CoercedValue.Numeric -> event.original.toString() to event.coerced.toString()
-                is CoercedValue.Distance -> event.originalFeet.toDistanceString(distanceUnit) to event.coercedFeet.toDistanceString(distanceUnit)
+                is CoercedValue.Distance ->
+                    event.originalFeet.toDistanceString(distanceUnit) to
+                        event.coercedFeet.toDistanceString(distanceUnit)
             }
             snackbarHostState.showSnackbar(coercedMessage.format(from, to))
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterEditDialogs.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.character.domain.Background
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Language
@@ -32,6 +31,7 @@ import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
 import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.dnd.domain.feetToMeters
 import com.cyrillrx.rpg.dnd.domain.metersToFeet

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -228,8 +228,11 @@ private fun InlineEditableText(
             modifier = modifier
                 .focusRequester(focusRequester)
                 .onFocusChanged { focusState ->
-                    if (focusState.isFocused) hasFocused = true
-                    else if (hasFocused) commit()
+                    if (focusState.isFocused) {
+                        hasFocused = true
+                    } else if (hasFocused) {
+                        commit()
+                    }
                 },
         )
     } else {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -200,7 +200,14 @@ private fun CharacterActionCard(
     Card(
         onClick = onClick,
         shape = MaterialTheme.shapes.medium,
-        border = if (filled) null else BorderStroke(borderWidth, MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha)),
+        border = if (filled) {
+            null
+        } else {
+            BorderStroke(
+                width = borderWidth,
+                color = MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha),
+            )
+        },
         colors = CardDefaults.cardColors(containerColor = containerColor),
         modifier = modifier,
     ) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CreateCharacterScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CreateCharacterScreen.kt
@@ -13,7 +13,8 @@ fun CreateCharacterScreen(onNavigateUpClicked: () -> Unit) {
     Scaffold { paddingValues ->
         Text(
             text = "Create Character Screen",
-            Modifier.clickable { onNavigateUpClicked() }
+            Modifier
+                .clickable { onNavigateUpClicked() }
                 .padding(paddingValues)
                 .fillMaxSize(),
         )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/navigation/CharacterRoute.kt
@@ -68,7 +68,11 @@ fun EntryProviderScope<NavKey>.handleCharacterRoutes(
 
     entry<CharacterRoute.PresetGallery> {
         val router = CharacterRouterImpl(backStack)
-        val viewModelFactory = CharacterPresetGalleryViewModelFactory(pcPresetRepository, npcPresetRepository, characterRepository)
+        val viewModelFactory = CharacterPresetGalleryViewModelFactory(
+            pcPresetRepository = pcPresetRepository,
+            npcPresetRepository = npcPresetRepository,
+            characterRepository = characterRepository,
+        )
         val viewModel = viewModel<CharacterPresetGalleryViewModel>(factory = viewModelFactory)
         CharacterPresetGalleryScreen(viewModel, router)
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
@@ -63,7 +63,12 @@ class CharacterEditViewModel(
     }
 
     fun saveRace(race: Race) {
-        updateAndSave { copy(character = character.copy(race = race, speeds = character.speeds.copy(walk = race.defaultWalkSpeed())), editingField = null) }
+        updateAndSave {
+            copy(
+                character = character.copy(race = race, speeds = character.speeds.copy(walk = race.defaultWalkSpeed())),
+                editingField = null,
+            )
+        }
     }
 
     fun saveClass(clazz: Character.Class) {
@@ -78,17 +83,29 @@ class CharacterEditViewModel(
         updateAndSave { copy(character = character.copy(background = background), editingField = null) }
     }
 
-    fun saveStrength(value: Int) = saveAbility(value, Abilities::strength) { coerced -> copy(strength = strength.copy(value = coerced)) }
+    fun saveStrength(value: Int) = saveAbility(value, Abilities::strength) { coerced ->
+        copy(strength = strength.copy(value = coerced))
+    }
 
-    fun saveDexterity(value: Int) = saveAbility(value, Abilities::dexterity) { coerced -> copy(dexterity = dexterity.copy(value = coerced)) }
+    fun saveDexterity(value: Int) = saveAbility(value, Abilities::dexterity) { coerced ->
+        copy(dexterity = dexterity.copy(value = coerced))
+    }
 
-    fun saveConstitution(value: Int) = saveAbility(value, Abilities::constitution) { coerced -> copy(constitution = constitution.copy(value = coerced)) }
+    fun saveConstitution(value: Int) = saveAbility(value, Abilities::constitution) { coerced ->
+        copy(constitution = constitution.copy(value = coerced))
+    }
 
-    fun saveIntelligence(value: Int) = saveAbility(value, Abilities::intelligence) { coerced -> copy(intelligence = intelligence.copy(value = coerced)) }
+    fun saveIntelligence(value: Int) = saveAbility(value, Abilities::intelligence) { coerced ->
+        copy(intelligence = intelligence.copy(value = coerced))
+    }
 
-    fun saveWisdom(value: Int) = saveAbility(value, Abilities::wisdom) { coerced -> copy(wisdom = wisdom.copy(value = coerced)) }
+    fun saveWisdom(value: Int) = saveAbility(value, Abilities::wisdom) { coerced ->
+        copy(wisdom = wisdom.copy(value = coerced))
+    }
 
-    fun saveCharisma(value: Int) = saveAbility(value, Abilities::charisma) { coerced -> copy(charisma = charisma.copy(value = coerced)) }
+    fun saveCharisma(value: Int) = saveAbility(value, Abilities::charisma) { coerced ->
+        copy(charisma = charisma.copy(value = coerced))
+    }
 
     fun saveArmorClass(value: Int) = updateAndSave(value, Int::coerceToValidArmorClass) { coerced ->
         copy(character = character.copy(armorClass = coerced), editingField = null)
@@ -101,7 +118,9 @@ class CharacterEditViewModel(
     fun saveWalkSpeed(value: Int) {
         val coerced = value.coerceToValidWalkSpeedInFeet()
         if (coerced != value) coercedValueEvent.tryEmit(CoercedValue.Distance(value, coerced))
-        updateAndSave { copy(character = character.copy(speeds = character.speeds.copy(walk = coerced)), editingField = null) }
+        updateAndSave {
+            copy(character = character.copy(speeds = character.speeds.copy(walk = coerced)), editingField = null)
+        }
     }
 
     fun saveLanguages(languages: List<Language>) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -128,7 +128,11 @@ class CharacterListViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                state.update { it.copy(body = CharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters)) }
+                state.update {
+                    it.copy(
+                        body = CharacterListState.Body.Error(errorMessage = Res.string.error_while_loading_characters),
+                    )
+                }
             }
         }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MarkdownTable.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MarkdownTable.kt
@@ -1,4 +1,3 @@
-
 package com.cyrillrx.rpg.core.presentation.component
 
 import androidx.compose.foundation.background
@@ -177,7 +176,9 @@ private fun rememberColumnWidths(
         val boldStyle = style.copy(fontWeight = FontWeight.Bold)
         val paddingPx = with(density) { (tableCellPadding * 2).roundToPx() }
         (0 until columnCount).map { colIdx ->
-            val headerPx = headerNode.children.filter { it.type == CELL }.getOrNull(colIdx)
+            val headerPx = headerNode.children
+                .filter { it.type == CELL }
+                .getOrNull(colIdx)
                 ?.let { cell ->
                     val text = content.substring(cell.startOffset, cell.endOffset).trim().stripMarkdown()
                     if (text.isEmpty()) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MarkdownTable.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MarkdownTable.kt
@@ -180,15 +180,21 @@ private fun rememberColumnWidths(
             val headerPx = headerNode.children.filter { it.type == CELL }.getOrNull(colIdx)
                 ?.let { cell ->
                     val text = content.substring(cell.startOffset, cell.endOffset).trim().stripMarkdown()
-                    if (text.isEmpty()) 1
-                    else textMeasurer.measure(text, style = boldStyle, softWrap = false).size.width
+                    if (text.isEmpty()) {
+                        1
+                    } else {
+                        textMeasurer.measure(text, style = boldStyle, softWrap = false).size.width
+                    }
                 } ?: 1
             val dataPx = dataRows.maxOfOrNull { rowNode ->
                 val cell = rowNode.children.filter { it.type == CELL }.getOrNull(colIdx)
                     ?: return@maxOfOrNull 1
                 val text = content.substring(cell.startOffset, cell.endOffset).trim().stripMarkdown()
-                if (text.isEmpty()) 1
-                else textMeasurer.measure(text, style = style, softWrap = false).size.width
+                if (text.isEmpty()) {
+                    1
+                } else {
+                    textMeasurer.measure(text, style = style, softWrap = false).size.width
+                }
             } ?: 1
             with(density) {
                 ColumnWidthData(
@@ -202,7 +208,7 @@ private fun rememberColumnWidths(
 
 internal fun String.stripMarkdown(): String = this
     .replace(Regex("\\[([^]]+)]\\([^)]*\\)"), "$1") // [text](url) → text
-    .replace(Regex("[*_`]+"), "")                    // *, **, _, __, ` → nothing
+    .replace(Regex("[*_`]+"), "") // *, **, _, __, ` → nothing
 
 @Composable
 private fun TableContent(
@@ -215,7 +221,14 @@ private fun TableContent(
 ) {
     node.children.forEach { child ->
         when (child.type) {
-            HEADER -> TableRow(content, child, colWidths, style.copy(fontWeight = FontWeight.Bold), cellPadding, annotatorSettings)
+            HEADER -> TableRow(
+                content,
+                child,
+                colWidths,
+                style.copy(fontWeight = FontWeight.Bold),
+                cellPadding,
+                annotatorSettings,
+            )
             ROW -> TableRow(content, child, colWidths, style, cellPadding, annotatorSettings)
             TABLE_SEPARATOR -> MarkdownDivider()
         }
@@ -255,7 +268,8 @@ private fun TableRow(
     }
 }
 
-private val SAMPLE_TABLE = """
+private val SAMPLE_TABLE =
+    """
     | Spell Level | Rarity | Spell Save DC | Attack Bonus |
     |-------------|--------|---------------|--------------|
     | 0 (cantrip) | Common | 13 | +5 |
@@ -263,7 +277,7 @@ private val SAMPLE_TABLE = """
     | 3rd–4th | Uncommon | 15 | +7 |
     | 5th–6th | Rare | 17 | +9 |
     | 7th–8th | Very Rare | 18 | +10 |
-""".trimIndent()
+    """.trimIndent()
 
 @Preview
 @Composable

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MarkdownTable.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MarkdownTable.kt
@@ -207,9 +207,12 @@ private fun rememberColumnWidths(
     }
 }
 
+private val LINK_REGEX = Regex("\\[([^]]+)]\\([^)]*\\)")
+private val MARKDOWN_CHARS_REGEX = Regex("[*_`]+")
+
 internal fun String.stripMarkdown(): String = this
-    .replace(Regex("\\[([^]]+)]\\([^)]*\\)"), "$1") // [text](url) → text
-    .replace(Regex("[*_`]+"), "") // *, **, _, __, ` → nothing
+    .replace(LINK_REGEX, "$1") // [text](url) → text
+    .replace(MARKDOWN_CHARS_REGEX, "") // *, **, _, __, ` → nothing
 
 @Composable
 private fun TableContent(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SearchBar.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SearchBar.kt
@@ -43,11 +43,13 @@ fun SearchBar(
         onValueChange = onQueryChanged,
         shape = RoundedCornerShape(50),
         colors = TextFieldDefaults.colors(),
-        placeholder = { Text(
-            text = hint,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        ) },
+        placeholder = {
+            Text(
+                text = hint,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
         leadingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/MonsterAddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/MonsterAddToListProvider.kt
@@ -16,8 +16,8 @@ import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
-import com.cyrillrx.rpg.creature.domain.MonsterRepository
 import com.cyrillrx.rpg.creature.domain.Monster
+import com.cyrillrx.rpg.creature.domain.MonsterRepository
 import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListProvider

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/MonsterListState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/MonsterListState.kt
@@ -1,7 +1,7 @@
 package com.cyrillrx.rpg.creature.presentation
 
-import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.Monster
+import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import org.jetbrains.compose.resources.StringResource
 
 data class MonsterListState(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterFilterBottomSheet.kt
@@ -25,8 +25,8 @@ import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.Monster
+import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -36,10 +36,31 @@ import rpg_companion.composeapp.generated.resources.label_filter_type
 import rpg_companion.composeapp.generated.resources.title_filter_monsters
 
 private val commonCRs = listOf(
-    0f, 0.125f, 0.25f, 0.5f,
-    1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f,
-    11f, 12f, 13f, 14f, 15f, 16f, 17f,
-    20f, 21f, 24f, 30f,
+    0f,
+    0.125f,
+    0.25f,
+    0.5f,
+    1f,
+    2f,
+    3f,
+    4f,
+    5f,
+    6f,
+    7f,
+    8f,
+    9f,
+    10f,
+    11f,
+    12f,
+    13f,
+    14f,
+    15f,
+    16f,
+    17f,
+    20f,
+    21f,
+    24f,
+    30f,
 )
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterItem.kt
@@ -23,9 +23,11 @@ fun MonsterItem(
     modifier: Modifier = Modifier,
 ) {
     val translation = monster.resolveTranslation(currentLocale())
-    Column(modifier = modifier
-        .background(MaterialTheme.colorScheme.background)
-        .padding(spacingCommon)) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.background)
+            .padding(spacingCommon),
+    ) {
         Text(
             text = translation.name,
             style = MaterialTheme.typography.headlineSmall,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedCR
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
@@ -37,7 +38,6 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.creature.data.SampleMonsterRepository
-import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.creature.domain.Monster
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -98,8 +98,10 @@ fun MonsterListItem(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 
+                val formattedMonterType = monster.type.toFormattedString()
+                val formattedMonsterSize = monster.size.name.lowercase().replaceFirstChar { it.uppercase() }
                 Text(
-                    text = "${monster.type.toFormattedString()} · ${monster.size.name.lowercase().replaceFirstChar { it.uppercase() }}",
+                    text = "$formattedMonterType · $formattedMonsterSize",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -98,10 +98,10 @@ fun MonsterListItem(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 
-                val formattedMonterType = monster.type.toFormattedString()
+                val formattedMonsterType = monster.type.toFormattedString()
                 val formattedMonsterSize = monster.size.name.lowercase().replaceFirstChar { it.uppercase() }
                 Text(
-                    text = "$formattedMonterType · $formattedMonsterSize",
+                    text = "$formattedMonsterType · $formattedMonsterSize",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterDetailViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterDetailViewModel.kt
@@ -3,8 +3,8 @@ package com.cyrillrx.rpg.creature.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.presentation.state.DetailState
-import com.cyrillrx.rpg.creature.domain.MonsterRepository
 import com.cyrillrx.rpg.creature.domain.Monster
+import com.cyrillrx.rpg.creature.domain.MonsterRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
@@ -70,7 +70,9 @@ class MonsterListViewModel(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            state.update { it.copy(body = MonsterListState.Body.Error(errorMessage = Res.string.error_while_loading_monsters)) }
+            state.update {
+                it.copy(body = MonsterListState.Body.Error(errorMessage = Res.string.error_while_loading_monsters))
+            }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -70,7 +70,11 @@ class MagicalItemListViewModel(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            state.update { it.copy(body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)) }
+            state.update {
+                it.copy(
+                    body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items),
+                )
+            }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/SettingsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/settings/presentation/SettingsScreen.kt
@@ -136,7 +136,7 @@ private fun PreviewSettingsScreenLight() {
             preferences = UserPreferences(theme = Theme.LIGHT),
             onThemeSelected = {},
             onDistanceUnitSelected = {},
-            router = object : SettingsRouter { override fun navigateUp() {} },
+            router = NoOpRouter(),
         )
     }
 }
@@ -149,7 +149,11 @@ private fun PreviewSettingsScreenDark() {
             preferences = UserPreferences(theme = Theme.DARK),
             onThemeSelected = {},
             onDistanceUnitSelected = {},
-            router = object : SettingsRouter { override fun navigateUp() {} },
+            router = NoOpRouter(),
         )
     }
+}
+
+private class NoOpRouter : SettingsRouter {
+    override fun navigateUp() {}
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
@@ -53,7 +53,6 @@ fun SpellListItem(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(spacingCommon),
         ) {
-
             // Spell info
             Column(
                 verticalArrangement = Arrangement.spacedBy(spacingSmall),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -75,7 +75,9 @@ class SpellListViewModel(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            state.update { it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)) }
+            state.update {
+                it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells))
+            }
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -28,12 +28,13 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
-import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.component.dialog.RenameListDialog
+import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
@@ -41,7 +42,6 @@ import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
 import com.cyrillrx.rpg.userlist.presentation.ListItemProvider
-import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.userlist.presentation.viewmodel.ListDetailViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -32,8 +32,8 @@ import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
 import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
-import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.component.dialog.CreateListDialog
+import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModel.kt
@@ -141,7 +141,9 @@ class UserListsViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                state.update { it.copy(body = UserListsState.Body.Error(errorMessage = Res.string.error_while_loading_user_lists)) }
+                state.update {
+                    it.copy(body = UserListsState.Body.Error(errorMessage = Res.string.error_while_loading_user_lists))
+                }
             }
         }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/create/viewmodel/CreateCampaignViewModelTest.kt
@@ -6,13 +6,13 @@ import com.cyrillrx.rpg.campaign.domain.CampaignRepository
 import com.cyrillrx.rpg.campaign.domain.RuleSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.coroutines.launch
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -143,6 +143,10 @@ private class TestCampaignRepository : CampaignRepository {
 
     override suspend fun getAll(filter: CampaignFilter?): List<Campaign> = campaigns
     override suspend fun get(id: String): Campaign? = campaigns.find { it.id == id }
-    override suspend fun save(campaign: Campaign) { campaigns.add(campaign) }
-    override suspend fun delete(id: String) { campaigns.removeAll { it.id == id } }
+    override suspend fun save(campaign: Campaign) {
+        campaigns.add(campaign)
+    }
+    override suspend fun delete(id: String) {
+        campaigns.removeAll { it.id == id }
+    }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/campaign/list/viewmodel/CampaignListViewModelTest.kt
@@ -159,7 +159,6 @@ class CampaignListViewModelTest {
 
         assertEquals(expected = "dnd", actual = viewModel.state.value.searchQuery)
     }
-
 }
 
 private class TestCampaignRepository : CampaignRepository {
@@ -172,8 +171,12 @@ private class TestCampaignRepository : CampaignRepository {
     }
 
     override suspend fun get(id: String): Campaign? = campaigns.find { it.id == id }
-    override suspend fun save(campaign: Campaign) { campaigns.add(campaign) }
-    override suspend fun delete(id: String) { campaigns.removeAll { it.id == id } }
+    override suspend fun save(campaign: Campaign) {
+        campaigns.add(campaign)
+    }
+    override suspend fun delete(id: String) {
+        campaigns.removeAll { it.id == id }
+    }
 }
 
 private class FailingCampaignRepository : CampaignRepository {

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
@@ -13,12 +13,12 @@ import com.cyrillrx.rpg.character.presentation.CoercedValue
 import com.cyrillrx.rpg.creature.domain.Creature
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.coroutines.launch
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -175,9 +175,15 @@ class CharacterEditViewModelTest {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
         viewModel.saveConstitution(0)
-        assertEquals(1, assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.constitution.value)
+        assertEquals(
+            expected = 1,
+            actual = assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.constitution.value,
+        )
         viewModel.saveConstitution(31)
-        assertEquals(30, assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.constitution.value)
+        assertEquals(
+            expected = 30,
+            actual = assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.constitution.value,
+        )
     }
 
     @Test
@@ -185,9 +191,15 @@ class CharacterEditViewModelTest {
         val viewModel = buildViewModel(repo = repoWithFighter())
         advanceUntilIdle()
         viewModel.saveIntelligence(0)
-        assertEquals(1, assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.intelligence.value)
+        assertEquals(
+            expected = 1,
+            actual = assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.intelligence.value,
+        )
         viewModel.saveIntelligence(31)
-        assertEquals(30, assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.intelligence.value)
+        assertEquals(
+            expected = 30,
+            actual = assertIs<CharacterEditState.Loaded>(viewModel.state.value).character.abilities.intelligence.value,
+        )
     }
 
     @Test
@@ -237,7 +249,7 @@ class CharacterEditViewModelTest {
         val events = mutableListOf<CoercedValue>()
         val job = launch { viewModel.coercedValueEvent.collect { events.add(it) } }
         advanceUntilIdle()
-        viewModel.saveLevel(25)  // max is 20, coerced to 20
+        viewModel.saveLevel(25) // max is 20, coerced to 20
         advanceUntilIdle()
         assertEquals(listOf<CoercedValue>(CoercedValue.Numeric(25, 20)), events)
         job.cancel()
@@ -250,7 +262,7 @@ class CharacterEditViewModelTest {
         val events = mutableListOf<CoercedValue>()
         val job = launch { viewModel.coercedValueEvent.collect { events.add(it) } }
         advanceUntilIdle()
-        viewModel.saveLevel(5)  // valid, no coercion
+        viewModel.saveLevel(5) // valid, no coercion
         advanceUntilIdle()
         assertTrue(events.isEmpty())
         job.cancel()
@@ -263,7 +275,7 @@ class CharacterEditViewModelTest {
         val events = mutableListOf<CoercedValue>()
         val job = launch { viewModel.coercedValueEvent.collect { events.add(it) } }
         advanceUntilIdle()
-        viewModel.saveWalkSpeed(27)  // not a multiple of 5, coerced to 25
+        viewModel.saveWalkSpeed(27) // not a multiple of 5, coerced to 25
         advanceUntilIdle()
         assertEquals(listOf<CoercedValue>(CoercedValue.Distance(27, 25)), events)
         job.cancel()

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModelTest.kt
@@ -2,7 +2,6 @@ package com.cyrillrx.rpg.character.presentation.viewmodel
 
 import com.cyrillrx.rpg.character.data.RamCharacterRepository
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
-import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.presentation.CharacterPresetGalleryState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/core/presentation/component/AllocateWidthsTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/core/presentation/component/AllocateWidthsTest.kt
@@ -110,8 +110,8 @@ class AllocateWidthsTest {
 
     private fun assertDpApprox(expected: Dp, actual: Dp, tolerance: Float = 0.1f) {
         assertTrue(
-            abs(expected.value - actual.value) < tolerance,
-            "Expected ~${expected} but was ${actual}",
+            actual = abs(expected.value - actual.value) < tolerance,
+            message = "Expected ~$expected but was $actual",
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterDetailViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterDetailViewModelTest.kt
@@ -70,6 +70,9 @@ class MonsterDetailViewModelTest {
         val state = viewModel.state.value
         assertIs<DetailState.Found<Monster>>(state)
         assertEquals(expected = monster.id, actual = state.item.id)
-        assertEquals(expected = monster.resolveTranslation("en").name, actual = state.item.resolveTranslation("en").name)
+        assertEquals(
+            expected = monster.resolveTranslation("en").name,
+            actual = state.item.resolveTranslation("en").name,
+        )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
@@ -1,9 +1,9 @@
 package com.cyrillrx.rpg.creature.presentation.viewmodel
 
 import com.cyrillrx.rpg.creature.data.SampleMonsterRepository
+import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.MonsterRepository
-import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.presentation.MonsterListState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -73,7 +73,10 @@ class MonsterListViewModelTest {
         assertTrue(state.filter.types.contains(Monster.Type.DRAGON))
         val body = assertIs<MonsterListState.Body.WithData>(state.body)
         assertEquals(expected = 1, actual = body.searchResults.size)
-        assertEquals(expected = dragon.resolveTranslation("en").name, actual = body.searchResults.first().resolveTranslation("en").name)
+        assertEquals(
+            expected = dragon.resolveTranslation("en").name,
+            actual = body.searchResults.first().resolveTranslation("en").name,
+        )
     }
 
     @Test
@@ -112,7 +115,10 @@ class MonsterListViewModelTest {
         val state = viewModel.state.value
         val body = assertIs<MonsterListState.Body.WithData>(state.body)
         assertEquals(expected = 1, actual = body.searchResults.size)
-        assertEquals(expected = goblin.resolveTranslation("en").name, actual = body.searchResults.first().resolveTranslation("en").name)
+        assertEquals(
+            expected = goblin.resolveTranslation("en").name,
+            actual = body.searchResults.first().resolveTranslation("en").name,
+        )
     }
 
     @Test

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/presentation/viewmodel/UserListsViewModelTest.kt
@@ -271,7 +271,6 @@ class UserListsViewModelTest {
 
         assertIs<UserListsState.Body.Loading>(viewModel.state.value.body)
     }
-
 }
 
 private class FailsOnDeleteUserListRepository : UserListRepository {
@@ -281,4 +280,3 @@ private class FailsOnDeleteUserListRepository : UserListRepository {
     override suspend fun save(list: UserList) = delegate.save(list)
     override suspend fun delete(id: String) = error("Delete failed")
 }
-

--- a/cmp-ttrpg-companion/composeApp/src/iosMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MainViewController.kt
+++ b/cmp-ttrpg-companion/composeApp/src/iosMain/kotlin/com/cyrillrx/rpg/core/presentation/component/MainViewController.kt
@@ -2,7 +2,7 @@ import androidx.compose.ui.window.ComposeUIViewController
 import com.cyrillrx.rpg.app.App
 import com.cyrillrx.rpg.core.data.cache.IOSDatabaseDriverFactory
 
-fun MainViewController() = ComposeUIViewController() {
+fun MainViewController() = ComposeUIViewController {
     val databaseDriverFactory = IOSDatabaseDriverFactory()
     App(databaseDriverFactory)
 }

--- a/cmp-ttrpg-companion/gradle.properties
+++ b/cmp-ttrpg-companion/gradle.properties
@@ -17,5 +17,3 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false

--- a/cmp-ttrpg-companion/shared/core/build.gradle.kts
+++ b/cmp-ttrpg-companion/shared/core/build.gradle.kts
@@ -1,5 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.ktlint)

--- a/cmp-ttrpg-companion/shared/core/src/androidMain/kotlin/com/cyrillrx/rpg/core/data/cache/AndroidDatabaseDriverFactory.kt
+++ b/cmp-ttrpg-companion/shared/core/src/androidMain/kotlin/com/cyrillrx/rpg/core/data/cache/AndroidDatabaseDriverFactory.kt
@@ -7,7 +7,5 @@ import com.cyrillrx.rpg.cache.AppDatabase
 import com.cyrillrx.rpg.core.data.cache.Database.Companion.DATABASE_NAME
 
 class AndroidDatabaseDriverFactory(private val context: Context) : DatabaseDriverFactory {
-    override fun createDriver(): SqlDriver {
-        return AndroidSqliteDriver(AppDatabase.Schema, context, DATABASE_NAME)
-    }
+    override fun createDriver(): SqlDriver = AndroidSqliteDriver(AppDatabase.Schema, context, DATABASE_NAME)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/domain/RuleSet.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/domain/RuleSet.kt
@@ -11,16 +11,14 @@ enum class RuleSet {
     ;
 
     companion object {
-        fun fromInt(value: Int): RuleSet {
-            return when (value) {
-                0 -> DND5E
-                1 -> PATHFINDER_2E
-                2 -> STARFINDER
-                3 -> CALL_OF_CTHULHU_7E
-                4 -> VAMPIRE_THE_MASQUERADE_5E
-                5 -> OTHER
-                else -> UNDEFINED
-            }
+        fun fromInt(value: Int): RuleSet = when (value) {
+            0 -> DND5E
+            1 -> PATHFINDER_2E
+            2 -> STARFINDER
+            3 -> CALL_OF_CTHULHU_7E
+            4 -> VAMPIRE_THE_MASQUERADE_5E
+            5 -> OTHER
+            else -> UNDEFINED
         }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -118,7 +118,9 @@ class JsonCharacterPresetRepository(
             )
         }
 
-        private fun Map<String, ApiCharacter.Translation>.toTranslations(characterId: String): Map<String, Character.Translation>? {
+        private fun Map<String, ApiCharacter.Translation>.toTranslations(
+            characterId: String,
+        ): Map<String, Character.Translation>? {
             val (parsedTranslations, translationErrors) = partitionBy { locale, t ->
                 t.toTranslation(characterId, locale)
             }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -36,9 +36,7 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     @Suppress("UNUSED_PARAMETER")
     private fun mapCharacterSelecting(id: String, data: String): Character = data.deserialize()
 
-    fun getAllCampaigns(): List<Campaign> {
-        return dbQuery.selectAllCampaigns(::mapCampaignSelecting).executeAsList()
-    }
+    fun getAllCampaigns(): List<Campaign> = dbQuery.selectAllCampaigns(::mapCampaignSelecting).executeAsList()
 
     fun insertCampaign(campaign: Campaign) {
         dbQuery.insertCampaign(
@@ -48,9 +46,7 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
         )
     }
 
-    fun getCampaign(id: String): Campaign? {
-        return dbQuery.selectCampaignById(id, ::mapCampaignSelecting).executeAsOneOrNull()
-    }
+    fun getCampaign(id: String): Campaign? = dbQuery.selectCampaignById(id, ::mapCampaignSelecting).executeAsOneOrNull()
 
     fun deleteCampaign(id: String) {
         dbQuery.deleteCampaign(id)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/core/data/cache/Database.kt
@@ -62,7 +62,8 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     fun getAllUserLists(type: UserList.Type): List<UserList> =
         dbQuery.selectAllUserListsByType(type.name, ::mapUserListSelecting).executeAsList()
 
-    fun getUserList(id: String): UserList? = dbQuery.selectUserListById(id, ::mapUserListSelecting).executeAsOneOrNull()
+    fun getUserList(id: String): UserList? =
+        dbQuery.selectUserListById(id, ::mapUserListSelecting).executeAsOneOrNull()
 
     fun saveUserList(list: UserList) {
         dbQuery.saveUserList(
@@ -85,8 +86,10 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
     fun getUserPreferences(): UserPreferences =
         dbQuery.getUserPreferences { _, theme, distanceUnit ->
             UserPreferences(
-                theme = Theme.entries.find { it.name.equals(theme, ignoreCase = true) } ?: Theme.SYSTEM,
-                distanceUnit = DistanceUnit.entries.find { it.name.equals(distanceUnit, ignoreCase = true) } ?: DistanceUnit.FEET,
+                theme = Theme.entries.find { it.name.equals(theme, ignoreCase = true) }
+                    ?: Theme.SYSTEM,
+                distanceUnit = DistanceUnit.entries.find { it.name.equals(distanceUnit, ignoreCase = true) }
+                    ?: DistanceUnit.FEET,
             )
         }.executeAsOneOrNull() ?: UserPreferences()
 
@@ -98,7 +101,7 @@ internal class Database(databaseDriverFactory: DatabaseDriverFactory) {
         dbQuery.updateDistanceUnit(distanceUnit.name.lowercase())
     }
 
-    private fun mapUserListSelecting(id: String, name: String, type: String, itemIds: String, lastModified: Long): UserList =
+    private fun mapUserListSelecting(id: String, name: String, type: String, itemIds: String, lastModified: Long) =
         UserList(
             id = id,
             name = name,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -99,7 +99,9 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
             )
         }
 
-        private fun Map<String, ApiMonster.Translation>.toTranslations(monsterId: String): Map<String, Monster.Translation>? {
+        private fun Map<String, ApiMonster.Translation>.toTranslations(
+            monsterId: String,
+        ): Map<String, Monster.Translation>? {
             val (parsedTranslations, translationErrors) = partitionBy { locale, t ->
                 t.toTranslation(monsterId, locale)
             }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
@@ -10,9 +10,7 @@ import com.cyrillrx.rpg.creature.domain.Speeds
 import com.cyrillrx.rpg.creature.domain.applyFilter
 
 class SampleMonsterRepository : MonsterRepository {
-    override suspend fun getAll(filter: MonsterFilter?): List<Monster> {
-        return monsters.applyFilter(filter)
-    }
+    override suspend fun getAll(filter: MonsterFilter?): List<Monster> = monsters.applyFilter(filter)
 
     override suspend fun getById(id: String): Monster? = monsters.firstOrNull { it.id == id }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
@@ -3,9 +3,9 @@ package com.cyrillrx.rpg.creature.data
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
 import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.MonsterRepository
-import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.Speeds
 import com.cyrillrx.rpg.creature.domain.applyFilter
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
@@ -52,7 +52,8 @@ class SampleMonsterRepository : MonsterRepository {
             translations = mapOf(
                 "en" to Monster.Translation(
                     name = "Goblin",
-                    description = "A small, black-hearted creature that lairs in despoiled dungeons and other dismal settings.",
+                    description = "A small, black-hearted creature that lairs in despoiled dungeons and other " +
+                        "dismal settings.",
                     senses = "Darkvision 60 ft.",
                     languages = listOf("Common", "Goblin"),
                 ),

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/MonsterFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/MonsterFilter.kt
@@ -13,11 +13,10 @@ fun List<Monster>.applyFilter(filter: MonsterFilter?): List<Monster> {
     return filter { it.matches(filter) }
 }
 
-internal fun Monster.matches(filter: MonsterFilter): Boolean {
-    return (filter.types.isEmpty() || filter.types.contains(type)) &&
+internal fun Monster.matches(filter: MonsterFilter): Boolean =
+    (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.challengeRatings.isEmpty() || filter.challengeRatings.contains(challengeRating)) &&
         (filter.query.isBlank() || matches(filter.query))
-}
 
 private fun Monster.matches(query: String): Boolean {
     val trimmedQuery = query.trim()

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -79,20 +79,22 @@ class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalIte
             locale: String,
         ): Result<MagicalItem.Translation, MagicalItemImportError> {
             val name = name
-                ?: return Result.Failure(MagicalItemImportError.InvalidTranslation(itemId, locale, field = "name"))
+                ?: return Result.Failure(
+                    MagicalItemImportError.InvalidTranslation(itemId, locale, field = "name"),
+                )
             val description = description
-                ?: return Result.Failure(MagicalItemImportError.InvalidTranslation(itemId, locale, field = "description"))
+                ?: return Result.Failure(
+                    MagicalItemImportError.InvalidTranslation(itemId, locale, field = "description"),
+                )
 
             return Result.Success(
-                MagicalItem.Translation(
-                    name = name,
-                    subtype = subtype,
-                    description = description,
-                ),
+                MagicalItem.Translation(name = name, subtype = subtype, description = description),
             )
         }
 
-        private fun Map<String, ApiMagicalItem.Translation>.toTranslations(itemId: String): Map<String, MagicalItem.Translation>? {
+        private fun Map<String, ApiMagicalItem.Translation>.toTranslations(
+            itemId: String,
+        ): Map<String, MagicalItem.Translation>? {
             val (parsedTranslations, translationErrors) = partitionBy { locale, t ->
                 t.toTranslation(itemId, locale)
             }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
@@ -38,7 +38,8 @@ class SampleMagicalItemRepository : MagicalItemRepository {
                 "en" to MagicalItem.Translation(
                     name = "Oath Axe",
                     subtype = null,
-                    description = "When you make a melee attack with this weapon, you can speak its command word. The target of your attack becomes your sworn enemy.",
+                    description = "When you make a melee attack with this weapon, you can speak its command word. " +
+                        "The target of your attack becomes your sworn enemy.",
                 ),
             ),
         )
@@ -88,7 +89,8 @@ class SampleMagicalItemRepository : MagicalItemRepository {
                 "en" to MagicalItem.Translation(
                     name = "Shield +1",
                     subtype = "shield",
-                    description = "While holding this shield, you have a +1 bonus to AC in addition to the shield's normal bonus.",
+                    description = "While holding this shield, you have a +1 bonus to AC in addition " +
+                        "to the shield's normal bonus.",
                 ),
             ),
         )
@@ -103,7 +105,8 @@ class SampleMagicalItemRepository : MagicalItemRepository {
                 "en" to MagicalItem.Translation(
                     name = "Wand of Fireballs",
                     subtype = null,
-                    description = "This wand has 7 charges. While holding it, you can use an action to expend 1 or more of its charges to cast the fireball spell.",
+                    description = "This wand has 7 charges. While holding it, you can use an action " +
+                        "to expend 1 or more of its charges to cast the fireball spell.",
                 ),
             ),
         )
@@ -133,7 +136,8 @@ class SampleMagicalItemRepository : MagicalItemRepository {
                 "en" to MagicalItem.Translation(
                     name = "Fireball Scroll",
                     subtype = null,
-                    description = "A fireball spell is written on this scroll. If the spell is on your class's spell list, you can cast it.",
+                    description = "A fireball spell is written on this scroll. " +
+                        "If the spell is on your class's spell list, you can cast it.",
                 ),
             ),
         )
@@ -148,7 +152,8 @@ class SampleMagicalItemRepository : MagicalItemRepository {
                 "en" to MagicalItem.Translation(
                     name = "Staff of Power",
                     subtype = null,
-                    description = "This staff grants a +2 bonus to attack and damage rolls made with it as a melee weapon.",
+                    description = "This staff grants a +2 bonus to attack and damage rolls made with " +
+                        "it as a melee weapon.",
                 ),
             ),
         )

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/SampleMagicalItemRepository.kt
@@ -6,9 +6,7 @@ import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.applyFilter
 
 class SampleMagicalItemRepository : MagicalItemRepository {
-    override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
-        return items.applyFilter(filter)
-    }
+    override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> = items.applyFilter(filter)
 
     override suspend fun getById(id: String): MagicalItem? = items.firstOrNull { it.id == id }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItem.kt
@@ -1,8 +1,7 @@
 package com.cyrillrx.rpg.magicalitem.domain
 
-import kotlinx.serialization.Serializable
-
 import com.cyrillrx.core.domain.FALLBACK_LOCALE
+import kotlinx.serialization.Serializable
 
 @Serializable
 class MagicalItem(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -13,11 +13,10 @@ fun List<MagicalItem>.applyFilter(filter: MagicalItemFilter?): List<MagicalItem>
     return filter { it.matches(filter) }
 }
 
-internal fun MagicalItem.matches(filter: MagicalItemFilter): Boolean {
-    return (filter.types.isEmpty() || filter.types.contains(type)) &&
+internal fun MagicalItem.matches(filter: MagicalItemFilter): Boolean =
+    (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.rarities.isEmpty() || filter.rarities.contains(rarity)) &&
         (filter.query.isBlank() || matchesQuery(filter.query))
-}
 
 private fun MagicalItem.matchesQuery(query: String): Boolean {
     val trimmed = query.trim()

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/DistanceUnit.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/DistanceUnit.kt
@@ -1,5 +1,6 @@
 package com.cyrillrx.rpg.settings.domain
 
 enum class DistanceUnit {
-    FEET, METERS
+    FEET,
+    METERS,
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/Theme.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/domain/Theme.kt
@@ -1,5 +1,7 @@
 package com.cyrillrx.rpg.settings.domain
 
 enum class Theme {
-    LIGHT, DARK, SYSTEM
+    LIGHT,
+    DARK,
+    SYSTEM,
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
@@ -45,7 +45,8 @@ class SampleSpellRepository : SpellRepository {
                     range = "150 feet",
                     duration = "Instantaneous",
                     materialDescription = "a tiny ball of bat guano and sulfur",
-                    description = "A bright streak flashes from your pointing finger to a point you choose within range and then blossoms with a low roar into an explosion of flame.",
+                    description = "A bright streak flashes from your pointing finger to a point you choose within " +
+                        "range and then blossoms with a low roar into an explosion of flame.",
                 ),
                 "fr" to Spell.Translation(
                     name = "Boule de feu",
@@ -53,7 +54,8 @@ class SampleSpellRepository : SpellRepository {
                     range = "45 mètres",
                     duration = "Instantanée",
                     materialDescription = "une minuscule bille de fiente de chauve-souris et de soufre",
-                    description = "Un trait lumineux jaillit de votre doigt pointé vers un point choisi à portée, puis explose dans un grondement sourd en une explosion de flammes.",
+                    description = "Un trait lumineux jaillit de votre doigt pointé vers un point choisi à portée, " +
+                        "puis explose dans un grondement sourd en une explosion de flammes.",
                 ),
             ),
         )
@@ -74,7 +76,8 @@ class SampleSpellRepository : SpellRepository {
                     range = "Touch",
                     duration = "8 hours",
                     materialDescription = "a piece of cured leather",
-                    description = "You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends.",
+                    description = "You touch a willing creature who isn't wearing armor, " +
+                        "and a protective magical force surrounds it until the spell ends.",
                 ),
             ),
         )

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
@@ -7,9 +7,7 @@ import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.domain.applyFilter
 
 class SampleSpellRepository : SpellRepository {
-    override suspend fun getAll(filter: SpellFilter?): List<Spell> {
-        return spells.applyFilter(filter)
-    }
+    override suspend fun getAll(filter: SpellFilter?): List<Spell> = spells.applyFilter(filter)
 
     override suspend fun getById(id: String): Spell? = spells.firstOrNull { it.id == id }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
@@ -1,9 +1,8 @@
 package com.cyrillrx.rpg.spell.domain
 
+import com.cyrillrx.core.domain.FALLBACK_LOCALE
 import com.cyrillrx.rpg.character.domain.Character
 import kotlinx.serialization.Serializable
-
-import com.cyrillrx.core.domain.FALLBACK_LOCALE
 
 @Serializable
 class Spell(

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -16,12 +16,11 @@ fun List<Spell>.applyFilter(filter: SpellFilter?): List<Spell> {
     return filter { it.matches(filter) }
 }
 
-internal fun Spell.matches(filter: SpellFilter): Boolean {
-    return (filter.schools.isEmpty() || school in filter.schools) &&
+internal fun Spell.matches(filter: SpellFilter): Boolean =
+    (filter.schools.isEmpty() || school in filter.schools) &&
         (filter.characterClasses.isEmpty() || availableClasses.any { filter.characterClasses.contains(it) }) &&
         (filter.levels.isEmpty() || filter.levels.contains(level)) &&
         (filter.query.isBlank() || matchesQuery(filter.query))
-}
 
 private fun Spell.matchesQuery(query: String): Boolean {
     val trimmed = query.trim()

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/domain/MapPartitionByExtTest.kt
@@ -35,7 +35,9 @@ class MapPartitionByExtTest {
 
     @Test
     fun `partitionBy empty map returns empty map and empty errors`() {
-        val (result, errors) = emptyMap<String, Int>().partitionBy<String, Int, Int, Error> { _, v -> Result.Success(v) }
+        val (result, errors) = emptyMap<String, Int>().partitionBy<String, Int, Int, Error> { _, v ->
+            Result.Success(v)
+        }
         assertTrue(result.isEmpty())
         assertTrue(errors.isEmpty())
     }
@@ -43,7 +45,9 @@ class MapPartitionByExtTest {
     @Test
     fun `partitionBy key is preserved in result map`() {
         val input = mapOf("locale" to "value")
-        val (result, _) = input.partitionBy<String, String, String, Error> { _, v -> Result.Success(v.uppercase()) }
+        val (result, _) = input.partitionBy<String, String, String, Error> { _, v ->
+            Result.Success(v.uppercase())
+        }
         assertEquals(expected = "VALUE", actual = result["locale"])
     }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepositoryTest.kt
@@ -15,51 +15,46 @@ import kotlin.test.assertTrue
 
 class JsonCharacterPresetRepositoryTest {
     @Test
-    fun `valid preset is parsed with correct field values`() =
-        runTest {
-            val result = repository(preset()).getAll(null)
+    fun `valid preset is parsed with correct field values`() = runTest {
+        val result = repository(preset()).getAll(null)
 
-            assertEquals(1, result.size)
-            val character = result.first()
-            assertEquals("test-fighter", character.id)
-            assertEquals("Aldus Test", character.name)
-            assertEquals(Race.HUMAN, character.race)
-            assertEquals(Character.Class.FIGHTER, character.clazz)
-            assertEquals(3, character.level)
-            assertEquals(Creature.Size.MEDIUM, character.size)
-            assertEquals(Creature.Alignment.LAWFUL_GOOD, character.alignment)
-            assertEquals(17, character.armorClass)
-            assertEquals(28, character.maxHitPoints)
-            assertEquals(listOf(Language.COMMON, Language.ELVISH), character.languages)
-        }
-
-    @Test
-    fun `preset with missing id is skipped`() =
-        runTest {
-            val json = preset(id = null)
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+        assertEquals(1, result.size)
+        val character = result.first()
+        assertEquals("test-fighter", character.id)
+        assertEquals("Aldus Test", character.name)
+        assertEquals(Race.HUMAN, character.race)
+        assertEquals(Character.Class.FIGHTER, character.clazz)
+        assertEquals(3, character.level)
+        assertEquals(Creature.Size.MEDIUM, character.size)
+        assertEquals(Creature.Alignment.LAWFUL_GOOD, character.alignment)
+        assertEquals(17, character.armorClass)
+        assertEquals(28, character.maxHitPoints)
+        assertEquals(listOf(Language.COMMON, Language.ELVISH), character.languages)
+    }
 
     @Test
-    fun `preset with missing name is skipped`() =
-        runTest {
-            val json = preset(name = null)
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with missing id is skipped`() = runTest {
+        val json = preset(id = null)
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `preset with missing translations is skipped`() =
-        runTest {
-            val json = preset(translations = null)
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with missing name is skipped`() = runTest {
+        val json = preset(name = null)
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `preset with missing level is skipped`() =
-        runTest {
-            val json = preset(level = null)
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with missing translations is skipped`() = runTest {
+        val json = preset(translations = null)
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
+
+    @Test
+    fun `preset with missing level is skipped`() = runTest {
+        val json = preset(level = null)
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
     fun `preset with unknown size is skipped`() =
@@ -69,73 +64,65 @@ class JsonCharacterPresetRepositoryTest {
         }
 
     @Test
-    fun `preset with unknown alignment is skipped`() =
-        runTest {
-            val json = preset(alignment = "CHAOTIC_POTATO")
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with unknown alignment is skipped`() = runTest {
+        val json = preset(alignment = "CHAOTIC_POTATO")
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `preset with missing skills is skipped`() =
-        runTest {
-            val json = preset(skills = null)
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with missing skills is skipped`() = runTest {
+        val json = preset(skills = null)
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `preset with unknown race is skipped`() =
-        runTest {
-            val json = preset(race = "martian")
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with unknown race is skipped`() = runTest {
+        val json = preset(race = "martian")
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `preset with unknown class is skipped`() =
-        runTest {
-            val json = preset(clazz = "jedi")
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with unknown class is skipped`() = runTest {
+        val json = preset(clazz = "jedi")
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `abilities and saving throws are parsed correctly`() =
-        runTest {
-            val json = preset(
-                abilities = """{"str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8}""",
-                savingThrows = """{"str": "proficient", "con": "proficient"}""",
-            )
-            val character = repository(json).getAll(null).first()
-            assertEquals(16, character.abilities.strength.value)
-            assertEquals(Proficiency.PROFICIENT, character.abilities.strength.savingThrowProficiency)
-            assertEquals(12, character.abilities.dexterity.value)
-            assertEquals(Proficiency.NONE, character.abilities.dexterity.savingThrowProficiency)
-            assertEquals(Proficiency.PROFICIENT, character.abilities.constitution.savingThrowProficiency)
-        }
+    fun `abilities and saving throws are parsed correctly`() = runTest {
+        val json = preset(
+            abilities = """{"str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8}""",
+            savingThrows = """{"str": "proficient", "con": "proficient"}""",
+        )
+        val character = repository(json).getAll(null).first()
+        assertEquals(16, character.abilities.strength.value)
+        assertEquals(Proficiency.PROFICIENT, character.abilities.strength.savingThrowProficiency)
+        assertEquals(12, character.abilities.dexterity.value)
+        assertEquals(Proficiency.NONE, character.abilities.dexterity.savingThrowProficiency)
+        assertEquals(Proficiency.PROFICIENT, character.abilities.constitution.savingThrowProficiency)
+    }
 
     @Test
-    fun `preset with missing walk speed is skipped`() =
-        runTest {
-            val json = preset(speeds = null)
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with missing walk speed is skipped`() = runTest {
+        val json = preset(speeds = null)
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `preset with unknown language is skipped`() =
-        runTest {
-            val json = preset(languages = """["klingon"]""")
-            assertTrue(repository(json).getAll(null).isEmpty())
-        }
+    fun `preset with unknown language is skipped`() = runTest {
+        val json = preset(languages = """["klingon"]""")
+        assertTrue(repository(json).getAll(null).isEmpty())
+    }
 
     @Test
-    fun `valid records are returned even when some records are invalid`() =
-        runTest {
-            val json = """[
+    fun `valid records are returned even when some records are invalid`() = runTest {
+        val json = """[
             ${preset().trimArray()},
             ${preset(id = "second-fighter", race = "martian").trimArray()}
         ]"""
-            val result = repository(json).getAll(null)
-            assertEquals(1, result.size)
-            assertEquals("test-fighter", result.first().id)
-        }
+        val result = repository(json).getAll(null)
+        assertEquals(1, result.size)
+        assertEquals("test-fighter", result.first().id)
+    }
 
     private fun repository(json: String) = JsonCharacterPresetRepository(FakeFileReader(json), "")
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CoerceToValidWalkSpeedInFeetTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CoerceToValidWalkSpeedInFeetTest.kt
@@ -20,10 +20,10 @@ class CoerceToValidWalkSpeedInFeetTest {
 
     @Test
     fun `rounds to nearest multiple of 5`() {
-        assertEquals(25, 26.coerceToValidWalkSpeedInFeet())  // remainder 1 → round down
-        assertEquals(25, 27.coerceToValidWalkSpeedInFeet())  // remainder 2 → round down (boundary)
-        assertEquals(30, 28.coerceToValidWalkSpeedInFeet())  // remainder 3 → round up
-        assertEquals(35, 33.coerceToValidWalkSpeedInFeet())  // remainder 3 → round up
+        assertEquals(25, 26.coerceToValidWalkSpeedInFeet()) // remainder 1 → round down
+        assertEquals(25, 27.coerceToValidWalkSpeedInFeet()) // remainder 2 → round down (boundary)
+        assertEquals(30, 28.coerceToValidWalkSpeedInFeet()) // remainder 3 → round up
+        assertEquals(35, 33.coerceToValidWalkSpeedInFeet()) // remainder 3 → round up
         assertEquals(115, 117.coerceToValidWalkSpeedInFeet()) // remainder 2 → round down
         assertEquals(120, 118.coerceToValidWalkSpeedInFeet()) // remainder 3 → round up to upper bound
         assertEquals(120, 119.coerceToValidWalkSpeedInFeet()) // remainder 4 → round up to upper bound

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CoerceToValidWalkSpeedInMetersTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CoerceToValidWalkSpeedInMetersTest.kt
@@ -9,7 +9,7 @@ class CoerceToValidWalkSpeedInMetersTest {
     fun `clamps values below 7,5 to 7,5`() {
         assertEquals(7.5f, 0f.coerceToValidWalkSpeedInMeters())
         assertEquals(7.5f, 5f.coerceToValidWalkSpeedInMeters())
-        assertEquals(7.5f, 7f.coerceToValidWalkSpeedInMeters())  // closer to 7.5 than to 9
+        assertEquals(7.5f, 7f.coerceToValidWalkSpeedInMeters()) // closer to 7.5 than to 9
     }
 
     @Test
@@ -20,10 +20,10 @@ class CoerceToValidWalkSpeedInMetersTest {
 
     @Test
     fun `rounds to nearest multiple of 1,5`() {
-        assertEquals(7.5f, 8f.coerceToValidWalkSpeedInMeters())    // closer to 7.5 than to 9
-        assertEquals(10.5f, 10f.coerceToValidWalkSpeedInMeters())   // closer to 10.5 than to 9
-        assertEquals(10.5f, 11f.coerceToValidWalkSpeedInMeters())   // closer to 10.5 than to 12
-        assertEquals(34.5f, 35f.coerceToValidWalkSpeedInMeters())   // closer to 34.5 than to 36
+        assertEquals(7.5f, 8f.coerceToValidWalkSpeedInMeters()) // closer to 7.5 than to 9
+        assertEquals(10.5f, 10f.coerceToValidWalkSpeedInMeters()) // closer to 10.5 than to 9
+        assertEquals(10.5f, 11f.coerceToValidWalkSpeedInMeters()) // closer to 10.5 than to 12
+        assertEquals(34.5f, 35f.coerceToValidWalkSpeedInMeters()) // closer to 34.5 than to 36
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/userlist/data/UserListRepositoryTest.kt
@@ -12,108 +12,101 @@ class UserListRepositoryTest {
     private fun buildRepository() = RamUserListRepository()
 
     @Test
-    fun `save and getAll returns list filtered by type`() =
-        runTest {
-            val repository = buildRepository()
+    fun `save and getAll returns list filtered by type`() = runTest {
+        val repository = buildRepository()
 
-            val spellList = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
-            val itemList = UserList(id = "2", name = "Artefacts", type = UserList.Type.MAGICAL_ITEM, itemIds = emptyList())
+        val spellList = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
+        val itemList = UserList(id = "2", name = "Artefacts", type = UserList.Type.MAGICAL_ITEM, itemIds = emptyList())
 
-            repository.save(spellList)
-            repository.save(itemList)
+        repository.save(spellList)
+        repository.save(itemList)
 
-            val spellLists = repository.getAll(UserList.Type.SPELL)
-            assertEquals(expected = 1, actual = spellLists.size)
-            assertEquals(expected = spellList, actual = spellLists.first())
+        val spellLists = repository.getAll(UserList.Type.SPELL)
+        assertEquals(expected = 1, actual = spellLists.size)
+        assertEquals(expected = spellList, actual = spellLists.first())
 
-            val itemLists = repository.getAll(UserList.Type.MAGICAL_ITEM)
-            assertEquals(expected = 1, actual = itemLists.size)
-            assertEquals(expected = itemList, actual = itemLists.first())
-        }
-
-    @Test
-    fun `get returns the list by id`() =
-        runTest {
-            val repository = buildRepository()
-            val list = UserList(id = "abc", name = "Test", type = UserList.Type.SPELL, itemIds = emptyList())
-
-            repository.save(list)
-
-            val result = repository.get("abc")
-            assertEquals(expected = list, actual = result)
-        }
+        val itemLists = repository.getAll(UserList.Type.MAGICAL_ITEM)
+        assertEquals(expected = 1, actual = itemLists.size)
+        assertEquals(expected = itemList, actual = itemLists.first())
+    }
 
     @Test
-    fun `get returns null for unknown id`() =
-        runTest {
-            val repository = buildRepository()
-            assertNull(repository.get("missing"))
-        }
+    fun `get returns the list by id`() = runTest {
+        val repository = buildRepository()
+        val list = UserList(id = "abc", name = "Test", type = UserList.Type.SPELL, itemIds = emptyList())
+
+        repository.save(list)
+
+        val result = repository.get("abc")
+        assertEquals(expected = list, actual = result)
+    }
 
     @Test
-    fun `save updates itemIds on existing list`() =
-        runTest {
-            val repository = buildRepository()
-            val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
-
-            repository.save(list)
-
-            val updated = list.copy(itemIds = listOf("spell1", "spell2"))
-            repository.save(updated)
-
-            val result = repository.get("1")
-            assertEquals(expected = updated, actual = result)
-        }
+    fun `get returns null for unknown id`() = runTest {
+        val repository = buildRepository()
+        assertNull(repository.get("missing"))
+    }
 
     @Test
-    fun `delete removes list by id`() =
-        runTest {
-            val repository = buildRepository()
-            val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
+    fun `save updates itemIds on existing list`() = runTest {
+        val repository = buildRepository()
+        val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
 
-            repository.save(list)
-            repository.delete("1")
+        repository.save(list)
 
-            assertNull(repository.get("1"))
-            assertTrue(repository.getAll(UserList.Type.SPELL).isEmpty())
-        }
+        val updated = list.copy(itemIds = listOf("spell1", "spell2"))
+        repository.save(updated)
 
-    @Test
-    fun `getAll returns empty list when no lists of given type exist`() =
-        runTest {
-            val repository = buildRepository()
-            val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
-
-            repository.save(list)
-
-            val monsterLists = repository.getAll(UserList.Type.MONSTER)
-            assertTrue(monsterLists.isEmpty())
-        }
+        val result = repository.get("1")
+        assertEquals(expected = updated, actual = result)
+    }
 
     @Test
-    fun `lists are returned sorted by lastModified descending`() =
-        runTest {
-            val repository = buildRepository()
-            val older = UserList(
-                id = "1",
-                name = "Older",
-                type = UserList.Type.SPELL,
-                itemIds = emptyList(),
-                lastModified = Instant.fromEpochMilliseconds(1000L),
-            )
-            val newer = UserList(
-                id = "2",
-                name = "Newer",
-                type = UserList.Type.SPELL,
-                itemIds = emptyList(),
-                lastModified = Instant.fromEpochMilliseconds(2000L),
-            )
+    fun `delete removes list by id`() = runTest {
+        val repository = buildRepository()
+        val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
 
-            repository.save(older)
-            repository.save(newer)
+        repository.save(list)
+        repository.delete("1")
 
-            val result = repository.getAll(UserList.Type.SPELL)
-            assertEquals(expected = newer, actual = result.first())
-            assertEquals(expected = older, actual = result.last())
-        }
+        assertNull(repository.get("1"))
+        assertTrue(repository.getAll(UserList.Type.SPELL).isEmpty())
+    }
+
+    @Test
+    fun `getAll returns empty list when no lists of given type exist`() = runTest {
+        val repository = buildRepository()
+        val list = UserList(id = "1", name = "Spellbook", type = UserList.Type.SPELL, itemIds = emptyList())
+
+        repository.save(list)
+
+        val monsterLists = repository.getAll(UserList.Type.MONSTER)
+        assertTrue(monsterLists.isEmpty())
+    }
+
+    @Test
+    fun `lists are returned sorted by lastModified descending`() = runTest {
+        val repository = buildRepository()
+        val older = UserList(
+            id = "1",
+            name = "Older",
+            type = UserList.Type.SPELL,
+            itemIds = emptyList(),
+            lastModified = Instant.fromEpochMilliseconds(1000L),
+        )
+        val newer = UserList(
+            id = "2",
+            name = "Newer",
+            type = UserList.Type.SPELL,
+            itemIds = emptyList(),
+            lastModified = Instant.fromEpochMilliseconds(2000L),
+        )
+
+        repository.save(older)
+        repository.save(newer)
+
+        val result = repository.getAll(UserList.Type.SPELL)
+        assertEquals(expected = newer, actual = result.first())
+        assertEquals(expected = older, actual = result.last())
+    }
 }

--- a/cmp-ttrpg-companion/shared/core/src/iosMain/kotlin/com/cyrillrx/rpg/core/data/cache/IOSDatabaseDriverFactory.kt
+++ b/cmp-ttrpg-companion/shared/core/src/iosMain/kotlin/com/cyrillrx/rpg/core/data/cache/IOSDatabaseDriverFactory.kt
@@ -6,7 +6,5 @@ import com.cyrillrx.rpg.cache.AppDatabase
 import com.cyrillrx.rpg.core.data.cache.Database.Companion.DATABASE_NAME
 
 class IOSDatabaseDriverFactory : DatabaseDriverFactory {
-    override fun createDriver(): SqlDriver {
-        return NativeSqliteDriver(AppDatabase.Schema, DATABASE_NAME)
-    }
+    override fun createDriver(): SqlDriver = NativeSqliteDriver(AppDatabase.Schema, DATABASE_NAME)
 }


### PR DESCRIPTION
## 📝 Description

Configure ktlint rules for the project, working through them one by one. Rules were either adopted (code fixed) or explicitly disabled in `.editorconfig` to be revisited later.

**Adopted rules** (code fixed to comply):
- `import-ordering` — lexicographic order, `kotlin`/`java` last
- `max-line-length` — limit set to 120 chars, violating lines split
- `enum-wrapping` — one entry per line with trailing comma
- `no-multi-spaces` — aligned inline comments removed
- `chain-method-continuation` — method chains split onto new lines
- `filename` — file names match their main declaration

**Disabled rules** (incompatible with current codebase style, to be revisited):
- `multiline-expression-wrapping` — compact `?: return` style preferred
- `class-signature` — compact single-line class signatures preferred
- `function-signature` — expression body on same line preferred
- `blank-line-before-declaration` — not enforced
- `no-empty-first-line-in-class-body` — not enforced
- `function-expression-body` — block bodies kept where already written
- `function-naming` — Compose `@Preview` functions use PascalCase by convention

**Also fixed**: migrated `androidApp` to AGP built-in Kotlin (removed deprecated `kotlin.android` plugin and `gradle.properties` flags).

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed