### PR TITLE
feat(home): make home screen responsive for tablet and landscape

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Dimen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Dimen.kt
@@ -18,3 +18,8 @@ val iconSizeLarge = 44.dp
 val iconButtonSize = 56.dp
 val avatarSize = 72.dp
 val avatarBorderWidth = 2.dp
+
+// Responsive layout breakpoints
+val widthExpandedMin = 840.dp
+val contentMaxWidth = 840.dp
+val iconCardMaxHeight = 120.dp

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeButton.kt
@@ -1,23 +1,18 @@
 package com.cyrillrx.rpg.home.presentation
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
-import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun HomeButton(text: String, onClick: () -> Unit) {
+fun HomeButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Button(
         onClick = onClick,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(PaddingValues(spacingMedium)),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Text(text = text)
     }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -1,11 +1,15 @@
 package com.cyrillrx.rpg.home.presentation
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Diamond
@@ -20,9 +24,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.contentMaxWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.widthExpandedMin
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -56,75 +64,121 @@ fun HomeScreen(router: HomeRouter) {
             )
         },
     ) { paddingValues ->
-        Column(
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
-            HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
-            HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheetList)
+            val contentModifier = Modifier
+                .align(Alignment.TopCenter)
+                .widthIn(max = contentMaxWidth)
+                .fillMaxWidth()
 
-            SectionHeader(
-                title = stringResource(Res.string.section_compendium),
-                modifier = Modifier.padding(spacingCommon),
-            )
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(spacingCommon),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = spacingCommon),
-            ) {
-                IconLabelButton(
-                    label = stringResource(Res.string.btn_spell_book),
-                    icon = Icons.Filled.AutoAwesome,
-                    onClick = router::openSpellCompendium,
-                    modifier = Modifier.weight(1f),
-                )
-                IconLabelButton(
-                    label = stringResource(Res.string.btn_magical_items),
-                    icon = Icons.Filled.Diamond,
-                    onClick = router::openMagicalItemCompendium,
-                    modifier = Modifier.weight(1f),
-                )
-                IconLabelButton(
-                    label = stringResource(Res.string.btn_bestiary),
-                    icon = Icons.Filled.Pets,
-                    onClick = router::openMonsterCompendium,
-                    modifier = Modifier.weight(1f),
-                )
+            if (maxWidth >= widthExpandedMin) {
+                HomeWideScreen(router, contentModifier)
+            } else {
+                HomeDefault(router, contentModifier)
             }
+        }
+    }
+}
 
-            SectionHeader(
-                title = stringResource(Res.string.section_my_lists),
-                modifier = Modifier.padding(spacingCommon),
+/** Single-column layout for phones and narrow tablets. */
+@Composable
+private fun HomeDefault(router: HomeRouter, modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = spacingCommon, vertical = spacingMedium),
+    ) {
+        HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
+        HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheetList)
+        CompendiumSection(router, modifier = Modifier.fillMaxWidth())
+        MyListsSection(router, modifier = Modifier.fillMaxWidth())
+    }
+}
+
+/** Two-pane layout for large landscape screens. */
+@Composable
+private fun HomeWideScreen(router: HomeRouter, modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = spacingCommon, vertical = spacingMedium),
+    ) {
+        HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
+        HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheetList)
+        Row(horizontalArrangement = Arrangement.spacedBy(spacingCommon)) {
+            CompendiumSection(router, modifier = Modifier.weight(1f))
+            MyListsSection(router, modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun CompendiumSection(router: HomeRouter, modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
+        modifier = modifier,
+    ) {
+        SectionHeader(title = stringResource(Res.string.section_compendium))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            IconLabelButton(
+                label = stringResource(Res.string.btn_spell_book),
+                icon = Icons.Filled.AutoAwesome,
+                onClick = router::openSpellCompendium,
+                modifier = Modifier.weight(1f),
             )
+            IconLabelButton(
+                label = stringResource(Res.string.btn_magical_items),
+                icon = Icons.Filled.Diamond,
+                onClick = router::openMagicalItemCompendium,
+                modifier = Modifier.weight(1f),
+            )
+            IconLabelButton(
+                label = stringResource(Res.string.btn_bestiary),
+                icon = Icons.Filled.Pets,
+                onClick = router::openMonsterCompendium,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(spacingCommon),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = spacingCommon),
-            ) {
-                IconLabelButton(
-                    label = stringResource(Res.string.btn_my_spell_lists),
-                    icon = Icons.Filled.AutoAwesome,
-                    onClick = router::openMySpellLists,
-                    modifier = Modifier.weight(1f),
-                )
-                IconLabelButton(
-                    label = stringResource(Res.string.btn_my_item_lists),
-                    icon = Icons.Filled.Diamond,
-                    onClick = router::openMyMagicalItemLists,
-                    modifier = Modifier.weight(1f),
-                )
-                IconLabelButton(
-                    label = stringResource(Res.string.btn_my_bestiary_lists),
-                    icon = Icons.Filled.Pets,
-                    onClick = router::openMyMonsterLists,
-                    modifier = Modifier.weight(1f),
-                )
-            }
+@Composable
+private fun MyListsSection(router: HomeRouter, modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
+        modifier = modifier,
+    ) {
+        SectionHeader(title = stringResource(Res.string.section_my_lists))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            IconLabelButton(
+                label = stringResource(Res.string.btn_my_spell_lists),
+                icon = Icons.Filled.AutoAwesome,
+                onClick = router::openMySpellLists,
+                modifier = Modifier.weight(1f),
+            )
+            IconLabelButton(
+                label = stringResource(Res.string.btn_my_item_lists),
+                icon = Icons.Filled.Diamond,
+                onClick = router::openMyMagicalItemLists,
+                modifier = Modifier.weight(1f),
+            )
+            IconLabelButton(
+                label = stringResource(Res.string.btn_my_bestiary_lists),
+                icon = Icons.Filled.Pets,
+                onClick = router::openMyMonsterLists,
+                modifier = Modifier.weight(1f),
+            )
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/IconLabelButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/IconLabelButton.kt
@@ -2,8 +2,8 @@ package com.cyrillrx.rpg.home.presentation
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.iconCardMaxHeight
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -33,7 +34,7 @@ fun IconLabelButton(
 ) {
     Card(
         onClick = onClick,
-        modifier = modifier.aspectRatio(1f),
+        modifier = modifier.height(iconCardMaxHeight),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
## 📝 Description

The home screen was a non-scrollable `Column` whose icon cards used an unbounded `aspectRatio(1f)`. In phone landscape the cards grew very tall and the content was clipped, and there was no adaptation for large screens.

This PR makes the home responsive:
- Wrap the content in a `BoxWithConstraints` + `verticalScroll`, centered and constrained to a max content width.
- Split the layout into two explicit composables: a single-column `HomeDefault` (phones / narrow tablets) and a two-pane `HomeWideScreen` (Compendium and My Lists side by side) used above the expanded width breakpoint.
- Bound the icon card height instead of forcing a square aspect ratio, so cards no longer blow up in landscape / on wide screens.
- Align every section to a single horizontal content inset (consistent paddings).

Pure presentation change — `HomeScreen` stays stateless and `shared/core` is untouched. New responsive breakpoint tokens (`widthExpandedMin`, `contentMaxWidth`, `iconCardMaxHeight`) added to `Dimen.kt`.

This is PR 1 of a series; a follow-up will add the "Character sheets" section with recent-sheet previews.

## 🖼️ Media

<img width="1796" height="1216" alt="image" src="https://github.com/user-attachments/assets/83e5ce46-70c5-47d7-88ec-30d1ca760c4c" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed