### PR TITLE
feat(character): add saving throws section to character sheet

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -31,6 +31,7 @@
     <string name="label_walk_speed">Vitesse (%1$s)</string>
     <string name="label_languages">Langues</string>
     <string name="label_level_short">niv.</string>
+    <string name="label_saving_throws">Jets de sauvegarde</string>
     <string name="label_saving_throw_proficiency">Maîtrise de sauvegarde</string>
     <string name="hint_ability">Min %1$d · Max %2$d · Score initial %3$s</string>
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -31,6 +31,7 @@
     <string name="label_walk_speed">Walk speed (%1$s)</string>
     <string name="label_languages">Languages</string>
     <string name="label_level_short">lv.</string>
+    <string name="label_saving_throws">Saving Throws</string>
     <string name="label_saving_throw_proficiency">Saving throw proficiency</string>
     <string name="hint_ability">Min %1$d · Max %2$d · Initial score %3$s</string>
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -52,6 +52,7 @@ import rpg_companion.composeapp.generated.resources.info_value_coerced
 import rpg_companion.composeapp.generated.resources.label_abilities
 import rpg_companion.composeapp.generated.resources.label_combat
 import rpg_companion.composeapp.generated.resources.label_languages
+import rpg_companion.composeapp.generated.resources.label_saving_throws
 
 @Composable
 fun CharacterDetailScreen(
@@ -187,6 +188,13 @@ fun CharacterDetailScreen(
                 onIntelligenceTapped = { onFieldTapped(EditingField.Intelligence) },
                 onWisdomTapped = { onFieldTapped(EditingField.Wisdom) },
                 onCharismaTapped = { onFieldTapped(EditingField.Charisma) },
+            )
+
+            SheetDivider(stringResource(Res.string.label_saving_throws))
+
+            SavingThrowsSection(
+                abilities = state.character.abilities,
+                proficiencyBonus = state.character.proficiencyBonus(),
             )
 
             SheetDivider(stringResource(Res.string.label_combat))

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -74,6 +74,7 @@ internal fun AbilityGrid(
     onCharismaTapped: () -> Unit,
 ) {
     StatCellGrid(
+        columns = 3,
         cells = listOf(
             { modifier ->
                 AbilityCard(
@@ -149,6 +150,7 @@ internal fun SavingThrowsSection(
     proficiencyBonus: Int,
 ) {
     StatCellGrid(
+        columns = 3,
         cells = listOf(
             { modifier ->
                 SavingThrowCard(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -28,7 +29,6 @@ import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
 import com.cyrillrx.rpg.creature.domain.Proficiency
@@ -133,35 +133,13 @@ private fun AbilityCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val modifierText = Ability(score).getModifier().toSignedString()
-
-    ElevatedCard(
+    StatCell(
+        label = label,
+        value = score.toString(),
+        caption = Ability(score).getModifier().toSignedString(),
         onClick = onClick,
         modifier = modifier,
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = spacingMedium, horizontal = spacingSmall),
-        ) {
-            Text(
-                text = score.toString(),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = modifierText,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.primary,
-            )
-        }
-    }
+    )
 }
 
 @Composable
@@ -175,20 +153,20 @@ internal fun SavingThrowsSection(
             modifier = Modifier.fillMaxWidth(),
         ) {
             SavingThrowCard(
-                ability = abilities.strength,
                 label = stringResource(Res.string.ability_label_str),
+                ability = abilities.strength,
                 proficiencyBonus = proficiencyBonus,
                 modifier = Modifier.weight(1f),
             )
             SavingThrowCard(
-                ability = abilities.dexterity,
                 label = stringResource(Res.string.ability_label_dex),
+                ability = abilities.dexterity,
                 proficiencyBonus = proficiencyBonus,
                 modifier = Modifier.weight(1f),
             )
             SavingThrowCard(
-                ability = abilities.constitution,
                 label = stringResource(Res.string.ability_label_con),
+                ability = abilities.constitution,
                 proficiencyBonus = proficiencyBonus,
                 modifier = Modifier.weight(1f),
             )
@@ -198,20 +176,20 @@ internal fun SavingThrowsSection(
             modifier = Modifier.fillMaxWidth(),
         ) {
             SavingThrowCard(
-                ability = abilities.intelligence,
                 label = stringResource(Res.string.ability_label_int),
+                ability = abilities.intelligence,
                 proficiencyBonus = proficiencyBonus,
                 modifier = Modifier.weight(1f),
             )
             SavingThrowCard(
-                ability = abilities.wisdom,
                 label = stringResource(Res.string.ability_label_wis),
+                ability = abilities.wisdom,
                 proficiencyBonus = proficiencyBonus,
                 modifier = Modifier.weight(1f),
             )
             SavingThrowCard(
-                ability = abilities.charisma,
                 label = stringResource(Res.string.ability_label_cha),
+                ability = abilities.charisma,
                 proficiencyBonus = proficiencyBonus,
                 modifier = Modifier.weight(1f),
             )
@@ -221,33 +199,18 @@ internal fun SavingThrowsSection(
 
 @Composable
 private fun SavingThrowCard(
-    ability: Ability,
     label: String,
+    ability: Ability,
     proficiencyBonus: Int,
     modifier: Modifier = Modifier,
 ) {
-    val savingThrow = ability.getSavingThrow(proficiencyBonus)
     val isProficient = ability.savingThrowProficiency != Proficiency.NONE
-    ElevatedCard(modifier = modifier) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = spacingMedium, horizontal = spacingSmall),
-        ) {
-            Text(
-                text = savingThrow.toSignedString(),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = if (isProficient) MaterialTheme.colorScheme.primary else Color.Unspecified,
-            )
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
+    StatCell(
+        label = label,
+        value = ability.getSavingThrow(proficiencyBonus).toSignedString(),
+        valueColor = if (isProficient) MaterialTheme.colorScheme.primary else Color.Unspecified,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -262,18 +225,18 @@ internal fun CombatRow(
         horizontalArrangement = Arrangement.spacedBy(spacingMedium),
         modifier = Modifier.fillMaxWidth(),
     ) {
-        StatCard(
+        StatCell(
             label = stringResource(Res.string.label_ac),
             value = armorClass.toString(),
             onClick = onAcTapped,
             modifier = Modifier.weight(1f),
         )
-        StatCard(
+        StatCell(
             label = stringResource(Res.string.label_initiative),
             value = initiative.toSignedString(),
             modifier = Modifier.weight(1f),
         )
-        StatCard(
+        StatCell(
             label = stringResource(Res.string.label_max_hp),
             value = maxHitPoints.toString(),
             onClick = onMaxHpTapped,
@@ -282,30 +245,44 @@ internal fun CombatRow(
     }
 }
 
+/**
+ * Shared stat cell used by ability, saving throw and combat sections: an [ElevatedCard] showing a
+ * bold [value] above a muted [label], with an optional [caption] line and an optional click action.
+ */
 @Composable
-private fun StatCard(
+private fun StatCell(
     label: String,
     value: String,
-    onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
+    valueColor: Color = Color.Unspecified,
+    caption: String? = null,
+    onClick: (() -> Unit)? = null,
 ) {
     val cardContent: @Composable ColumnScope.() -> Unit = {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(spacingMedium),
+                .padding(PaddingValues(vertical = spacingMedium)),
         ) {
-            Text(
-                text = value,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-            )
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = valueColor,
+            )
+            if (caption != null) {
+                Text(
+                    text = caption,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
         }
     }
     if (onClick == null) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -3,14 +3,11 @@ package com.cyrillrx.rpg.character.presentation.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -242,53 +239,6 @@ internal fun CombatRow(
             onClick = onMaxHpTapped,
             modifier = Modifier.weight(1f),
         )
-    }
-}
-
-/**
- * Shared stat cell used by ability, saving throw and combat sections: an [ElevatedCard] showing a
- * bold [value] above a muted [label], with an optional [caption] line and an optional click action.
- */
-@Composable
-private fun StatCell(
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier,
-    valueColor: Color = Color.Unspecified,
-    caption: String? = null,
-    onClick: (() -> Unit)? = null,
-) {
-    val cardContent: @Composable ColumnScope.() -> Unit = {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(PaddingValues(vertical = spacingMedium)),
-        ) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = value,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = valueColor,
-            )
-            if (caption != null) {
-                Text(
-                    text = caption,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-        }
-    }
-    if (onClick == null) {
-        ElevatedCard(modifier = modifier, content = cardContent)
-    } else {
-        ElevatedCard(onClick = onClick, modifier = modifier, content = cardContent)
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -101,10 +101,10 @@ internal fun AbilityGrid(
             },
             { modifier ->
                 AbilityCard(
-                    abilities.intelligence.value,
-                    stringResource(Res.string.ability_label_int),
-                    onIntelligenceTapped,
-                    modifier,
+                    score = abilities.intelligence.value,
+                    label = stringResource(Res.string.ability_label_int),
+                    onClick = onIntelligenceTapped,
+                    modifier = modifier,
                 )
             },
             { modifier ->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -73,54 +73,58 @@ internal fun AbilityGrid(
     onWisdomTapped: () -> Unit,
     onCharismaTapped: () -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(spacingMedium)) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            AbilityCard(
-                score = abilities.strength.value,
-                label = stringResource(Res.string.ability_label_str),
-                onClick = onStrengthTapped,
-                modifier = Modifier.weight(1f),
-            )
-            AbilityCard(
-                score = abilities.dexterity.value,
-                label = stringResource(Res.string.ability_label_dex),
-                onClick = onDexterityTapped,
-                modifier = Modifier.weight(1f),
-            )
-            AbilityCard(
-                score = abilities.constitution.value,
-                label = stringResource(Res.string.ability_label_con),
-                onClick = onConstitutionTapped,
-                modifier = Modifier.weight(1f),
-            )
-        }
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            AbilityCard(
-                score = abilities.intelligence.value,
-                label = stringResource(Res.string.ability_label_int),
-                onClick = onIntelligenceTapped,
-                modifier = Modifier.weight(1f),
-            )
-            AbilityCard(
-                score = abilities.wisdom.value,
-                label = stringResource(Res.string.ability_label_wis),
-                onClick = onWisdomTapped,
-                modifier = Modifier.weight(1f),
-            )
-            AbilityCard(
-                score = abilities.charisma.value,
-                label = stringResource(Res.string.ability_label_cha),
-                onClick = onCharismaTapped,
-                modifier = Modifier.weight(1f),
-            )
-        }
-    }
+    StatCellGrid(
+        cells = listOf(
+            { modifier ->
+                AbilityCard(
+                    score = abilities.strength.value,
+                    label = stringResource(Res.string.ability_label_str),
+                    onClick = onStrengthTapped,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                AbilityCard(
+                    score = abilities.dexterity.value,
+                    label = stringResource(Res.string.ability_label_dex),
+                    onClick = onDexterityTapped,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                AbilityCard(
+                    score = abilities.constitution.value,
+                    label = stringResource(Res.string.ability_label_con),
+                    onClick = onConstitutionTapped,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                AbilityCard(
+                    abilities.intelligence.value,
+                    stringResource(Res.string.ability_label_int),
+                    onIntelligenceTapped,
+                    modifier,
+                )
+            },
+            { modifier ->
+                AbilityCard(
+                    score = abilities.wisdom.value,
+                    label = stringResource(Res.string.ability_label_wis),
+                    onClick = onWisdomTapped,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                AbilityCard(
+                    score = abilities.charisma.value,
+                    label = stringResource(Res.string.ability_label_cha),
+                    onClick = onCharismaTapped,
+                    modifier = modifier,
+                )
+            },
+        ),
+    )
 }
 
 @Composable
@@ -144,54 +148,58 @@ internal fun SavingThrowsSection(
     abilities: Abilities,
     proficiencyBonus: Int,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(spacingMedium)) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            SavingThrowCard(
-                label = stringResource(Res.string.ability_label_str),
-                ability = abilities.strength,
-                proficiencyBonus = proficiencyBonus,
-                modifier = Modifier.weight(1f),
-            )
-            SavingThrowCard(
-                label = stringResource(Res.string.ability_label_dex),
-                ability = abilities.dexterity,
-                proficiencyBonus = proficiencyBonus,
-                modifier = Modifier.weight(1f),
-            )
-            SavingThrowCard(
-                label = stringResource(Res.string.ability_label_con),
-                ability = abilities.constitution,
-                proficiencyBonus = proficiencyBonus,
-                modifier = Modifier.weight(1f),
-            )
-        }
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            SavingThrowCard(
-                label = stringResource(Res.string.ability_label_int),
-                ability = abilities.intelligence,
-                proficiencyBonus = proficiencyBonus,
-                modifier = Modifier.weight(1f),
-            )
-            SavingThrowCard(
-                label = stringResource(Res.string.ability_label_wis),
-                ability = abilities.wisdom,
-                proficiencyBonus = proficiencyBonus,
-                modifier = Modifier.weight(1f),
-            )
-            SavingThrowCard(
-                label = stringResource(Res.string.ability_label_cha),
-                ability = abilities.charisma,
-                proficiencyBonus = proficiencyBonus,
-                modifier = Modifier.weight(1f),
-            )
-        }
-    }
+    StatCellGrid(
+        cells = listOf(
+            { modifier ->
+                SavingThrowCard(
+                    label = stringResource(Res.string.ability_label_str),
+                    ability = abilities.strength,
+                    proficiencyBonus = proficiencyBonus,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                SavingThrowCard(
+                    label = stringResource(Res.string.ability_label_dex),
+                    ability = abilities.dexterity,
+                    proficiencyBonus = proficiencyBonus,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                SavingThrowCard(
+                    label = stringResource(Res.string.ability_label_con),
+                    ability = abilities.constitution,
+                    proficiencyBonus = proficiencyBonus,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                SavingThrowCard(
+                    label = stringResource(Res.string.ability_label_int),
+                    ability = abilities.intelligence,
+                    proficiencyBonus = proficiencyBonus,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                SavingThrowCard(
+                    label = stringResource(Res.string.ability_label_wis),
+                    ability = abilities.wisdom,
+                    proficiencyBonus = proficiencyBonus,
+                    modifier = modifier,
+                )
+            },
+            { modifier ->
+                SavingThrowCard(
+                    label = stringResource(Res.string.ability_label_cha),
+                    ability = abilities.charisma,
+                    proficiencyBonus = proficiencyBonus,
+                    modifier = modifier,
+                )
+            },
+        ),
+    )
 }
 
 @Composable

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -30,16 +30,17 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
+import com.cyrillrx.rpg.creature.domain.Proficiency
 import com.cyrillrx.rpg.settings.domain.DistanceUnit
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.label_ac
 import rpg_companion.composeapp.generated.resources.ability_label_cha
 import rpg_companion.composeapp.generated.resources.ability_label_con
 import rpg_companion.composeapp.generated.resources.ability_label_dex
 import rpg_companion.composeapp.generated.resources.ability_label_int
 import rpg_companion.composeapp.generated.resources.ability_label_str
 import rpg_companion.composeapp.generated.resources.ability_label_wis
+import rpg_companion.composeapp.generated.resources.label_ac
 import rpg_companion.composeapp.generated.resources.label_initiative
 import rpg_companion.composeapp.generated.resources.label_languages
 import rpg_companion.composeapp.generated.resources.label_max_hp
@@ -157,6 +158,96 @@ private fun AbilityCard(
                 text = modifierText,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun SavingThrowsSection(
+    abilities: Abilities,
+    proficiencyBonus: Int,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(spacingMedium)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SavingThrowCard(
+                ability = abilities.strength,
+                label = stringResource(Res.string.ability_label_str),
+                proficiencyBonus = proficiencyBonus,
+                modifier = Modifier.weight(1f),
+            )
+            SavingThrowCard(
+                ability = abilities.dexterity,
+                label = stringResource(Res.string.ability_label_dex),
+                proficiencyBonus = proficiencyBonus,
+                modifier = Modifier.weight(1f),
+            )
+            SavingThrowCard(
+                ability = abilities.constitution,
+                label = stringResource(Res.string.ability_label_con),
+                proficiencyBonus = proficiencyBonus,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SavingThrowCard(
+                ability = abilities.intelligence,
+                label = stringResource(Res.string.ability_label_int),
+                proficiencyBonus = proficiencyBonus,
+                modifier = Modifier.weight(1f),
+            )
+            SavingThrowCard(
+                ability = abilities.wisdom,
+                label = stringResource(Res.string.ability_label_wis),
+                proficiencyBonus = proficiencyBonus,
+                modifier = Modifier.weight(1f),
+            )
+            SavingThrowCard(
+                ability = abilities.charisma,
+                label = stringResource(Res.string.ability_label_cha),
+                proficiencyBonus = proficiencyBonus,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SavingThrowCard(
+    ability: Ability,
+    label: String,
+    proficiencyBonus: Int,
+    modifier: Modifier = Modifier,
+) {
+    val savingThrow = ability.getModifier() + when (ability.savingThrowProficiency) {
+        Proficiency.NONE -> 0
+        Proficiency.PROFICIENT -> proficiencyBonus
+        Proficiency.EXPERT -> proficiencyBonus * 2
+    }
+    val isProficient = ability.savingThrowProficiency != Proficiency.NONE
+    ElevatedCard(modifier = modifier) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = spacingMedium, horizontal = spacingSmall),
+        ) {
+            Text(
+                text = savingThrow.toSignedString(),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = if (isProficient) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterSheetSections.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.cyrillrx.rpg.character.domain.Language
@@ -225,11 +226,7 @@ private fun SavingThrowCard(
     proficiencyBonus: Int,
     modifier: Modifier = Modifier,
 ) {
-    val savingThrow = ability.getModifier() + when (ability.savingThrowProficiency) {
-        Proficiency.NONE -> 0
-        Proficiency.PROFICIENT -> proficiencyBonus
-        Proficiency.EXPERT -> proficiencyBonus * 2
-    }
+    val savingThrow = ability.getSavingThrow(proficiencyBonus)
     val isProficient = ability.savingThrowProficiency != Proficiency.NONE
     ElevatedCard(modifier = modifier) {
         Column(
@@ -242,7 +239,7 @@ private fun SavingThrowCard(
                 text = savingThrow.toSignedString(),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
-                color = if (isProficient) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                color = if (isProficient) MaterialTheme.colorScheme.primary else Color.Unspecified,
             )
             Text(
                 text = label,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCell.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCell.kt
@@ -33,7 +33,7 @@ internal fun StatCell(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(PaddingValues(vertical = spacingMedium)),
+                .padding(PaddingValues(all = spacingMedium)),
         ) {
             Text(
                 text = label,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCell.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCell.kt
@@ -1,0 +1,63 @@
+package com.cyrillrx.rpg.character.presentation.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+
+/**
+ * Reusable stat cell used by ability, saving throw and combat sections: an [ElevatedCard] showing a
+ * bold [value] under a muted [label], with an optional [caption] line and an optional click action.
+ */
+@Composable
+internal fun StatCell(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    valueColor: Color = Color.Unspecified,
+    caption: String? = null,
+    onClick: (() -> Unit)? = null,
+) {
+    val cardContent: @Composable ColumnScope.() -> Unit = {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(PaddingValues(vertical = spacingMedium)),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = valueColor,
+            )
+            if (caption != null) {
+                Text(
+                    text = caption,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+    if (onClick == null) {
+        ElevatedCard(modifier = modifier, content = cardContent)
+    } else {
+        ElevatedCard(onClick = onClick, modifier = modifier, content = cardContent)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCell.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCell.kt
@@ -2,7 +2,6 @@ package com.cyrillrx.rpg.character.presentation.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ElevatedCard
@@ -33,7 +32,7 @@ internal fun StatCell(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(PaddingValues(all = spacingMedium)),
+                .padding(spacingMedium),
         ) {
             Text(
                 text = label,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCellGrid.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCellGrid.kt
@@ -1,0 +1,30 @@
+package com.cyrillrx.rpg.character.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+
+/**
+ * Lays out [cells] in a grid of [columns] equally-weighted columns, spaced by [spacingMedium].
+ * Each cell receives the [Modifier] carrying its column weight.
+ */
+@Composable
+internal fun StatCellGrid(
+    cells: List<@Composable (Modifier) -> Unit>,
+    columns: Int = 3,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(spacingMedium)) {
+        cells.chunked(columns).forEach { rowCells ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                rowCells.forEach { cell -> cell(Modifier.weight(1f)) }
+            }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCellGrid.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/StatCellGrid.kt
@@ -14,8 +14,8 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
  */
 @Composable
 internal fun StatCellGrid(
+    columns: Int,
     cells: List<@Composable (Modifier) -> Unit>,
-    columns: Int = 3,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(spacingMedium)) {
         cells.chunked(columns).forEach { rowCells ->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
@@ -145,7 +145,8 @@ class CharacterEditViewModel(
         if (coerced != ability.value) coercedValueEvent.tryEmit(CoercedValue.Numeric(ability.value, coerced))
         val coercedAbility = ability.copy(value = coerced)
         updateAndSave {
-            copy(character = character.copy(abilities = character.abilities.update(coercedAbility)), editingField = null)
+            val updatedCharacter = character.copy(abilities = character.abilities.update(coercedAbility))
+            copy(character = updatedCharacter, editingField = null)
         }
     }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModelTest.kt
@@ -439,7 +439,7 @@ class CharacterEditViewModelTest {
     @Test
     fun `saveShortDescription with blank input results in empty translations`() = runTest(testDispatcher) {
         val repo = RamCharacterRepository()
-        repo.save(fighter.copy(translations = mapOf(otherLocale to Character.Translation(shortDescription = "Héros"))))
+        repo.save(fighter.copy(translations = mapOf(otherLocale to Character.Translation(shortDescription = "Hero"))))
         val viewModel = buildViewModel(repo = repo)
         advanceUntilIdle()
         viewModel.saveShortDescription("  ")
@@ -450,7 +450,7 @@ class CharacterEditViewModelTest {
     @Test
     fun `saveShortDescription removes other locale translation when it becomes empty`() = runTest(testDispatcher) {
         val repo = RamCharacterRepository()
-        repo.save(fighter.copy(translations = mapOf(otherLocale to Character.Translation(shortDescription = "Héros"))))
+        repo.save(fighter.copy(translations = mapOf(otherLocale to Character.Translation(shortDescription = "Hero"))))
         val viewModel = buildViewModel(repo = repo)
         advanceUntilIdle()
         viewModel.saveShortDescription("Hero")
@@ -459,11 +459,15 @@ class CharacterEditViewModelTest {
     }
 
     @Test
-    fun `saveShortDescription preserves other translation fields when clearing short description`() = runTest(testDispatcher) {
+    fun `saveShortDescription preserves other translation fields when clearing short description`() = runTest(
+        testDispatcher,
+    ) {
         val repo = RamCharacterRepository()
         repo.save(
             fighter.copy(
-                translations = mapOf(otherLocale to Character.Translation(shortDescription = "Héros", description = "Un brave guerrier")),
+                translations = mapOf(
+                    otherLocale to Character.Translation(shortDescription = "Hero", description = "A brave warrior"),
+                ),
             ),
         )
         val viewModel = buildViewModel(repo = repo)
@@ -471,7 +475,7 @@ class CharacterEditViewModelTest {
         viewModel.saveShortDescription("Hero")
         val loaded = assertIs<CharacterEditState.Loaded>(viewModel.state.value)
         assertEquals("", loaded.character.translations[otherLocale]?.shortDescription)
-        assertEquals("Un brave guerrier", loaded.character.translations[otherLocale]?.description)
+        assertEquals("A brave warrior", loaded.character.translations[otherLocale]?.description)
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SampleCharacterRepository.kt
@@ -8,6 +8,7 @@ import com.cyrillrx.rpg.character.domain.applyFilter
 import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Ability
 import com.cyrillrx.rpg.creature.domain.Creature
+import com.cyrillrx.rpg.creature.domain.Proficiency
 import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
 
@@ -42,9 +43,9 @@ class SampleCharacterRepository : CharacterRepository {
                 alignment = Creature.Alignment.LAWFUL_GOOD,
                 abilities =
                     Abilities(
-                        strength = Ability(16),
+                        strength = Ability(16, Proficiency.PROFICIENT),
                         dexterity = Ability(12),
-                        constitution = Ability(14),
+                        constitution = Ability(14, Proficiency.PROFICIENT),
                         intelligence = Ability(10),
                         wisdom = Ability(10),
                         charisma = Ability(8),

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/Ability.kt
@@ -12,6 +12,12 @@ data class Ability(
 
     fun getValueWithModifier(): String = "$value (${getModifier().toSignedString()})"
 
+    fun getSavingThrow(proficiencyBonus: Int): Int = getModifier() + when (savingThrowProficiency) {
+        Proficiency.NONE -> 0
+        Proficiency.PROFICIENT -> proficiencyBonus
+        Proficiency.EXPERT -> proficiencyBonus * 2
+    }
+
     companion object {
         const val DEFAULT_VALUE = 10
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/AbilityTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/creature/domain/AbilityTest.kt
@@ -27,4 +27,16 @@ class AbilityTest {
         assertEquals("10 (+0)", Ability(10).getValueWithModifier())
         assertEquals("8 (-1)", Ability(8).getValueWithModifier())
     }
+
+    @Test
+    fun `getSavingThrow adds proficiency bonus per proficiency level`() {
+        assertEquals(2, Ability(14, Proficiency.NONE).getSavingThrow(3))
+        assertEquals(5, Ability(14, Proficiency.PROFICIENT).getSavingThrow(3))
+        assertEquals(8, Ability(14, Proficiency.EXPERT).getSavingThrow(3))
+    }
+
+    @Test
+    fun `getSavingThrow keeps negative modifier when not proficient`() {
+        assertEquals(-1, Ability(8, Proficiency.NONE).getSavingThrow(3))
+    }
 }


### PR DESCRIPTION
## 📝 Description

Adds a read-only saving throws section to the character detail screen, displayed between the abilities grid and the combat section.

Each saving throw is computed from the linked ability modifier plus the proficiency bonus when applicable:
- `savingThrow = ability.getModifier() + when(proficiency) { NONE→0, PROFICIENT→profBonus, EXPERT→profBonus*2 }`

Proficient saving throws are highlighted in primary color. Proficiency is set via the ability edit dialog (PR #131).

Along the way, the ability, saving throw and combat cards now share two extracted components:
- `StatCell` — the card itself (bold value under a muted label, with an optional caption line and optional click action). Cards display the label on top of the value, which unifies the layout across all three sections.
- `StatCellGrid` — lays cells out in an equally-weighted grid, reused by the abilities and saving throws sections.

## 🖼️ Media

<img width="540" height="240" alt="image" src="https://github.com/user-attachments/assets/3c4bd5a0-c315-4e09-a75c-b224f3186f37" />

## ✅ Checklist

- [x] Code follows the conventions in \`AGENTS.md\` and \`docs/conventions/\`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed