### PR TITLE
feat(character): replace short alignment abbreviations with full text

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_creature.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_creature.xml
@@ -69,15 +69,4 @@
     <string name="title_filter_monsters">Filtrer les monstres</string>
     <string name="label_filter_cr">Indice de dangerosité</string>
 
-    <!-- Alignment short labels -->
-    <string name="alignment_short_lawful_good">LB</string>
-    <string name="alignment_short_lawful_neutral">LN</string>
-    <string name="alignment_short_lawful_evil">LM</string>
-    <string name="alignment_short_neutral_good">NB</string>
-    <string name="alignment_short_neutral">N</string>
-    <string name="alignment_short_neutral_evil">NM</string>
-    <string name="alignment_short_chaotic_good">CB</string>
-    <string name="alignment_short_chaotic_neutral">CN</string>
-    <string name="alignment_short_chaotic_evil">CM</string>
-    <string name="alignment_short_unknown">?</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_creature.xml
@@ -69,15 +69,4 @@
     <string name="title_filter_monsters">Filter Monsters</string>
     <string name="label_filter_cr">Challenge Rating</string>
 
-    <!-- Alignment short labels -->
-    <string name="alignment_short_lawful_good">LG</string>
-    <string name="alignment_short_lawful_neutral">LN</string>
-    <string name="alignment_short_lawful_evil">LE</string>
-    <string name="alignment_short_neutral_good">NG</string>
-    <string name="alignment_short_neutral">N</string>
-    <string name="alignment_short_neutral_evil">NE</string>
-    <string name="alignment_short_chaotic_good">CG</string>
-    <string name="alignment_short_chaotic_neutral">CN</string>
-    <string name="alignment_short_chaotic_evil">CE</string>
-    <string name="alignment_short_unknown">?</string>
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -47,7 +47,6 @@ import com.cyrillrx.rpg.character.data.SampleCharacterRepository
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.domain.Race
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
-import com.cyrillrx.rpg.core.presentation.component.dnd.toShortString
 import com.cyrillrx.rpg.core.presentation.component.dnd.toSvgPath
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.DndGold
@@ -108,7 +107,7 @@ internal fun CharacterHeader(
                 }
                 if (alignment != Creature.Alignment.UNKNOWN) {
                     SubtitleDot()
-                    SubtitleChip(alignment.toShortString(), onAlignmentTapped)
+                    SubtitleChip(alignment.toFormattedString(), onAlignmentTapped)
                 }
             }
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/CreatureFormatExt.kt
@@ -7,16 +7,6 @@ import com.cyrillrx.rpg.dnd.domain.feetToMeters
 import com.cyrillrx.rpg.settings.domain.DistanceUnit
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.alignment_short_chaotic_evil
-import rpg_companion.composeapp.generated.resources.alignment_short_chaotic_good
-import rpg_companion.composeapp.generated.resources.alignment_short_chaotic_neutral
-import rpg_companion.composeapp.generated.resources.alignment_short_lawful_evil
-import rpg_companion.composeapp.generated.resources.alignment_short_lawful_good
-import rpg_companion.composeapp.generated.resources.alignment_short_lawful_neutral
-import rpg_companion.composeapp.generated.resources.alignment_short_neutral
-import rpg_companion.composeapp.generated.resources.alignment_short_neutral_evil
-import rpg_companion.composeapp.generated.resources.alignment_short_neutral_good
-import rpg_companion.composeapp.generated.resources.alignment_short_unknown
 import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_evil
 import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_good
 import rpg_companion.composeapp.generated.resources.creature_alignment_chaotic_neutral
@@ -82,22 +72,6 @@ fun Speeds.toFormattedString(unit: DistanceUnit): String {
         burrow?.let { add("$burrowLabel ${it.format()}") }
     }.joinToString(", ")
 }
-
-@Composable
-fun Creature.Alignment.toShortString(): String = stringResource(
-    when (this) {
-        Creature.Alignment.LAWFUL_GOOD -> Res.string.alignment_short_lawful_good
-        Creature.Alignment.LAWFUL_NEUTRAL -> Res.string.alignment_short_lawful_neutral
-        Creature.Alignment.LAWFUL_EVIL -> Res.string.alignment_short_lawful_evil
-        Creature.Alignment.NEUTRAL_GOOD -> Res.string.alignment_short_neutral_good
-        Creature.Alignment.NEUTRAL -> Res.string.alignment_short_neutral
-        Creature.Alignment.NEUTRAL_EVIL -> Res.string.alignment_short_neutral_evil
-        Creature.Alignment.CHAOTIC_GOOD -> Res.string.alignment_short_chaotic_good
-        Creature.Alignment.CHAOTIC_NEUTRAL -> Res.string.alignment_short_chaotic_neutral
-        Creature.Alignment.CHAOTIC_EVIL -> Res.string.alignment_short_chaotic_evil
-        Creature.Alignment.UNKNOWN -> Res.string.alignment_short_unknown
-    },
-)
 
 @Composable
 fun Creature.Alignment.toFormattedString(): String {


### PR DESCRIPTION
## 📝 Description

Remove `toShortString()` and its `alignment_short_*` string resources, which were duplicates of `toFormattedString()`. The character header now displays full alignment names (e.g. "Lawful good") instead of abbreviations (e.g. "LG").

This is a prerequisite cleanup before adding new `UNALIGNED` and `ANY_ALIGNMENT` enum values, to avoid duplicating the new strings in both format functions.

## 🖼️ Media

Character header alignment chip changes from short abbreviation ("LG") to full text ("Lawful good").

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed