### PR TITLE
feat(character): organize the character sheet into tabs

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -35,6 +35,7 @@
     <string name="label_saving_throws">Jets de sauvegarde</string>
     <string name="label_saving_throw_proficiency">Maîtrise de sauvegarde</string>
     <string name="label_skills">Compétences</string>
+    <string name="label_aptitudes">Aptitudes</string>
     <string name="label_profile">Profil</string>
     <string name="hint_ability">Min %1$d · Max %2$d · Score initial %3$s</string>
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_character.xml
@@ -35,6 +35,7 @@
     <string name="label_saving_throws">Jets de sauvegarde</string>
     <string name="label_saving_throw_proficiency">Maîtrise de sauvegarde</string>
     <string name="label_skills">Compétences</string>
+    <string name="label_profile">Profil</string>
     <string name="hint_ability">Min %1$d · Max %2$d · Score initial %3$s</string>
 
     <!-- Skills -->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -35,6 +35,7 @@
     <string name="label_saving_throws">Saving Throws</string>
     <string name="label_saving_throw_proficiency">Saving throw proficiency</string>
     <string name="label_skills">Skills</string>
+    <string name="label_aptitudes">Aptitudes</string>
     <string name="label_profile">Profile</string>
     <string name="hint_ability">Min %1$d · Max %2$d · Initial score %3$s</string>
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_character.xml
@@ -35,6 +35,7 @@
     <string name="label_saving_throws">Saving Throws</string>
     <string name="label_saving_throw_proficiency">Saving throw proficiency</string>
     <string name="label_skills">Skills</string>
+    <string name="label_profile">Profile</string>
     <string name="hint_ability">Min %1$d · Max %2$d · Initial score %3$s</string>
 
     <!-- Skills -->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,11 +21,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
@@ -59,6 +59,7 @@ import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.creature.domain.AbilityScore
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.Skills
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -216,39 +217,45 @@ fun CharacterDetailScreen(
                 )
             }
 
-            var selectedTab by rememberSaveable { mutableStateOf(0) }
-            PrimaryTabRow(selectedTabIndex = selectedTab) {
+            val pagerState = rememberPagerState(pageCount = { 3 })
+            val coroutineScope = rememberCoroutineScope()
+            PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
                 Tab(
-                    selected = selectedTab == 0,
-                    onClick = { selectedTab = 0 },
+                    selected = pagerState.currentPage == 0,
+                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(0) } },
                     text = { Text(stringResource(Res.string.label_combat)) },
                 )
                 Tab(
-                    selected = selectedTab == 1,
-                    onClick = { selectedTab = 1 },
+                    selected = pagerState.currentPage == 1,
+                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(1) } },
                     text = { Text(stringResource(Res.string.label_skills)) },
                 )
                 Tab(
-                    selected = selectedTab == 2,
-                    onClick = { selectedTab = 2 },
+                    selected = pagerState.currentPage == 2,
+                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(2) } },
                     text = { Text(stringResource(Res.string.label_profile)) },
                 )
             }
 
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState())
-                    .padding(spacingCommon),
-                verticalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
-                when (selectedTab) {
-                    0 -> CombatTabContent(state, onFieldTapped)
-                    1 -> SkillsTabContent(state, onFieldTapped)
-                    else -> ProfileTabContent(state, onFieldTapped)
-                }
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.weight(1f),
+            ) { page ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(spacingCommon),
+                    verticalArrangement = Arrangement.spacedBy(spacingMedium),
+                ) {
+                    when (page) {
+                        0 -> CombatTabContent(state, onFieldTapped)
+                        1 -> SkillsTabContent(state, onFieldTapped)
+                        else -> ProfileTabContent(state, onFieldTapped)
+                    }
 
-                Spacer(Modifier.height(spacingCommon))
+                    Spacer(Modifier.height(spacingCommon))
+                }
             }
         }
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -2,16 +2,24 @@ package com.cyrillrx.rpg.character.presentation.component
 
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -21,11 +29,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.app.currentLocale
@@ -50,12 +68,12 @@ import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterEditViewModel
 import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
-import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.dnd.toDistanceString
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.topAppBarHeight
 import com.cyrillrx.rpg.creature.domain.AbilityScore
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.Skills
@@ -64,6 +82,7 @@ import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_back
 import rpg_companion.composeapp.generated.resources.character_not_found
 import rpg_companion.composeapp.generated.resources.info_value_coerced
 import rpg_companion.composeapp.generated.resources.label_abilities
@@ -72,6 +91,7 @@ import rpg_companion.composeapp.generated.resources.label_languages
 import rpg_companion.composeapp.generated.resources.label_profile
 import rpg_companion.composeapp.generated.resources.label_saving_throws
 import rpg_companion.composeapp.generated.resources.label_skills
+import kotlin.math.roundToInt
 
 @Composable
 fun CharacterDetailScreen(
@@ -164,13 +184,32 @@ fun CharacterDetailScreen(
 ) {
     val locale = currentLocale()
     val shortDescription = state.character.resolveTranslation(locale)?.shortDescription.orEmpty()
+    val pagerState = rememberPagerState(pageCount = { 3 })
+    val coroutineScope = rememberCoroutineScope()
+
+    // Collapsing header state, driven by the nested scroll of the pager content.
+    var expandableHeightPx by remember { mutableStateOf(0) }
+    var collapse by remember { mutableStateOf(0f) }
+    val collapsedFraction = if (expandableHeightPx == 0) 0f else collapse / expandableHeightPx
+    val collapseConnection = remember {
+        object : NestedScrollConnection {
+            private fun consume(deltaY: Float): Offset {
+                val previous = collapse
+                collapse = (collapse - deltaY).coerceIn(0f, expandableHeightPx.toFloat())
+                return Offset(0f, -(collapse - previous))
+            }
+
+            // Collapse first when scrolling up.
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset =
+                if (available.y < 0f) consume(available.y) else Offset.Zero
+
+            // Re-expand only once the content has reached its top.
+            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset =
+                if (available.y > 0f) consume(available.y) else Offset.Zero
+        }
+    }
+
     Scaffold(
-        topBar = {
-            SimpleTopBar(
-                title = "",
-                onNavigateUpClicked = onNavigateUpClicked,
-            )
-        },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         val focusManager = LocalFocusManager.current
@@ -178,57 +217,77 @@ fun CharacterDetailScreen(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
-                .pointerInput(focusManager) { detectTapGestures(onTap = { focusManager.clearFocus() }) },
+                .pointerInput(focusManager) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
+                .nestedScroll(collapseConnection),
         ) {
-            // Persistent zone: identity header + abilities stay visible on every tab.
-            Column(
+            // Pinned compact bar: back button, plus the name fading in once collapsed.
+            Row(
                 modifier = Modifier
-                    .padding(horizontal = spacingCommon)
-                    .padding(top = spacingCommon),
-                verticalArrangement = Arrangement.spacedBy(spacingMedium),
+                    .fillMaxWidth()
+                    .height(topAppBarHeight),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                CharacterHeader(
-                    name = state.character.name,
-                    shortDescription = shortDescription,
-                    race = state.character.race,
-                    clazz = state.character.clazz,
-                    level = state.character.level,
-                    background = state.character.background.toFormattedString(),
-                    alignment = state.character.alignment,
-                    onNameConfirmed = onNameConfirmed,
-                    onShortDescriptionTapped = onShortDescriptionTapped,
-                    onClassTapped = { onFieldTapped(EditingField.Clazz) },
-                    onRaceTapped = { onFieldTapped(EditingField.Race) },
-                    onLevelTapped = { onFieldTapped(EditingField.Level) },
-                    onBackgroundTapped = { onFieldTapped(EditingField.Background) },
-                    onAlignmentTapped = { onFieldTapped(EditingField.Alignment) },
-                )
-
-                SheetDivider(stringResource(Res.string.label_abilities))
-
-                AbilitySection(
-                    abilities = state.character.abilities,
-                    onStrengthTapped = { onFieldTapped(EditingField.Strength) },
-                    onDexterityTapped = { onFieldTapped(EditingField.Dexterity) },
-                    onConstitutionTapped = { onFieldTapped(EditingField.Constitution) },
-                    onIntelligenceTapped = { onFieldTapped(EditingField.Intelligence) },
-                    onWisdomTapped = { onFieldTapped(EditingField.Wisdom) },
-                    onCharismaTapped = { onFieldTapped(EditingField.Charisma) },
+                IconButton(onClick = onNavigateUpClicked) {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = stringResource(Res.string.btn_back),
+                    )
+                }
+                Text(
+                    text = state.character.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.alpha(collapsedFraction),
                 )
             }
 
-            val pagerState = rememberPagerState(pageCount = { 3 })
-            val coroutineScope = rememberCoroutineScope()
+            // Rich identity header; its measured height shrinks with `collapse`.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clipToBounds()
+                    .layout { measurable, constraints ->
+                        val placeable = measurable.measure(constraints)
+                        expandableHeightPx = placeable.height
+                        val collapsePx = collapse.roundToInt().coerceIn(0, placeable.height)
+                        layout(placeable.width, placeable.height - collapsePx) {
+                            placeable.place(0, -collapsePx)
+                        }
+                    },
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = spacingCommon)
+                        .padding(bottom = spacingMedium),
+                ) {
+                    CharacterHeader(
+                        name = state.character.name,
+                        shortDescription = shortDescription,
+                        race = state.character.race,
+                        clazz = state.character.clazz,
+                        level = state.character.level,
+                        background = state.character.background.toFormattedString(),
+                        alignment = state.character.alignment,
+                        onNameConfirmed = onNameConfirmed,
+                        onShortDescriptionTapped = onShortDescriptionTapped,
+                        onClassTapped = { onFieldTapped(EditingField.Clazz) },
+                        onRaceTapped = { onFieldTapped(EditingField.Race) },
+                        onLevelTapped = { onFieldTapped(EditingField.Level) },
+                        onBackgroundTapped = { onFieldTapped(EditingField.Background) },
+                        onAlignmentTapped = { onFieldTapped(EditingField.Alignment) },
+                    )
+                }
+            }
+
             PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
                 Tab(
                     selected = pagerState.currentPage == 0,
                     onClick = { coroutineScope.launch { pagerState.animateScrollToPage(0) } },
-                    text = { Text(stringResource(Res.string.label_combat)) },
+                    text = { Text(stringResource(Res.string.label_abilities)) },
                 )
                 Tab(
                     selected = pagerState.currentPage == 1,
                     onClick = { coroutineScope.launch { pagerState.animateScrollToPage(1) } },
-                    text = { Text(stringResource(Res.string.label_skills)) },
+                    text = { Text(stringResource(Res.string.label_combat)) },
                 )
                 Tab(
                     selected = pagerState.currentPage == 2,
@@ -249,8 +308,8 @@ fun CharacterDetailScreen(
                     verticalArrangement = Arrangement.spacedBy(spacingMedium),
                 ) {
                     when (page) {
-                        0 -> CombatTabContent(state, onFieldTapped)
-                        1 -> SkillsTabContent(state, onFieldTapped)
+                        0 -> AbilitiesTabContent(state, onFieldTapped)
+                        1 -> CombatTabContent(state, onFieldTapped)
                         else -> ProfileTabContent(state, onFieldTapped)
                     }
 
@@ -306,10 +365,22 @@ private fun CombatTabContent(
 }
 
 @Composable
-private fun SkillsTabContent(
+private fun AbilitiesTabContent(
     state: CharacterEditState.Loaded,
     onFieldTapped: (EditingField) -> Unit,
 ) {
+    SheetDivider(stringResource(Res.string.label_abilities))
+
+    AbilitySection(
+        abilities = state.character.abilities,
+        onStrengthTapped = { onFieldTapped(EditingField.Strength) },
+        onDexterityTapped = { onFieldTapped(EditingField.Dexterity) },
+        onConstitutionTapped = { onFieldTapped(EditingField.Constitution) },
+        onIntelligenceTapped = { onFieldTapped(EditingField.Intelligence) },
+        onWisdomTapped = { onFieldTapped(EditingField.Wisdom) },
+        onCharismaTapped = { onFieldTapped(EditingField.Charisma) },
+    )
+
     SheetDivider(stringResource(Res.string.label_saving_throws))
 
     SavingThrowsSection(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -9,14 +9,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
@@ -61,6 +68,7 @@ import rpg_companion.composeapp.generated.resources.info_value_coerced
 import rpg_companion.composeapp.generated.resources.label_abilities
 import rpg_companion.composeapp.generated.resources.label_combat
 import rpg_companion.composeapp.generated.resources.label_languages
+import rpg_companion.composeapp.generated.resources.label_profile
 import rpg_companion.composeapp.generated.resources.label_saving_throws
 import rpg_companion.composeapp.generated.resources.label_skills
 
@@ -125,6 +133,7 @@ fun CharacterDetailScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CharacterDetailScreen(
     state: CharacterEditState.Loaded,
@@ -168,79 +177,79 @@ fun CharacterDetailScreen(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
-                .pointerInput(focusManager) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
-                .verticalScroll(rememberScrollState())
-                .padding(spacingCommon),
-            verticalArrangement = Arrangement.spacedBy(spacingMedium),
+                .pointerInput(focusManager) { detectTapGestures(onTap = { focusManager.clearFocus() }) },
         ) {
-            CharacterHeader(
-                name = state.character.name,
-                shortDescription = shortDescription,
-                race = state.character.race,
-                clazz = state.character.clazz,
-                level = state.character.level,
-                background = state.character.background.toFormattedString(),
-                alignment = state.character.alignment,
-                onNameConfirmed = onNameConfirmed,
-                onShortDescriptionTapped = onShortDescriptionTapped,
-                onClassTapped = { onFieldTapped(EditingField.Clazz) },
-                onRaceTapped = { onFieldTapped(EditingField.Race) },
-                onLevelTapped = { onFieldTapped(EditingField.Level) },
-                onBackgroundTapped = { onFieldTapped(EditingField.Background) },
-                onAlignmentTapped = { onFieldTapped(EditingField.Alignment) },
-            )
+            // Persistent zone: identity header + abilities stay visible on every tab.
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = spacingCommon)
+                    .padding(top = spacingCommon),
+                verticalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                CharacterHeader(
+                    name = state.character.name,
+                    shortDescription = shortDescription,
+                    race = state.character.race,
+                    clazz = state.character.clazz,
+                    level = state.character.level,
+                    background = state.character.background.toFormattedString(),
+                    alignment = state.character.alignment,
+                    onNameConfirmed = onNameConfirmed,
+                    onShortDescriptionTapped = onShortDescriptionTapped,
+                    onClassTapped = { onFieldTapped(EditingField.Clazz) },
+                    onRaceTapped = { onFieldTapped(EditingField.Race) },
+                    onLevelTapped = { onFieldTapped(EditingField.Level) },
+                    onBackgroundTapped = { onFieldTapped(EditingField.Background) },
+                    onAlignmentTapped = { onFieldTapped(EditingField.Alignment) },
+                )
 
-            SheetDivider(stringResource(Res.string.label_abilities))
+                SheetDivider(stringResource(Res.string.label_abilities))
 
-            AbilitySection(
-                abilities = state.character.abilities,
-                onStrengthTapped = { onFieldTapped(EditingField.Strength) },
-                onDexterityTapped = { onFieldTapped(EditingField.Dexterity) },
-                onConstitutionTapped = { onFieldTapped(EditingField.Constitution) },
-                onIntelligenceTapped = { onFieldTapped(EditingField.Intelligence) },
-                onWisdomTapped = { onFieldTapped(EditingField.Wisdom) },
-                onCharismaTapped = { onFieldTapped(EditingField.Charisma) },
-            )
+                AbilitySection(
+                    abilities = state.character.abilities,
+                    onStrengthTapped = { onFieldTapped(EditingField.Strength) },
+                    onDexterityTapped = { onFieldTapped(EditingField.Dexterity) },
+                    onConstitutionTapped = { onFieldTapped(EditingField.Constitution) },
+                    onIntelligenceTapped = { onFieldTapped(EditingField.Intelligence) },
+                    onWisdomTapped = { onFieldTapped(EditingField.Wisdom) },
+                    onCharismaTapped = { onFieldTapped(EditingField.Charisma) },
+                )
+            }
 
-            SheetDivider(stringResource(Res.string.label_saving_throws))
+            var selectedTab by rememberSaveable { mutableStateOf(0) }
+            PrimaryTabRow(selectedTabIndex = selectedTab) {
+                Tab(
+                    selected = selectedTab == 0,
+                    onClick = { selectedTab = 0 },
+                    text = { Text(stringResource(Res.string.label_combat)) },
+                )
+                Tab(
+                    selected = selectedTab == 1,
+                    onClick = { selectedTab = 1 },
+                    text = { Text(stringResource(Res.string.label_skills)) },
+                )
+                Tab(
+                    selected = selectedTab == 2,
+                    onClick = { selectedTab = 2 },
+                    text = { Text(stringResource(Res.string.label_profile)) },
+                )
+            }
 
-            SavingThrowsSection(
-                abilities = state.character.abilities,
-                proficiencyBonus = state.character.proficiencyBonus(),
-            )
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(spacingCommon),
+                verticalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                when (selectedTab) {
+                    0 -> CombatTabContent(state, onFieldTapped)
+                    1 -> SkillsTabContent(state, onFieldTapped)
+                    else -> ProfileTabContent(state, onFieldTapped)
+                }
 
-            SheetDivider(stringResource(Res.string.label_combat))
-
-            CombatRow(
-                armorClass = state.character.armorClass,
-                initiative = state.character.initiativeModifier(),
-                maxHitPoints = state.character.maxHitPoints,
-                onArmorClassTapped = { onFieldTapped(EditingField.ArmorClass) },
-                onMaxHitPointsTapped = { onFieldTapped(EditingField.MaxHitPoints) },
-            )
-
-            WalkSpeedRow(
-                walkSpeed = state.character.speeds.walk,
-                onTap = { onFieldTapped(EditingField.WalkSpeed) },
-            )
-
-            SheetDivider(stringResource(Res.string.label_skills))
-
-            SkillsSection(
-                skills = state.character.skills,
-                abilities = state.character.abilities,
-                proficiencyBonus = state.character.proficiencyBonus(),
-                onTap = { onFieldTapped(EditingField.Skills) },
-            )
-
-            SheetDivider(stringResource(Res.string.label_languages))
-
-            LanguagesRow(
-                languages = state.character.languages,
-                onTap = { onFieldTapped(EditingField.Languages) },
-            )
-
-            Spacer(Modifier.height(spacingCommon))
+                Spacer(Modifier.height(spacingCommon))
+            }
         }
     }
 
@@ -265,6 +274,62 @@ fun CharacterDetailScreen(
         onAlignmentConfirmed = onAlignmentConfirmed,
         onSkillsConfirmed = onSkillsConfirmed,
         onDismiss = onDialogDismissed,
+    )
+}
+
+// ─── Tab content ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun CombatTabContent(
+    state: CharacterEditState.Loaded,
+    onFieldTapped: (EditingField) -> Unit,
+) {
+    CombatRow(
+        armorClass = state.character.armorClass,
+        initiative = state.character.initiativeModifier(),
+        maxHitPoints = state.character.maxHitPoints,
+        onArmorClassTapped = { onFieldTapped(EditingField.ArmorClass) },
+        onMaxHitPointsTapped = { onFieldTapped(EditingField.MaxHitPoints) },
+    )
+
+    WalkSpeedRow(
+        walkSpeed = state.character.speeds.walk,
+        onTap = { onFieldTapped(EditingField.WalkSpeed) },
+    )
+}
+
+@Composable
+private fun SkillsTabContent(
+    state: CharacterEditState.Loaded,
+    onFieldTapped: (EditingField) -> Unit,
+) {
+    SheetDivider(stringResource(Res.string.label_saving_throws))
+
+    SavingThrowsSection(
+        abilities = state.character.abilities,
+        proficiencyBonus = state.character.proficiencyBonus(),
+    )
+
+    SheetDivider(stringResource(Res.string.label_skills))
+
+    SkillsSection(
+        skills = state.character.skills,
+        abilities = state.character.abilities,
+        proficiencyBonus = state.character.proficiencyBonus(),
+        onTap = { onFieldTapped(EditingField.Skills) },
+    )
+}
+
+@Composable
+private fun ProfileTabContent(
+    state: CharacterEditState.Loaded,
+    onFieldTapped: (EditingField) -> Unit,
+) {
+    SheetDivider(stringResource(Res.string.label_languages))
+
+    LanguagesRow(
+        languages = state.character.languages,
+        onTap = { onFieldTapped(EditingField.Languages) },
     )
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -2,7 +2,6 @@ package com.cyrillrx.rpg.character.presentation.component
 
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,7 +18,6 @@ import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -29,21 +27,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.app.currentLocale
@@ -91,7 +80,6 @@ import rpg_companion.composeapp.generated.resources.label_languages
 import rpg_companion.composeapp.generated.resources.label_profile
 import rpg_companion.composeapp.generated.resources.label_saving_throws
 import rpg_companion.composeapp.generated.resources.label_skills
-import kotlin.math.roundToInt
 
 @Composable
 fun CharacterDetailScreen(
@@ -187,28 +175,6 @@ fun CharacterDetailScreen(
     val pagerState = rememberPagerState(pageCount = { 3 })
     val coroutineScope = rememberCoroutineScope()
 
-    // Collapsing header state, driven by the nested scroll of the pager content.
-    var expandableHeightPx by remember { mutableStateOf(0) }
-    var collapse by remember { mutableStateOf(0f) }
-    val collapsedFraction = if (expandableHeightPx == 0) 0f else collapse / expandableHeightPx
-    val collapseConnection = remember {
-        object : NestedScrollConnection {
-            private fun consume(deltaY: Float): Offset {
-                val previous = collapse
-                collapse = (collapse - deltaY).coerceIn(0f, expandableHeightPx.toFloat())
-                return Offset(0f, -(collapse - previous))
-            }
-
-            // Collapse first when scrolling up.
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset =
-                if (available.y < 0f) consume(available.y) else Offset.Zero
-
-            // Re-expand only once the content has reached its top.
-            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset =
-                if (available.y > 0f) consume(available.y) else Offset.Zero
-        }
-    }
-
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
@@ -217,10 +183,9 @@ fun CharacterDetailScreen(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
-                .pointerInput(focusManager) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
-                .nestedScroll(collapseConnection),
+                .pointerInput(focusManager) { detectTapGestures(onTap = { focusManager.clearFocus() }) },
         ) {
-            // Pinned compact bar: back button, plus the name fading in once collapsed.
+            // Pinned compact bar: back button only (the name lives in the header below).
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -233,51 +198,33 @@ fun CharacterDetailScreen(
                         contentDescription = stringResource(Res.string.btn_back),
                     )
                 }
-                Text(
-                    text = state.character.name,
-                    style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.alpha(collapsedFraction),
+            }
+
+            // Pinned rich identity header.
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = spacingCommon)
+                    .padding(bottom = spacingMedium),
+            ) {
+                CharacterHeader(
+                    name = state.character.name,
+                    shortDescription = shortDescription,
+                    race = state.character.race,
+                    clazz = state.character.clazz,
+                    level = state.character.level,
+                    background = state.character.background.toFormattedString(),
+                    alignment = state.character.alignment,
+                    onNameConfirmed = onNameConfirmed,
+                    onShortDescriptionTapped = onShortDescriptionTapped,
+                    onClassTapped = { onFieldTapped(EditingField.Clazz) },
+                    onRaceTapped = { onFieldTapped(EditingField.Race) },
+                    onLevelTapped = { onFieldTapped(EditingField.Level) },
+                    onBackgroundTapped = { onFieldTapped(EditingField.Background) },
+                    onAlignmentTapped = { onFieldTapped(EditingField.Alignment) },
                 )
             }
 
-            // Rich identity header; its measured height shrinks with `collapse`.
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clipToBounds()
-                    .layout { measurable, constraints ->
-                        val placeable = measurable.measure(constraints)
-                        expandableHeightPx = placeable.height
-                        val collapsePx = collapse.roundToInt().coerceIn(0, placeable.height)
-                        layout(placeable.width, placeable.height - collapsePx) {
-                            placeable.place(0, -collapsePx)
-                        }
-                    },
-            ) {
-                Column(
-                    modifier = Modifier
-                        .padding(horizontal = spacingCommon)
-                        .padding(bottom = spacingMedium),
-                ) {
-                    CharacterHeader(
-                        name = state.character.name,
-                        shortDescription = shortDescription,
-                        race = state.character.race,
-                        clazz = state.character.clazz,
-                        level = state.character.level,
-                        background = state.character.background.toFormattedString(),
-                        alignment = state.character.alignment,
-                        onNameConfirmed = onNameConfirmed,
-                        onShortDescriptionTapped = onShortDescriptionTapped,
-                        onClassTapped = { onFieldTapped(EditingField.Clazz) },
-                        onRaceTapped = { onFieldTapped(EditingField.Race) },
-                        onLevelTapped = { onFieldTapped(EditingField.Level) },
-                        onBackgroundTapped = { onFieldTapped(EditingField.Background) },
-                        onAlignmentTapped = { onFieldTapped(EditingField.Alignment) },
-                    )
-                }
-            }
-
+            // Pinned tab row, kept in sync with the pager.
             PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
                 Tab(
                     selected = pagerState.currentPage == 0,
@@ -296,6 +243,7 @@ fun CharacterDetailScreen(
                 )
             }
 
+            // Only the tab content scrolls (vertically) and swipes (horizontally).
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.weight(1f),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -45,13 +45,10 @@ import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
 import com.cyrillrx.rpg.character.presentation.CoercedValue
 import com.cyrillrx.rpg.character.presentation.component.dialog.CharacterEditDialog
-import com.cyrillrx.rpg.character.presentation.component.section.AbilitySection
-import com.cyrillrx.rpg.character.presentation.component.section.CombatRow
-import com.cyrillrx.rpg.character.presentation.component.section.LanguagesRow
-import com.cyrillrx.rpg.character.presentation.component.section.SavingThrowsSection
-import com.cyrillrx.rpg.character.presentation.component.section.SheetDivider
-import com.cyrillrx.rpg.character.presentation.component.section.SkillsSection
-import com.cyrillrx.rpg.character.presentation.component.section.WalkSpeedRow
+import com.cyrillrx.rpg.character.presentation.component.tab.AptitudesTabContent
+import com.cyrillrx.rpg.character.presentation.component.tab.CharacterSheetTab
+import com.cyrillrx.rpg.character.presentation.component.tab.CombatTabContent
+import com.cyrillrx.rpg.character.presentation.component.tab.ProfileTabContent
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRouter
 import com.cyrillrx.rpg.character.presentation.viewmodel.CharacterEditViewModel
 import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
@@ -74,13 +71,6 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_back
 import rpg_companion.composeapp.generated.resources.character_not_found
 import rpg_companion.composeapp.generated.resources.info_value_coerced
-import rpg_companion.composeapp.generated.resources.label_abilities
-import rpg_companion.composeapp.generated.resources.label_aptitudes
-import rpg_companion.composeapp.generated.resources.label_combat
-import rpg_companion.composeapp.generated.resources.label_languages
-import rpg_companion.composeapp.generated.resources.label_profile
-import rpg_companion.composeapp.generated.resources.label_saving_throws
-import rpg_companion.composeapp.generated.resources.label_skills
 
 @Composable
 fun CharacterDetailScreen(
@@ -173,7 +163,7 @@ fun CharacterDetailScreen(
 ) {
     val locale = currentLocale()
     val shortDescription = state.character.resolveTranslation(locale)?.shortDescription.orEmpty()
-    val pagerState = rememberPagerState(pageCount = { 3 })
+    val pagerState = rememberPagerState(pageCount = { CharacterSheetTab.entries.size })
     val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
@@ -227,21 +217,13 @@ fun CharacterDetailScreen(
 
             // Pinned tab row, kept in sync with the pager.
             PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
-                Tab(
-                    selected = pagerState.currentPage == 0,
-                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(0) } },
-                    text = { Text(stringResource(Res.string.label_aptitudes)) },
-                )
-                Tab(
-                    selected = pagerState.currentPage == 1,
-                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(1) } },
-                    text = { Text(stringResource(Res.string.label_combat)) },
-                )
-                Tab(
-                    selected = pagerState.currentPage == 2,
-                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(2) } },
-                    text = { Text(stringResource(Res.string.label_profile)) },
-                )
+                CharacterSheetTab.entries.forEachIndexed { index, tab ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                        text = { Text(stringResource(tab.label)) },
+                    )
+                }
             }
 
             // Only the tab content scrolls (vertically) and swipes (horizontally).
@@ -256,10 +238,10 @@ fun CharacterDetailScreen(
                         .padding(spacingCommon),
                     verticalArrangement = Arrangement.spacedBy(spacingMedium),
                 ) {
-                    when (page) {
-                        0 -> AbilitiesTabContent(state, onFieldTapped)
-                        1 -> CombatTabContent(state, onFieldTapped)
-                        else -> ProfileTabContent(state, onFieldTapped)
+                    when (CharacterSheetTab.entries[page]) {
+                        CharacterSheetTab.APTITUDES -> AptitudesTabContent(state, onFieldTapped)
+                        CharacterSheetTab.COMBAT -> CombatTabContent(state, onFieldTapped)
+                        CharacterSheetTab.PROFILE -> ProfileTabContent(state, onFieldTapped)
                     }
 
                     Spacer(Modifier.height(spacingCommon))
@@ -289,74 +271,6 @@ fun CharacterDetailScreen(
         onAlignmentConfirmed = onAlignmentConfirmed,
         onSkillsConfirmed = onSkillsConfirmed,
         onDismiss = onDialogDismissed,
-    )
-}
-
-// ─── Tab content ─────────────────────────────────────────────────────────────
-
-@Composable
-private fun CombatTabContent(
-    state: CharacterEditState.Loaded,
-    onFieldTapped: (EditingField) -> Unit,
-) {
-    CombatRow(
-        armorClass = state.character.armorClass,
-        initiative = state.character.initiativeModifier(),
-        maxHitPoints = state.character.maxHitPoints,
-        onArmorClassTapped = { onFieldTapped(EditingField.ArmorClass) },
-        onMaxHitPointsTapped = { onFieldTapped(EditingField.MaxHitPoints) },
-    )
-
-    WalkSpeedRow(
-        walkSpeed = state.character.speeds.walk,
-        onTap = { onFieldTapped(EditingField.WalkSpeed) },
-    )
-}
-
-@Composable
-private fun AbilitiesTabContent(
-    state: CharacterEditState.Loaded,
-    onFieldTapped: (EditingField) -> Unit,
-) {
-    SheetDivider(stringResource(Res.string.label_abilities))
-
-    AbilitySection(
-        abilities = state.character.abilities,
-        onStrengthTapped = { onFieldTapped(EditingField.Strength) },
-        onDexterityTapped = { onFieldTapped(EditingField.Dexterity) },
-        onConstitutionTapped = { onFieldTapped(EditingField.Constitution) },
-        onIntelligenceTapped = { onFieldTapped(EditingField.Intelligence) },
-        onWisdomTapped = { onFieldTapped(EditingField.Wisdom) },
-        onCharismaTapped = { onFieldTapped(EditingField.Charisma) },
-    )
-
-    SheetDivider(stringResource(Res.string.label_saving_throws))
-
-    SavingThrowsSection(
-        abilities = state.character.abilities,
-        proficiencyBonus = state.character.proficiencyBonus(),
-    )
-
-    SheetDivider(stringResource(Res.string.label_skills))
-
-    SkillsSection(
-        skills = state.character.skills,
-        abilities = state.character.abilities,
-        proficiencyBonus = state.character.proficiencyBonus(),
-        onTap = { onFieldTapped(EditingField.Skills) },
-    )
-}
-
-@Composable
-private fun ProfileTabContent(
-    state: CharacterEditState.Loaded,
-    onFieldTapped: (EditingField) -> Unit,
-) {
-    SheetDivider(stringResource(Res.string.label_languages))
-
-    LanguagesRow(
-        languages = state.character.languages,
-        onTap = { onFieldTapped(EditingField.Languages) },
     )
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterDetailScreen.kt
@@ -75,6 +75,7 @@ import rpg_companion.composeapp.generated.resources.btn_back
 import rpg_companion.composeapp.generated.resources.character_not_found
 import rpg_companion.composeapp.generated.resources.info_value_coerced
 import rpg_companion.composeapp.generated.resources.label_abilities
+import rpg_companion.composeapp.generated.resources.label_aptitudes
 import rpg_companion.composeapp.generated.resources.label_combat
 import rpg_companion.composeapp.generated.resources.label_languages
 import rpg_companion.composeapp.generated.resources.label_profile
@@ -229,7 +230,7 @@ fun CharacterDetailScreen(
                 Tab(
                     selected = pagerState.currentPage == 0,
                     onClick = { coroutineScope.launch { pagerState.animateScrollToPage(0) } },
-                    text = { Text(stringResource(Res.string.label_abilities)) },
+                    text = { Text(stringResource(Res.string.label_aptitudes)) },
                 )
                 Tab(
                     selected = pagerState.currentPage == 1,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/AptitudesTabContent.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/AptitudesTabContent.kt
@@ -1,0 +1,48 @@
+package com.cyrillrx.rpg.character.presentation.component.tab
+
+import androidx.compose.runtime.Composable
+import com.cyrillrx.rpg.character.presentation.CharacterEditState
+import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
+import com.cyrillrx.rpg.character.presentation.component.section.AbilitySection
+import com.cyrillrx.rpg.character.presentation.component.section.SavingThrowsSection
+import com.cyrillrx.rpg.character.presentation.component.section.SheetDivider
+import com.cyrillrx.rpg.character.presentation.component.section.SkillsSection
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.label_abilities
+import rpg_companion.composeapp.generated.resources.label_saving_throws
+import rpg_companion.composeapp.generated.resources.label_skills
+
+@Composable
+internal fun AptitudesTabContent(
+    state: CharacterEditState.Loaded,
+    onFieldTapped: (EditingField) -> Unit,
+) {
+    SheetDivider(stringResource(Res.string.label_abilities))
+
+    AbilitySection(
+        abilities = state.character.abilities,
+        onStrengthTapped = { onFieldTapped(EditingField.Strength) },
+        onDexterityTapped = { onFieldTapped(EditingField.Dexterity) },
+        onConstitutionTapped = { onFieldTapped(EditingField.Constitution) },
+        onIntelligenceTapped = { onFieldTapped(EditingField.Intelligence) },
+        onWisdomTapped = { onFieldTapped(EditingField.Wisdom) },
+        onCharismaTapped = { onFieldTapped(EditingField.Charisma) },
+    )
+
+    SheetDivider(stringResource(Res.string.label_saving_throws))
+
+    SavingThrowsSection(
+        abilities = state.character.abilities,
+        proficiencyBonus = state.character.proficiencyBonus(),
+    )
+
+    SheetDivider(stringResource(Res.string.label_skills))
+
+    SkillsSection(
+        skills = state.character.skills,
+        abilities = state.character.abilities,
+        proficiencyBonus = state.character.proficiencyBonus(),
+        onTap = { onFieldTapped(EditingField.Skills) },
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/CharacterSheetTab.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/CharacterSheetTab.kt
@@ -1,0 +1,13 @@
+package com.cyrillrx.rpg.character.presentation.component.tab
+
+import org.jetbrains.compose.resources.StringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.label_aptitudes
+import rpg_companion.composeapp.generated.resources.label_combat
+import rpg_companion.composeapp.generated.resources.label_profile
+
+internal enum class CharacterSheetTab(val label: StringResource) {
+    APTITUDES(Res.string.label_aptitudes),
+    COMBAT(Res.string.label_combat),
+    PROFILE(Res.string.label_profile),
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/CombatTabContent.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/CombatTabContent.kt
@@ -4,13 +4,19 @@ import androidx.compose.runtime.Composable
 import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
 import com.cyrillrx.rpg.character.presentation.component.section.CombatRow
+import com.cyrillrx.rpg.character.presentation.component.section.SheetDivider
 import com.cyrillrx.rpg.character.presentation.component.section.WalkSpeedRow
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.label_combat
 
 @Composable
 internal fun CombatTabContent(
     state: CharacterEditState.Loaded,
     onFieldTapped: (EditingField) -> Unit,
 ) {
+    SheetDivider(stringResource(Res.string.label_combat))
+
     CombatRow(
         armorClass = state.character.armorClass,
         initiative = state.character.initiativeModifier(),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/CombatTabContent.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/CombatTabContent.kt
@@ -1,0 +1,26 @@
+package com.cyrillrx.rpg.character.presentation.component.tab
+
+import androidx.compose.runtime.Composable
+import com.cyrillrx.rpg.character.presentation.CharacterEditState
+import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
+import com.cyrillrx.rpg.character.presentation.component.section.CombatRow
+import com.cyrillrx.rpg.character.presentation.component.section.WalkSpeedRow
+
+@Composable
+internal fun CombatTabContent(
+    state: CharacterEditState.Loaded,
+    onFieldTapped: (EditingField) -> Unit,
+) {
+    CombatRow(
+        armorClass = state.character.armorClass,
+        initiative = state.character.initiativeModifier(),
+        maxHitPoints = state.character.maxHitPoints,
+        onArmorClassTapped = { onFieldTapped(EditingField.ArmorClass) },
+        onMaxHitPointsTapped = { onFieldTapped(EditingField.MaxHitPoints) },
+    )
+
+    WalkSpeedRow(
+        walkSpeed = state.character.speeds.walk,
+        onTap = { onFieldTapped(EditingField.WalkSpeed) },
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/ProfileTabContent.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/tab/ProfileTabContent.kt
@@ -1,0 +1,23 @@
+package com.cyrillrx.rpg.character.presentation.component.tab
+
+import androidx.compose.runtime.Composable
+import com.cyrillrx.rpg.character.presentation.CharacterEditState
+import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
+import com.cyrillrx.rpg.character.presentation.component.section.LanguagesRow
+import com.cyrillrx.rpg.character.presentation.component.section.SheetDivider
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.label_languages
+
+@Composable
+internal fun ProfileTabContent(
+    state: CharacterEditState.Loaded,
+    onFieldTapped: (EditingField) -> Unit,
+) {
+    SheetDivider(stringResource(Res.string.label_languages))
+
+    LanguagesRow(
+        languages = state.character.languages,
+        onTap = { onFieldTapped(EditingField.Languages) },
+    )
+}


### PR DESCRIPTION
## 📝 Description

Reorganize the character sheet into tabs (reorganization of existing content only — no new features).

The sheet previously stacked every section in a single vertical scroll. It is now split into three tabs, with a fixed top area above them:

- **Pinned top**: a compact back bar + the rich identity header (`CharacterHeader`) + the tab row.
- **Aptitudes** tab: abilities, saving throws and skills.
- **Combat** tab: armor class, hit points, initiative and walk speed.
- **Profile** tab: languages (long description and other content will come later).

Each tab groups its content under section dividers (`SheetDivider`) for consistency.

Only the selected tab's content scrolls vertically and can be swiped horizontally (`HorizontalPager`); the header and tab row stay pinned. Navigation also works by tapping a tab.

No changes to the domain, state, ViewModel or edit dialogs — the existing tap-to-edit callbacks are simply wired from the new locations. Two new string resources were added: `label_profile` and `label_aptitudes` (EN/FR).

## 🖼️ Media

<img width="688" height="1444" alt="image" src="https://github.com/user-attachments/assets/bc55bbc6-2e6b-47e8-b925-54dbd65d4b61" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
