### PR TITLE
feat(creature): replace Monster.type with Monster.types

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MonsterFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MonsterFormatExt.kt
@@ -88,13 +88,8 @@ fun Monster.Type.getColor(): Color = when (this) {
 }
 
 @Composable
-fun Set<Monster.Type>.toFormattedString(): String {
-    val parts = mutableListOf<String>()
-    for (type in this) {
-        parts.add(type.toFormattedString())
-    }
-    return parts.joinToString(" / ")
-}
+fun Set<Monster.Type>.toFormattedString(): String =
+    map { it.toFormattedString() }.joinToString(" / ")
 
 @Composable
 fun Monster.getSubtitle(): String = stringResource(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MonsterFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MonsterFormatExt.kt
@@ -88,9 +88,18 @@ fun Monster.Type.getColor(): Color = when (this) {
 }
 
 @Composable
+fun Set<Monster.Type>.toFormattedString(): String {
+    val parts = mutableListOf<String>()
+    for (type in this) {
+        parts.add(type.toFormattedString())
+    }
+    return parts.joinToString(" / ")
+}
+
+@Composable
 fun Monster.getSubtitle(): String = stringResource(
     Res.string.monster_subtitle,
-    type.toFormattedString(),
+    types.toFormattedString(),
     size.toFormattedString(),
     alignment.toFormattedString(),
 )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/MonsterAddToListProvider.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/MonsterAddToListProvider.kt
@@ -52,7 +52,7 @@ class MonsterAddToListProvider(
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = entity.type.toFormattedString(),
+                text = entity.types.toFormattedString(),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -55,7 +55,8 @@ fun MonsterListItem(
     modifier: Modifier = Modifier,
 ) {
     val translation = monster.resolveTranslation(currentLocale())
-    val typeColor = monster.types.first().getColor()
+    val primaryType = monster.types.first()
+    val typeColor = primaryType.getColor()
 
     Card(
         onClick = onClick,
@@ -78,7 +79,7 @@ fun MonsterListItem(
                     ),
             ) {
                 Icon(
-                    imageVector = monster.types.first().toIcon(),
+                    imageVector = primaryType.toIcon(),
                     contentDescription = null,
                     tint = typeColor,
                     modifier = Modifier.size(typeIconSize),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -55,7 +55,7 @@ fun MonsterListItem(
     modifier: Modifier = Modifier,
 ) {
     val translation = monster.resolveTranslation(currentLocale())
-    val primaryType = monster.types.first()
+    val primaryType = monster.getPrimaryType()
     val typeColor = primaryType.getColor()
 
     Card(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -55,7 +55,7 @@ fun MonsterListItem(
     modifier: Modifier = Modifier,
 ) {
     val translation = monster.resolveTranslation(currentLocale())
-    val typeColor = monster.type.getColor()
+    val typeColor = monster.types.first().getColor()
 
     Card(
         onClick = onClick,
@@ -78,7 +78,7 @@ fun MonsterListItem(
                     ),
             ) {
                 Icon(
-                    imageVector = monster.type.toIcon(),
+                    imageVector = monster.types.first().toIcon(),
                     contentDescription = null,
                     tint = typeColor,
                     modifier = Modifier.size(typeIconSize),
@@ -98,7 +98,7 @@ fun MonsterListItem(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 
-                val formattedMonsterType = monster.type.toFormattedString()
+                val formattedMonsterType = monster.types.toFormattedString()
                 val formattedMonsterSize = monster.size.name.lowercase().replaceFirstChar { it.uppercase() }
                 Text(
                     text = "$formattedMonsterType · $formattedMonsterSize",

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -100,7 +100,7 @@ fun MonsterListItem(
                 )
 
                 val formattedMonsterType = monster.types.toFormattedString()
-                val formattedMonsterSize = monster.size.name.lowercase().replaceFirstChar { it.uppercase() }
+                val formattedMonsterSize = monster.size.toFormattedString()
                 Text(
                     text = "$formattedMonsterType · $formattedMonsterSize",
                     style = MaterialTheme.typography.bodySmall,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -55,8 +55,8 @@ fun MonsterListItem(
     modifier: Modifier = Modifier,
 ) {
     val translation = monster.resolveTranslation(currentLocale())
-    val primaryType = monster.getPrimaryType()
-    val typeColor = primaryType.getColor()
+    val monsterType = monster.getDisplayType()
+    val typeColor = monsterType.getColor()
 
     Card(
         onClick = onClick,
@@ -79,7 +79,7 @@ fun MonsterListItem(
                     ),
             ) {
                 Icon(
-                    imageVector = primaryType.toIcon(),
+                    imageVector = monsterType.toIcon(),
                     contentDescription = null,
                     tint = typeColor,
                     modifier = Modifier.size(typeIconSize),

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
@@ -52,7 +52,7 @@ class MonsterListViewModelTest {
 
         val state = viewModel.state.value
         val body = assertIs<MonsterListState.Body.WithData>(state.body)
-        assertEquals(expected = 6, actual = body.searchResults.size)
+        assertEquals(expected = 7, actual = body.searchResults.size)
     }
 
     @Test
@@ -144,7 +144,7 @@ class MonsterListViewModelTest {
         assertFalse(viewModel.state.value.filter.hasActiveFilters)
         assertEquals(expected = MonsterFilter(), actual = viewModel.state.value.filter)
         val body = assertIs<MonsterListState.Body.WithData>(viewModel.state.value.body)
-        assertEquals(expected = 6, actual = body.searchResults.size)
+        assertEquals(expected = 7, actual = body.searchResults.size)
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -134,23 +134,18 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
         }
 
         private fun String.toTypes(): Set<Monster.Type>? {
-            Monster.Type.entries.find { it.name.equals(this, ignoreCase = true) }
-                ?.let { return setOf(it) }
+            val monsterType = Monster.Type.valueOfOrNull(type = this)
+            if (monsterType != null) return setOf(monsterType)
 
-            if (equals("swarm", ignoreCase = true) || startsWith("swarm_", ignoreCase = true)) {
-                return setOf(Monster.Type.SWARM)
-            }
+            if (isTypeSwarm()) return setOf(Monster.Type.SWARM)
 
-            val parts = split("_or_")
-            if (parts.size > 1) {
-                val resolved = parts.map { part ->
-                    Monster.Type.entries.find { it.name.equals(part, ignoreCase = true) }
-                        ?: return null
-                }.toSet()
-                return resolved
-            }
+            val monsterTypes = split("_or_")
+            if (monsterTypes.size <= 1) return null
 
-            return null
+            return monsterTypes.mapTo(HashSet()) { type -> Monster.Type.valueOfOrNull(type) ?: return null }
         }
+
+        private fun String.isTypeSwarm(): Boolean =
+            equals("swarm", ignoreCase = true) || startsWith("swarm_", ignoreCase = true)
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -146,6 +146,6 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
         }
 
         private fun String.isTypeSwarm(): Boolean =
-            equals("swarm", ignoreCase = true) || startsWith("swarm_", ignoreCase = true)
+            equals("swarm", ignoreCase = true) || startsWith("swarm_of", ignoreCase = true)
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -49,7 +49,7 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
                 ?: return Result.Failure(MonsterImportError.MissingSource(id))
             val apiType = type
                 ?: return Result.Failure(MonsterImportError.MissingType(id))
-            val type = apiType.toType()
+            val types = apiType.toTypes()
                 ?: return Result.Failure(MonsterImportError.UnknownType(id, apiType))
             val apiSize = size
                 ?: return Result.Failure(MonsterImportError.MissingSize(id))
@@ -82,7 +82,7 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
                 Monster(
                     id = id,
                     source = source,
-                    type = type,
+                    types = types,
                     size = size,
                     alignment = alignment,
                     challengeRating = challengeRating,
@@ -133,19 +133,21 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
             )
         }
 
-        // Fallback chain: exact match → "swarm_of_*" prefix → first component of "A_or_B" composites.
-        // Composite resolution is a temporary workaround; a future PR will refactor Monster.Type to handle these natively.
-        private fun String.toType(): Monster.Type? {
+        private fun String.toTypes(): Set<Monster.Type>? {
             Monster.Type.entries.find { it.name.equals(this, ignoreCase = true) }
-                ?.let { return it }
+                ?.let { return setOf(it) }
 
             if (equals("swarm", ignoreCase = true) || startsWith("swarm_", ignoreCase = true)) {
-                return Monster.Type.SWARM
+                return setOf(Monster.Type.SWARM)
             }
 
-            val primary = substringBefore("_or_")
-            if (primary != this) {
-                return Monster.Type.entries.find { it.name.equals(primary, ignoreCase = true) }
+            val parts = split("_or_")
+            if (parts.size > 1) {
+                val resolved = parts.map { part ->
+                    Monster.Type.entries.find { it.name.equals(part, ignoreCase = true) }
+                        ?: return null
+                }.toSet()
+                return resolved
             }
 
             return null

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -142,7 +142,7 @@ class JsonMonsterRepository(private val fileReader: FileReader) : MonsterReposit
             val monsterTypes = split("_or_")
             if (monsterTypes.size <= 1) return null
 
-            return monsterTypes.mapTo(HashSet()) { type -> Monster.Type.valueOfOrNull(type) ?: return null }
+            return monsterTypes.mapTo(LinkedHashSet()) { type -> Monster.Type.valueOfOrNull(type) ?: return null }
         }
 
         private fun String.isTypeSwarm(): Boolean =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
@@ -22,6 +22,7 @@ class SampleMonsterRepository : MonsterRepository {
             direWolf(),
             balor(),
             gelatinousCube(),
+            celestialFiend(),
         )
 
         fun getAll(): List<Monster> = monsters
@@ -199,6 +200,35 @@ class SampleMonsterRepository : MonsterRepository {
                     description = "A nearly transparent ooze that fills dungeon corridors.",
                     senses = "Blindsight 60 ft.",
                     languages = emptyList(),
+                ),
+            ),
+        )
+
+        fun celestialFiend() = Monster(
+            id = "7",
+            source = "srd_5.1",
+            types = setOf(Monster.Type.CELESTIAL, Monster.Type.FIEND),
+            size = Creature.Size.MEDIUM,
+            alignment = Creature.Alignment.CHAOTIC_EVIL,
+            challengeRating = 4f,
+            hitDice = "9d8",
+            abilities = Abilities(
+                strength = Ability(16),
+                dexterity = Ability(12),
+                constitution = Ability(13),
+                intelligence = Ability(14),
+                wisdom = Ability(11),
+                charisma = Ability(10),
+            ),
+            armorClass = 13,
+            maxHitPoints = 40,
+            speeds = Speeds(walk = 30),
+            translations = mapOf(
+                "en" to Monster.Translation(
+                    name = "Celestial Fiend",
+                    description = "A creature of dual nature.",
+                    senses = "Darkvision 60 ft.",
+                    languages = listOf("Common", "Celestial", "Infernal"),
                 ),
             ),
         )

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/SampleMonsterRepository.kt
@@ -31,7 +31,7 @@ class SampleMonsterRepository : MonsterRepository {
         fun goblin() = Monster(
             id = "1",
             source = "srd_5.1",
-            type = Monster.Type.HUMANOID,
+            types = setOf(Monster.Type.HUMANOID),
             size = Creature.Size.SMALL,
             alignment = Creature.Alignment.NEUTRAL_EVIL,
             challengeRating = 0.25f,
@@ -61,7 +61,7 @@ class SampleMonsterRepository : MonsterRepository {
         fun youngRedDragon() = Monster(
             id = "2",
             source = "srd_5.1",
-            type = Monster.Type.DRAGON,
+            types = setOf(Monster.Type.DRAGON),
             size = Creature.Size.LARGE,
             alignment = Creature.Alignment.CHAOTIC_EVIL,
             challengeRating = 10f,
@@ -90,7 +90,7 @@ class SampleMonsterRepository : MonsterRepository {
         private fun skeleton() = Monster(
             id = "3",
             source = "srd_5.1",
-            type = Monster.Type.UNDEAD,
+            types = setOf(Monster.Type.UNDEAD),
             size = Creature.Size.MEDIUM,
             alignment = Creature.Alignment.LAWFUL_EVIL,
             challengeRating = 0.25f,
@@ -119,7 +119,7 @@ class SampleMonsterRepository : MonsterRepository {
         private fun direWolf() = Monster(
             id = "4",
             source = "srd_5.1",
-            type = Monster.Type.BEAST,
+            types = setOf(Monster.Type.BEAST),
             size = Creature.Size.LARGE,
             alignment = Creature.Alignment.NEUTRAL,
             challengeRating = 1f,
@@ -148,7 +148,7 @@ class SampleMonsterRepository : MonsterRepository {
         private fun balor() = Monster(
             id = "5",
             source = "srd_5.1",
-            type = Monster.Type.FIEND,
+            types = setOf(Monster.Type.FIEND),
             size = Creature.Size.HUGE,
             alignment = Creature.Alignment.CHAOTIC_EVIL,
             challengeRating = 19f,
@@ -177,7 +177,7 @@ class SampleMonsterRepository : MonsterRepository {
         private fun gelatinousCube() = Monster(
             id = "6",
             source = "srd_5.1",
-            type = Monster.Type.OOZE,
+            types = setOf(Monster.Type.OOZE),
             size = Creature.Size.LARGE,
             alignment = Creature.Alignment.NEUTRAL,
             challengeRating = 2f,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
@@ -11,7 +11,7 @@ class Monster(
     override val maxHitPoints: Int,
     override val speeds: Speeds,
     val source: String,
-    val type: Type,
+    val types: Set<Type>,
     val challengeRating: Float,
     val hitDice: String,
     val skills: Skills = Skills(),
@@ -20,6 +20,7 @@ class Monster(
     val translations: Map<String, Translation>,
 ) : Creature() {
     init {
+        require(types.isNotEmpty()) { "Monster $id must have at least one type" }
         require(translations.isNotEmpty()) { "Monster $id must have at least one translation" }
     }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
@@ -24,6 +24,8 @@ class Monster(
         require(translations.isNotEmpty()) { "Monster $id must have at least one translation" }
     }
 
+    fun getPrimaryType(): Type = types.first()
+
     fun resolveTranslation(locale: String): Translation =
         translations[locale]
             ?: translations[FALLBACK_LOCALE]

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
@@ -24,7 +24,7 @@ class Monster(
         require(translations.isNotEmpty()) { "Monster $id must have at least one translation" }
     }
 
-    fun getPrimaryType(): Type = types.first()
+    fun getDisplayType(): Type = types.first()
 
     fun resolveTranslation(locale: String): Translation =
         translations[locale]

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Monster.kt
@@ -57,6 +57,10 @@ class Monster(
         PLANT,
         SWARM,
         UNDEAD,
-        UNKNOWN,
+        UNKNOWN;
+
+        companion object {
+            fun valueOfOrNull(type: String): Type? = entries.find { it.name.equals(type, ignoreCase = true) }
+        }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/MonsterFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/MonsterFilter.kt
@@ -14,7 +14,7 @@ fun List<Monster>.applyFilter(filter: MonsterFilter?): List<Monster> {
 }
 
 internal fun Monster.matches(filter: MonsterFilter): Boolean =
-    (filter.types.isEmpty() || filter.types.contains(type)) &&
+    (filter.types.isEmpty() || filter.types.any { it in types }) &&
         (filter.challengeRatings.isEmpty() || filter.challengeRatings.contains(challengeRating)) &&
         (filter.query.isBlank() || matches(filter.query))
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepositoryTest.kt
@@ -74,6 +74,7 @@ class JsonMonsterRepositoryTest {
     fun `monster with composite type whose any component is unknown is skipped`() = runTest {
         assertTrue(repository(monster(type = "newtype_or_fiend")).getAll(null).isEmpty())
         assertTrue(repository(monster(type = "fiend_or_newtype")).getAll(null).isEmpty())
+        assertTrue(repository(monster(type = "newtype_or_newtype")).getAll(null).isEmpty())
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepositoryTest.kt
@@ -51,7 +51,7 @@ class JsonMonsterRepositoryTest {
         val result = repository(monster(type = "swarm")).getAll(null)
 
         assertEquals(1, result.size)
-        assertEquals(Monster.Type.SWARM, result.first().type)
+        assertEquals(setOf(Monster.Type.SWARM), result.first().types)
     }
 
     @Test
@@ -59,20 +59,21 @@ class JsonMonsterRepositoryTest {
         val result = repository(monster(type = "swarm_of_tiny_beasts")).getAll(null)
 
         assertEquals(1, result.size)
-        assertEquals(Monster.Type.SWARM, result.first().type)
+        assertEquals(setOf(Monster.Type.SWARM), result.first().types)
     }
 
     @Test
-    fun `monster with composite type uses first type`() = runTest {
+    fun `monster with composite type resolves all known types`() = runTest {
         val result = repository(monster(type = "celestial_or_fiend")).getAll(null)
 
         assertEquals(1, result.size)
-        assertEquals(Monster.Type.CELESTIAL, result.first().type)
+        assertEquals(setOf(Monster.Type.CELESTIAL, Monster.Type.FIEND), result.first().types)
     }
 
     @Test
-    fun `monster with composite type whose first component is unknown is skipped`() = runTest {
+    fun `monster with composite type whose any component is unknown is skipped`() = runTest {
         assertTrue(repository(monster(type = "newtype_or_fiend")).getAll(null).isEmpty())
+        assertTrue(repository(monster(type = "fiend_or_newtype")).getAll(null).isEmpty())
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepositoryTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepositoryTest.kt
@@ -63,6 +63,14 @@ class JsonMonsterRepositoryTest {
     }
 
     @Test
+    fun `monster with swarm_or composite type resolves as composite not swarm`() = runTest {
+        val result = repository(monster(type = "swarm_or_fiend")).getAll(null)
+
+        assertEquals(1, result.size)
+        assertEquals(setOf(Monster.Type.SWARM, Monster.Type.FIEND), result.first().types)
+    }
+
+    @Test
     fun `monster with composite type resolves all known types`() = runTest {
         val result = repository(monster(type = "celestial_or_fiend")).getAll(null)
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterApplyFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterApplyFilterTest.kt
@@ -24,7 +24,7 @@ class MonsterApplyFilterTest {
     @Test
     fun `filter by type keeps only matching creatures`() {
         val result = monsters.applyFilter(MonsterFilter(types = setOf(Monster.Type.HUMANOID)))
-        assertTrue(result.all { it.type == Monster.Type.HUMANOID })
+        assertTrue(result.all { Monster.Type.HUMANOID in it.types })
         assertEquals(1, result.size)
     }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterApplyFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterApplyFilterTest.kt
@@ -29,6 +29,18 @@ class MonsterApplyFilterTest {
     }
 
     @Test
+    fun `filter by type matches multi-type monster on first type`() {
+        val result = monsters.applyFilter(MonsterFilter(types = setOf(Monster.Type.CELESTIAL)))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `filter by type matches multi-type monster on second type`() {
+        val result = monsters.applyFilter(MonsterFilter(types = setOf(Monster.Type.FIEND)))
+        assertEquals(2, result.size)
+    }
+
+    @Test
     fun `filter by challenge rating keeps only matching creatures`() {
         val result = monsters.applyFilter(MonsterFilter(challengeRatings = setOf(0.25f)))
         assertTrue(result.all { it.challengeRating == 0.25f })

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
@@ -27,7 +27,7 @@ class MonsterTest {
     }
 
     private fun validMonster(
-        types: Set<Monster.Type> = hashSetOf(Monster.Type.BEAST),
+        types: Set<Monster.Type> = setOf(Monster.Type.BEAST),
         translations: Map<String, Monster.Translation> = mapOf(
             "en" to Monster.Translation(
                 name = "Test",

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
@@ -1,8 +1,8 @@
 package com.cyrillrx.rpg.creature.domain
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class MonsterTest {
 
@@ -21,9 +21,9 @@ class MonsterTest {
     }
 
     @Test
-    fun `getPrimaryType returns the first type in declaration order`() {
+    fun `getDisplayType returns one of the monster's types`() {
         val monster = validMonster(types = setOf(Monster.Type.CELESTIAL, Monster.Type.FIEND))
-        assertEquals(Monster.Type.CELESTIAL, monster.getPrimaryType())
+        assertTrue(monster.getDisplayType() in monster.types)
     }
 
     private fun validMonster(

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.creature.domain
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class MonsterTest {
@@ -19,8 +20,14 @@ class MonsterTest {
         }
     }
 
+    @Test
+    fun `getPrimaryType returns the first type in declaration order`() {
+        val monster = validMonster(types = setOf(Monster.Type.CELESTIAL, Monster.Type.FIEND))
+        assertEquals(Monster.Type.CELESTIAL, monster.getPrimaryType())
+    }
+
     private fun validMonster(
-        types: Set<Monster.Type> = setOf(Monster.Type.BEAST),
+        types: Set<Monster.Type> = hashSetOf(Monster.Type.BEAST),
         translations: Map<String, Monster.Translation> = mapOf(
             "en" to Monster.Translation(
                 name = "Test",

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/MonsterTest.kt
@@ -1,0 +1,53 @@
+package com.cyrillrx.rpg.creature.domain
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class MonsterTest {
+
+    @Test
+    fun `construction fails when types is empty`() {
+        assertFailsWith<IllegalArgumentException> {
+            validMonster(types = emptySet())
+        }
+    }
+
+    @Test
+    fun `construction fails when translations is empty`() {
+        assertFailsWith<IllegalArgumentException> {
+            validMonster(translations = emptyMap())
+        }
+    }
+
+    private fun validMonster(
+        types: Set<Monster.Type> = setOf(Monster.Type.BEAST),
+        translations: Map<String, Monster.Translation> = mapOf(
+            "en" to Monster.Translation(
+                name = "Test",
+                description = "A test.",
+                senses = "Darkvision 60 ft.",
+                languages = emptyList(),
+            ),
+        ),
+    ) = Monster(
+        id = "test",
+        source = "test",
+        types = types,
+        size = Creature.Size.MEDIUM,
+        alignment = Creature.Alignment.NEUTRAL,
+        challengeRating = 1f,
+        hitDice = "1d8",
+        abilities = Abilities(
+            strength = Ability(10),
+            dexterity = Ability(10),
+            constitution = Ability(10),
+            intelligence = Ability(10),
+            wisdom = Ability(10),
+            charisma = Ability(10),
+        ),
+        armorClass = 10,
+        maxHitPoints = 10,
+        speeds = Speeds(walk = 30),
+        translations = translations,
+    )
+}


### PR DESCRIPTION
## 📝 Description

A monster can have multiple types in the source data (e.g. `"celestial_or_fiend"`, `"celestial_or_fey_or_fiend"`). The previous implementation silently discarded all but the first type via a workaround noted in a TODO comment. This PR replaces `Monster.type: Monster.Type` with `Monster.types: Set<Monster.Type>` to faithfully represent the data.

**Key behavioral changes:**
- `Monster.types` is a non-empty `Set<Monster.Type>` — construction fails if the set is empty.
- `JsonMonsterRepository.toTypes()` now resolves **all** components of composite type strings. If any component is unrecognized, the whole monster is rejected (strict parsing), so the integration test (`JsonMonsterRepositoryIntegrationTest`) catches unrecognized values rather than silently dropping type information.
- `toTypes()` uses `LinkedHashSet` to preserve the insertion order of components, so `getDisplayType()` consistently returns the first type listed in the source data.
- The monster filter now matches if **any** of the monster's types is in the selected set.
- The UI joins all type labels with ` / ` (e.g. `"Celestial / Fiend"`). Icon and color still use `getDisplayType()` (the first listed type) as the primary visual indicator.

**Also includes:** `MonsterListItem` now uses `monster.size.toFormattedString()` (localized string resource) instead of a manual `.name.lowercase().replaceFirstChar { }` formatting.

## 🖼️ Media

N/A — data-layer and display change; no new screens.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed