### PR TITLE
fix(ios): fix iOS compilation error with KMP-safe string interpolation

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -50,6 +50,7 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.creature.domain.Ability
 import com.cyrillrx.rpg.creature.domain.Creature
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -67,7 +68,6 @@ fun CharacterDetailScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val coercedMessage = stringResource(Res.string.info_value_coerced)
     val distanceUnit by rememberUpdatedState(LocalDistanceUnit.current)
     LaunchedEffect(viewModel) {
         viewModel.coercedValueEvent.collect { event ->
@@ -77,7 +77,7 @@ fun CharacterDetailScreen(
                     event.originalFeet.toDistanceString(distanceUnit) to
                         event.coercedFeet.toDistanceString(distanceUnit)
             }
-            snackbarHostState.showSnackbar(coercedMessage.format(from, to))
+            snackbarHostState.showSnackbar(getString(Res.string.info_value_coerced, from, to))
         }
     }
     when (val s = state) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -77,7 +77,8 @@ fun CharacterDetailScreen(
                     event.originalFeet.toDistanceString(distanceUnit) to
                         event.coercedFeet.toDistanceString(distanceUnit)
             }
-            snackbarHostState.showSnackbar(getString(Res.string.info_value_coerced, from, to))
+            val message = getString(Res.string.info_value_coerced, from, to)
+            snackbarHostState.showSnackbar(message)
         }
     }
     when (val s = state) {


### PR DESCRIPTION
## 📝 Description

`String.format()` is a JVM-only Java interop method. On iOS (Kotlin/Native) it fails to resolve with `Unresolved reference 'format'`, breaking compilation.

This PR fixes the iOS compilation error by replacing the JVM-only `String.format()` with the KMP-safe `getString()` from Compose resources, which supports positional format arguments on all targets.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed