### PR TITLE
feat(home): add character sheets section to home screen

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -8,6 +8,7 @@
     <string name="btn_alternative_spell_book">Grimoire alternatif</string>
     <string name="btn_bestiary">Bestiaire</string>
     <string name="btn_magical_items">Objets magiques</string>
+    <string name="btn_see_all">Voir tout</string>
 
     <!-- Search -->
     <string name="hint_search_campaign">Oblivion, La chute de Londres, etc.</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -8,6 +8,7 @@
     <string name="btn_alternative_spell_book">Alternative Spellbook</string>
     <string name="btn_bestiary">Bestiary</string>
     <string name="btn_magical_items">Magical items</string>
+    <string name="btn_see_all">See all</string>
 
     <!-- Search -->
     <string name="hint_search_campaign">Oblivion, The fall of London, etc.</string>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/app/App.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -43,6 +44,8 @@ import com.cyrillrx.rpg.creature.presentation.navigation.handleMonsterRoutes
 import com.cyrillrx.rpg.creature.presentation.navigation.registerMonsterRoutes
 import com.cyrillrx.rpg.home.presentation.HomeScreen
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouterImpl
+import com.cyrillrx.rpg.home.presentation.viewmodel.HomeViewModel
+import com.cyrillrx.rpg.home.presentation.viewmodel.HomeViewModelFactory
 import com.cyrillrx.rpg.magicalitem.data.JsonMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouterImpl
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.handleMagicalItemRoutes
@@ -109,6 +112,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
 
             val fileReader = ComposeFileReader()
             val userListRepository = remember(dbDriverFactory) { SQLDelightUserListRepository(dbDriverFactory) }
+            val characterRepository = remember(dbDriverFactory) { SQLDelightCharacterRepository(dbDriverFactory) }
 
             NavDisplay(
                 backStack = backStack,
@@ -126,7 +130,12 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                 },
                 entryProvider = entryProvider {
                     val homeRouter = HomeRouterImpl(backStack)
-                    entry<MainRoute.Home> { HomeScreen(homeRouter) }
+                    entry<MainRoute.Home> {
+                        val viewModel = viewModel<HomeViewModel>(
+                            factory = HomeViewModelFactory(characterRepository),
+                        )
+                        HomeScreen(viewModel, homeRouter)
+                    }
 
                     handleCampaignRoutes(
                         backStack = backStack,
@@ -136,9 +145,7 @@ fun App(dbDriverFactory: DatabaseDriverFactory) {
                     )
                     handleCharacterRoutes(
                         backStack = backStack,
-                        characterRepository = remember(dbDriverFactory) {
-                            SQLDelightCharacterRepository(dbDriverFactory)
-                        },
+                        characterRepository = characterRepository,
                         pcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/pc-presets.json"),
                         npcPresetRepository = JsonCharacterPresetRepository(fileReader, "files/npc-presets.json"),
                     )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterCreateActions.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterCreateActions.kt
@@ -3,8 +3,11 @@ package com.cyrillrx.rpg.character.presentation.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -41,7 +44,7 @@ fun CharacterCreateActions(
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().height(IntrinsicSize.Max),
     ) {
         CharacterActionCard(
             icon = Icons.Filled.Add,
@@ -49,7 +52,7 @@ fun CharacterCreateActions(
             subtitle = stringResource(Res.string.btn_new_character_subtitle),
             onClick = onNewCharacterClicked,
             filled = true,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).fillMaxHeight(),
         )
         CharacterActionCard(
             icon = Icons.Filled.Bolt,
@@ -57,7 +60,7 @@ fun CharacterCreateActions(
             subtitle = stringResource(Res.string.btn_quick_create_subtitle),
             onClick = onQuickCreateClicked,
             filled = false,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).fillMaxHeight(),
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterCreateActions.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterCreateActions.kt
@@ -1,0 +1,134 @@
+package com.cyrillrx.rpg.character.presentation.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
+import com.cyrillrx.rpg.core.presentation.theme.borderWidth
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_new_character
+import rpg_companion.composeapp.generated.resources.btn_new_character_subtitle
+import rpg_companion.composeapp.generated.resources.btn_quick_create
+import rpg_companion.composeapp.generated.resources.btn_quick_create_subtitle
+
+/** The pair of "New character" / "Quick create" action cards shown above the character list. */
+@Composable
+fun CharacterCreateActions(
+    onNewCharacterClicked: () -> Unit,
+    onQuickCreateClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        CharacterActionCard(
+            icon = Icons.Filled.Add,
+            title = stringResource(Res.string.btn_new_character),
+            subtitle = stringResource(Res.string.btn_new_character_subtitle),
+            onClick = onNewCharacterClicked,
+            filled = true,
+            modifier = Modifier.weight(1f),
+        )
+        CharacterActionCard(
+            icon = Icons.Filled.Bolt,
+            title = stringResource(Res.string.btn_quick_create),
+            subtitle = stringResource(Res.string.btn_quick_create_subtitle),
+            onClick = onQuickCreateClicked,
+            filled = false,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun CharacterActionCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    filled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val containerColor = if (filled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface
+    val contentColor = if (filled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.medium,
+        border = if (filled) {
+            null
+        } else {
+            BorderStroke(
+                width = borderWidth,
+                color = MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha),
+            )
+        },
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        modifier = modifier,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(spacingSmall),
+            modifier = Modifier.padding(spacingCommon),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = contentColor,
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = contentColor,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = contentColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CharacterCreateActionsPreview() {
+    CharacterCreateActions(
+        onNewCharacterClicked = {},
+        onQuickCreateClicked = {},
+        modifier = Modifier.padding(spacingCommon),
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterCreateActionsLight() {
+    AppThemePreview(darkTheme = false) { CharacterCreateActionsPreview() }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterCreateActionsDark() {
+    AppThemePreview(darkTheme = true) { CharacterCreateActionsPreview() }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -33,7 +33,6 @@ import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
 import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
-import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -127,7 +126,7 @@ fun CharacterListScreen(
             CharacterCreateActions(
                 onNewCharacterClicked = onNewCharacterClicked,
                 onQuickCreateClicked = onQuickCreateClicked,
-                modifier = Modifier.padding(spacingCommon),
+                modifier = Modifier.padding(spacingMedium),
             )
 
             Column(modifier = Modifier.weight(1f).fillMaxWidth()) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -1,35 +1,23 @@
 package com.cyrillrx.rpg.character.presentation.component
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -45,21 +33,14 @@ import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
 import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
-import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
-import com.cyrillrx.rpg.core.presentation.theme.borderWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import org.jetbrains.compose.resources.getString
-import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_new_character
-import rpg_companion.composeapp.generated.resources.btn_new_character_subtitle
-import rpg_companion.composeapp.generated.resources.btn_quick_create
-import rpg_companion.composeapp.generated.resources.btn_quick_create_subtitle
 import rpg_companion.composeapp.generated.resources.snackbar_character_deleted
 import rpg_companion.composeapp.generated.resources.snackbar_error_deleting_character
 import rpg_companion.composeapp.generated.resources.title_character_list
@@ -143,30 +124,11 @@ fun CharacterListScreen(
                     .padding(paddingValues)
                     .fillMaxSize(),
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(spacingCommon),
-            ) {
-                CharacterActionCard(
-                    icon = Icons.Filled.Add,
-                    title = stringResource(Res.string.btn_new_character),
-                    subtitle = stringResource(Res.string.btn_new_character_subtitle),
-                    onClick = onNewCharacterClicked,
-                    filled = true,
-                    modifier = Modifier.weight(1f),
-                )
-                CharacterActionCard(
-                    icon = Icons.Filled.Bolt,
-                    title = stringResource(Res.string.btn_quick_create),
-                    subtitle = stringResource(Res.string.btn_quick_create_subtitle),
-                    onClick = onQuickCreateClicked,
-                    filled = false,
-                    modifier = Modifier.weight(1f),
-                )
-            }
+            CharacterCreateActions(
+                onNewCharacterClicked = onNewCharacterClicked,
+                onQuickCreateClicked = onQuickCreateClicked,
+                modifier = Modifier.padding(spacingCommon),
+            )
 
             Column(modifier = Modifier.weight(1f).fillMaxWidth()) {
                 when (val body = state.body) {
@@ -181,56 +143,6 @@ fun CharacterListScreen(
                         )
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun CharacterActionCard(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    onClick: () -> Unit,
-    filled: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    val containerColor = if (filled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface
-    val contentColor = if (filled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
-
-    Card(
-        onClick = onClick,
-        shape = MaterialTheme.shapes.medium,
-        border = if (filled) {
-            null
-        } else {
-            BorderStroke(
-                width = borderWidth,
-                color = MaterialTheme.colorScheme.outline.copy(alpha = borderAlpha),
-            )
-        },
-        colors = CardDefaults.cardColors(containerColor = containerColor),
-        modifier = modifier,
-    ) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(spacingSmall),
-            modifier = Modifier.padding(spacingCommon),
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = contentColor,
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold,
-                color = contentColor,
-            )
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = contentColor,
-            )
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Dimen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Dimen.kt
@@ -19,6 +19,9 @@ val iconButtonSize = 56.dp
 val avatarSize = 72.dp
 val avatarBorderWidth = 2.dp
 
+// Height shared by section headers (with or without a trailing action) so they align across panes
+val sectionHeaderHeight = 48.dp
+
 // Responsive layout breakpoints
 val widthExpandedMin = 840.dp
 val contentMaxWidth = 840.dp

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CharacterPreviewSection.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CharacterPreviewSection.kt
@@ -18,7 +18,6 @@ import com.cyrillrx.rpg.character.presentation.component.CharacterListItem
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.iconSizeLarge
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -33,7 +32,7 @@ fun CharacterPreviewSection(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
         modifier = modifier,
     ) {
         SectionHeaderWithAction(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CharacterPreviewSection.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/CharacterPreviewSection.kt
@@ -1,0 +1,97 @@
+package com.cyrillrx.rpg.home.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.presentation.component.CharacterCreateActions
+import com.cyrillrx.rpg.character.presentation.component.CharacterListItem
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.iconSizeLarge
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.home.presentation.navigation.HomeRouter
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_character_sheets
+import rpg_companion.composeapp.generated.resources.btn_see_all
+
+@Composable
+fun CharacterPreviewSection(
+    state: HomeState,
+    router: HomeRouter,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        modifier = modifier,
+    ) {
+        SectionHeaderWithAction(
+            title = stringResource(Res.string.btn_character_sheets),
+            actionLabel = stringResource(Res.string.btn_see_all),
+            onActionClick = router::openCharacterSheetList,
+        )
+
+        CharacterCreateActions(
+            onNewCharacterClicked = router::openCreateCharacter,
+            onQuickCreateClicked = router::openPresetGallery,
+        )
+
+        when (val body = state.body) {
+            is HomeState.Body.Loading ->
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxWidth().padding(spacingMedium),
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(iconSizeLarge))
+                }
+
+            is HomeState.Body.Error ->
+                Text(
+                    text = stringResource(body.errorMessage),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(vertical = spacingMedium),
+                )
+
+            is HomeState.Body.WithData ->
+                body.characters.forEach { character ->
+                    CharacterListItem(
+                        character = character,
+                        onClick = { router.openCharacterDetail(character) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+        }
+    }
+}
+
+@Composable
+private fun CharacterPreviewSectionPreview() {
+    CharacterPreviewSection(
+        state = HomeState(body = HomeState.Body.WithData(SampleCharacterRepository.getAll())),
+        router = PreviewHomeRouter,
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterPreviewSectionLight() {
+    AppThemePreview(darkTheme = false) { CharacterPreviewSectionPreview() }
+}
+
+@Preview
+@Composable
+private fun PreviewCharacterPreviewSectionDark() {
+    AppThemePreview(darkTheme = true) { CharacterPreviewSectionPreview() }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -24,21 +24,27 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyrillrx.rpg.character.data.SampleCharacterRepository
+import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.contentMaxWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.widthExpandedMin
 import com.cyrillrx.rpg.home.presentation.navigation.HomeRouter
+import com.cyrillrx.rpg.home.presentation.viewmodel.HomeViewModel
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.app_name
 import rpg_companion.composeapp.generated.resources.btn_bestiary
 import rpg_companion.composeapp.generated.resources.btn_campaign_list
-import rpg_companion.composeapp.generated.resources.btn_character_sheets
 import rpg_companion.composeapp.generated.resources.btn_magical_items
 import rpg_companion.composeapp.generated.resources.btn_my_bestiary_lists
 import rpg_companion.composeapp.generated.resources.btn_my_item_lists
@@ -48,9 +54,20 @@ import rpg_companion.composeapp.generated.resources.section_compendium
 import rpg_companion.composeapp.generated.resources.section_my_lists
 import rpg_companion.composeapp.generated.resources.title_settings
 
+@Composable
+fun HomeScreen(viewModel: HomeViewModel, router: HomeRouter) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.silentRefresh()
+    }
+
+    HomeScreen(state = state, router = router)
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(router: HomeRouter) {
+fun HomeScreen(state: HomeState, router: HomeRouter) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -75,9 +92,9 @@ fun HomeScreen(router: HomeRouter) {
                 .fillMaxWidth()
 
             if (maxWidth >= widthExpandedMin) {
-                HomeWideScreen(router, contentModifier)
+                HomeWideScreen(state, router, contentModifier)
             } else {
-                HomeDefault(router, contentModifier)
+                HomeDefault(state, router, contentModifier)
             }
         }
     }
@@ -85,7 +102,7 @@ fun HomeScreen(router: HomeRouter) {
 
 /** Single-column layout for phones and narrow tablets. */
 @Composable
-private fun HomeDefault(router: HomeRouter, modifier: Modifier = Modifier) {
+private fun HomeDefault(state: HomeState, router: HomeRouter, modifier: Modifier = Modifier) {
     Column(
         verticalArrangement = Arrangement.spacedBy(spacingMedium),
         modifier = modifier
@@ -93,7 +110,7 @@ private fun HomeDefault(router: HomeRouter, modifier: Modifier = Modifier) {
             .padding(horizontal = spacingCommon, vertical = spacingMedium),
     ) {
         HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
-        HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheetList)
+        CharacterPreviewSection(state, router, modifier = Modifier.fillMaxWidth())
         CompendiumSection(router, modifier = Modifier.fillMaxWidth())
         MyListsSection(router, modifier = Modifier.fillMaxWidth())
     }
@@ -101,7 +118,7 @@ private fun HomeDefault(router: HomeRouter, modifier: Modifier = Modifier) {
 
 /** Two-pane layout for large landscape screens. */
 @Composable
-private fun HomeWideScreen(router: HomeRouter, modifier: Modifier = Modifier) {
+private fun HomeWideScreen(state: HomeState, router: HomeRouter, modifier: Modifier = Modifier) {
     Column(
         verticalArrangement = Arrangement.spacedBy(spacingMedium),
         modifier = modifier
@@ -109,10 +126,15 @@ private fun HomeWideScreen(router: HomeRouter, modifier: Modifier = Modifier) {
             .padding(horizontal = spacingCommon, vertical = spacingMedium),
     ) {
         HomeButton(stringResource(Res.string.btn_campaign_list), router::openCampaignList)
-        HomeButton(stringResource(Res.string.btn_character_sheets), router::openCharacterSheetList)
         Row(horizontalArrangement = Arrangement.spacedBy(spacingCommon)) {
-            CompendiumSection(router, modifier = Modifier.weight(1f))
-            MyListsSection(router, modifier = Modifier.weight(1f))
+            CharacterPreviewSection(state, router, modifier = Modifier.weight(1f))
+            Column(
+                verticalArrangement = Arrangement.spacedBy(spacingMedium),
+                modifier = Modifier.weight(1f),
+            ) {
+                CompendiumSection(router, modifier = Modifier.fillMaxWidth())
+                MyListsSection(router, modifier = Modifier.fillMaxWidth())
+            }
         }
     }
 }
@@ -183,9 +205,12 @@ private fun MyListsSection(router: HomeRouter, modifier: Modifier = Modifier) {
     }
 }
 
-private object PreviewHomeRouter : HomeRouter {
+internal object PreviewHomeRouter : HomeRouter {
     override fun openCampaignList() {}
     override fun openCharacterSheetList() {}
+    override fun openCharacterDetail(character: Character) {}
+    override fun openCreateCharacter() {}
+    override fun openPresetGallery() {}
     override fun openSpellCompendium() {}
     override fun openMagicalItemCompendium() {}
     override fun openMonsterCompendium() {}
@@ -195,18 +220,22 @@ private object PreviewHomeRouter : HomeRouter {
     override fun openSettings() {}
 }
 
+@Composable
+private fun HomeScreenPreview() {
+    HomeScreen(
+        state = HomeState(body = HomeState.Body.WithData(SampleCharacterRepository.getAll())),
+        router = PreviewHomeRouter,
+    )
+}
+
 @Preview
 @Composable
 private fun PreviewHomeScreenLight() {
-    AppThemePreview(darkTheme = false) {
-        HomeScreen(PreviewHomeRouter)
-    }
+    AppThemePreview(darkTheme = false) { HomeScreenPreview() }
 }
 
 @Preview
 @Composable
 private fun PreviewHomeScreenDark() {
-    AppThemePreview(darkTheme = true) {
-        HomeScreen(PreviewHomeRouter)
-    }
+    AppThemePreview(darkTheme = true) { HomeScreenPreview() }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeState.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeState.kt
@@ -1,0 +1,14 @@
+package com.cyrillrx.rpg.home.presentation
+
+import com.cyrillrx.rpg.character.domain.Character
+import org.jetbrains.compose.resources.StringResource
+
+data class HomeState(
+    val body: Body,
+) {
+    sealed interface Body {
+        data object Loading : Body
+        data class Error(val errorMessage: StringResource) : Body
+        data class WithData(val characters: List<Character>) : Body
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/SectionHeader.kt
@@ -1,8 +1,10 @@
 package com.cyrillrx.rpg.home.presentation
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -11,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.sectionHeaderHeight
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -19,11 +22,15 @@ fun SectionHeader(
     title: String,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleLarge,
-        modifier = modifier,
-    )
+    Box(
+        contentAlignment = Alignment.CenterStart,
+        modifier = modifier.heightIn(min = sectionHeaderHeight),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+        )
+    }
 }
 
 @Composable
@@ -36,7 +43,9 @@ fun SectionHeaderWithAction(
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = sectionHeaderHeight),
     ) {
         SectionHeader(title = title)
         TextButton(onClick = onActionClick) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/navigation/HomeRouter.kt
@@ -3,6 +3,7 @@ package com.cyrillrx.rpg.home.presentation.navigation
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.cyrillrx.rpg.campaign.navigation.CampaignRoute
+import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.character.presentation.navigation.CharacterRoute
 import com.cyrillrx.rpg.creature.presentation.navigation.MonsterRoute
 import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRoute
@@ -13,6 +14,9 @@ import com.cyrillrx.rpg.userlist.presentation.navigation.UserListRoute
 interface HomeRouter {
     fun openCampaignList()
     fun openCharacterSheetList()
+    fun openCharacterDetail(character: Character)
+    fun openCreateCharacter()
+    fun openPresetGallery()
     fun openSpellCompendium()
     fun openMagicalItemCompendium()
     fun openMonsterCompendium()
@@ -29,6 +33,18 @@ class HomeRouterImpl(private val backStack: NavBackStack<NavKey>) : HomeRouter {
 
     override fun openCharacterSheetList() {
         backStack.add(CharacterRoute.List)
+    }
+
+    override fun openCharacterDetail(character: Character) {
+        backStack.add(CharacterRoute.Detail(character.id))
+    }
+
+    override fun openCreateCharacter() {
+        backStack.add(CharacterRoute.Create)
+    }
+
+    override fun openPresetGallery() {
+        backStack.add(CharacterRoute.PresetGallery)
     }
 
     override fun openSpellCompendium() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/viewmodel/HomeViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/viewmodel/HomeViewModel.kt
@@ -1,0 +1,56 @@
+package com.cyrillrx.rpg.home.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import com.cyrillrx.rpg.home.presentation.HomeState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.error_while_loading_characters
+import kotlin.coroutines.cancellation.CancellationException
+
+class HomeViewModel(
+    private val repository: CharacterRepository,
+) : ViewModel() {
+
+    val state: StateFlow<HomeState>
+        field = MutableStateFlow(HomeState(body = HomeState.Body.Loading))
+
+    private var activeJob: Job? = null
+
+    init {
+        loadCharacters(showLoading = true)
+    }
+
+    fun silentRefresh() {
+        if (state.value.body is HomeState.Body.Loading) return
+        activeJob?.cancel()
+        activeJob = loadCharacters(showLoading = false)
+    }
+
+    private fun loadCharacters(showLoading: Boolean): Job =
+        viewModelScope.launch {
+            if (showLoading) state.update { it.copy(body = HomeState.Body.Loading) }
+            try {
+                val characters = repository.getAll(filter = null).take(RECENT_LIMIT)
+                state.update { it.copy(body = HomeState.Body.WithData(characters)) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (showLoading) {
+                    state.update {
+                        it.copy(body = HomeState.Body.Error(errorMessage = Res.string.error_while_loading_characters))
+                    }
+                }
+                // On silent refresh failure, keep the existing state.
+            }
+        }
+
+    companion object {
+        private const val RECENT_LIMIT = 2
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/viewmodel/HomeViewModelFactory.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/viewmodel/HomeViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.cyrillrx.rpg.home.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.cyrillrx.rpg.character.domain.CharacterRepository
+import kotlin.reflect.KClass
+
+class HomeViewModelFactory(
+    private val repository: CharacterRepository,
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+        return HomeViewModel(repository) as T
+    }
+}


### PR DESCRIPTION
## 📝 Description

Adds a "Character sheets" section to the home screen.

The section shows:
- a header with a **See all** shortcut to the full character list,
- the **New character** / **Quick create** actions (always visible),
- up to **two** tappable sheet previews opening the character detail.

It slots into the existing responsive layout: stacked in the single-column layout, left pane in the two-pane layout.

Implementation notes:
- New `HomeViewModel` / `HomeViewModelFactory` / `HomeState`, following the `CharacterListViewModel` pattern (`StateFlow` + sealed `Body`, refresh on `ON_RESUME`). It loads `getAll(null).take(2)` — ordering by last-modified is intentionally deferred to a follow-up PR to keep this one UI-only (no `shared/core` changes).
- The new-character / quick-create card pair was extracted from `CharacterListScreen` into a reusable `CharacterCreateActions` composable (first commit) and reused both on the list screen and in the home section.
- The character repository is hoisted in `App` so the home and the character routes share a single instance.
- New strings: `btn_see_all` (EN/FR). Section title reuses the existing `btn_character_sheets`.

## 🖼️ Media

### Default
<img width="1030" height="1778" alt="image" src="https://github.com/user-attachments/assets/f60277ce-f157-4478-85ab-5347fce9eea3" />

### Wide Screen
<img width="2162" height="1198" alt="image" src="https://github.com/user-attachments/assets/1feeebae-b371-4491-8385-58cc4c114f78" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed