### PR TITLE
docs(agents): fix desktop run command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ All commands run from `cmp-ttrpg-companion/`:
 
 ```bash
 ./gradlew build               # Build all targets
-./gradlew desktopRun          # Run on Desktop (JVM)
+./gradlew :composeApp:run     # Run on Desktop (JVM)
 ./gradlew installDebug        # Install on Android
 ./gradlew test                # Run all tests
 ./gradlew jvmTest             # Run JVM/Desktop tests only


### PR DESCRIPTION
## 📝 Description

The contributor guide documents `./gradlew desktopRun` to run the desktop app, but that task does not exist (it fails with "Task 'desktopRun' not found").
The actual Compose desktop run task is `:composeApp:run`. Update the command accordingly.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed