### PR TITLE
feat(character): sort home previews by last modified date

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
@@ -5,9 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.Shield
@@ -25,6 +25,7 @@ import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.formatRelativeTime
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.borderAlpha
 import com.cyrillrx.rpg.core.presentation.theme.borderWidth
@@ -47,6 +48,7 @@ fun CharacterListItem(
     val shortDescription = character.resolveTranslation(locale)?.shortDescription.orEmpty()
     val primaryText = shortDescription.ifBlank { character.name }
     val secondaryText = if (shortDescription.isNotBlank()) character.name else ""
+    val relativeTime = character.lastModified.formatRelativeTime()
 
     Card(
         onClick = onClick,
@@ -55,31 +57,50 @@ fun CharacterListItem(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         modifier = modifier,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(spacingCommon),
+        Column(
+            verticalArrangement = Arrangement.spacedBy(spacingSmall),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(spacingCommon),
         ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(spacingSmall),
-                modifier = Modifier.weight(1f),
+            // Title line: name / short description on the left, class on the right.
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
                     text = primaryText,
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
+                Text(
+                    text = character.clazz.toFormattedString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
 
-                if (shortDescription.isNotBlank()) {
-                    Text(
-                        text = secondaryText,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
+            if (shortDescription.isNotBlank()) {
+                Text(
+                    text = secondaryText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
 
+            // Stats line: armor class / hit points on the left, last-modified date on the right.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(spacingCommon),
                     verticalAlignment = Alignment.CenterVertically,
@@ -118,16 +139,16 @@ fun CharacterListItem(
                         )
                     }
                 }
+
+                if (relativeTime != null) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = relativeTime,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
-
-            Spacer(modifier = Modifier.width(spacingCommon))
-
-            Text(
-                text = character.clazz.toFormattedString(),
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary,
-            )
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -19,7 +18,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
@@ -98,58 +99,49 @@ fun CharacterListItem(
 
             // Stats line: armor class / hit points on the left, last-modified date on the right.
             Row(
+                horizontalArrangement = Arrangement.spacedBy(spacingCommon),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(spacingCommon),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(spacingSmall),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Shield,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(iconSizeSmall),
-                        )
-                        Text(
-                            text = stringResource(Res.string.value_armor_class, character.armorClass),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(spacingSmall),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Favorite,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(iconSizeSmall),
-                        )
-                        Text(
-                            text = stringResource(Res.string.value_hit_points, character.maxHitPoints),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-
+                StatChip(
+                    icon = Icons.Outlined.Shield,
+                    text = stringResource(Res.string.value_armor_class, character.armorClass),
+                )
+                StatChip(
+                    icon = Icons.Outlined.Favorite,
+                    text = stringResource(Res.string.value_hit_points, character.maxHitPoints),
+                )
                 if (relativeTime != null) {
-                    Spacer(modifier = Modifier.weight(1f))
                     Text(
                         text = relativeTime,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.End,
+                        modifier = Modifier.weight(1f),
                     )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun StatChip(icon: ImageVector, text: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(iconSizeSmall),
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 
 class CharacterEditViewModel(
     private val characterId: String,
@@ -174,7 +175,7 @@ class CharacterEditViewModel(
         viewModelScope.launch {
             val loaded = state.value as? Loaded ?: return@launch
             if (loaded.character == characterBeforeEdit) return@launch
-            characterRepository.save(loaded.character)
+            characterRepository.save(loaded.character.copy(lastModified = Clock.System.now()))
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterEditViewModel.kt
@@ -172,10 +172,13 @@ class CharacterEditViewModel(
         val characterBeforeEdit = (state.value as? Loaded)?.character ?: return
 
         updateEditState(applyEdit)
+        val editedCharacter = (state.value as? Loaded)?.character ?: return
+        if (editedCharacter == characterBeforeEdit) return
+
+        val stampedCharacter = editedCharacter.copy(lastModified = Clock.System.now())
+        updateEditState { copy(character = stampedCharacter) }
         viewModelScope.launch {
-            val loaded = state.value as? Loaded ?: return@launch
-            if (loaded.character == characterBeforeEdit) return@launch
-            characterRepository.save(loaded.character.copy(lastModified = Clock.System.now()))
+            characterRepository.save(stampedCharacter)
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterListViewModel.kt
@@ -138,7 +138,7 @@ class CharacterListViewModel(
 
     private suspend fun fetchAndUpdateCharacters(query: String) {
         val filter = CharacterFilter(query = query)
-        val characters = repository.getAll(filter)
+        val characters = repository.getAll(filter).sortedByDescending { it.lastModified }
         val body = if (characters.isEmpty()) {
             CharacterListState.Body.Empty
         } else {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/viewmodel/CharacterPresetGalleryViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_characters
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -44,7 +45,7 @@ class CharacterPresetGalleryViewModel(
     @OptIn(ExperimentalUuidApi::class)
     fun onPresetSelected(preset: Character) {
         viewModelScope.launch {
-            val newCharacter = preset.copy(id = Uuid.random().toString())
+            val newCharacter = preset.copy(id = Uuid.random().toString(), lastModified = Clock.System.now())
             characterRepository.save(newCharacter)
             navigationEvents.tryEmit(NavigationEvent.NavigateToDetail(newCharacter))
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/RelativeTime.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/RelativeTime.kt
@@ -1,0 +1,43 @@
+package com.cyrillrx.rpg.core.presentation
+
+import androidx.compose.runtime.Composable
+import kotlinx.datetime.Instant
+import org.jetbrains.compose.resources.pluralStringResource
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.time_ago_days
+import rpg_companion.composeapp.generated.resources.time_ago_hours
+import rpg_companion.composeapp.generated.resources.time_ago_minutes
+import rpg_companion.composeapp.generated.resources.time_ago_months
+import rpg_companion.composeapp.generated.resources.time_ago_now
+import rpg_companion.composeapp.generated.resources.time_ago_years
+import kotlin.time.Clock
+
+/**
+ * Formats this instant as a human-readable "x ago" string (now / minutes / hours / days / months / years).
+ * Returns null for the epoch-zero sentinel, i.e. when no modification date is known.
+ */
+@Composable
+fun Instant.formatRelativeTime(): String? {
+    if (toEpochMilliseconds() == 0L) return null
+
+    val elapsed = Clock.System.now() - this
+    val minutes = elapsed.inWholeMinutes.toInt()
+    val hours = elapsed.inWholeHours.toInt()
+    val days = elapsed.inWholeDays.toInt()
+    return when {
+        minutes < 1 -> stringResource(Res.string.time_ago_now)
+        hours < 1 -> pluralStringResource(Res.plurals.time_ago_minutes, minutes, minutes)
+        days < 1 -> pluralStringResource(Res.plurals.time_ago_hours, hours, hours)
+        days < 30 -> pluralStringResource(Res.plurals.time_ago_days, days, days)
+        days < 365 -> {
+            val months = (days / 30).coerceAtLeast(1)
+            pluralStringResource(Res.plurals.time_ago_months, months, months)
+        }
+
+        else -> {
+            val years = (days / 365).coerceAtLeast(1)
+            pluralStringResource(Res.plurals.time_ago_years, years, years)
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/RelativeTime.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/RelativeTime.kt
@@ -13,31 +13,50 @@ import rpg_companion.composeapp.generated.resources.time_ago_now
 import rpg_companion.composeapp.generated.resources.time_ago_years
 import kotlin.time.Clock
 
+/** Coarse relative-time bucket computed from the elapsed duration between two instants. */
+sealed interface RelativeTimePeriod {
+    object Now : RelativeTimePeriod
+    data class Minutes(val count: Int) : RelativeTimePeriod
+    data class Hours(val count: Int) : RelativeTimePeriod
+    data class Days(val count: Int) : RelativeTimePeriod
+    data class Months(val count: Int) : RelativeTimePeriod
+    data class Years(val count: Int) : RelativeTimePeriod
+}
+
+/**
+ * Computes the relative-time bucket between this instant and [now].
+ * Returns null for the epoch-zero sentinel, i.e. when no modification date is known.
+ */
+fun Instant.getRelativeTimePeriod(now: Instant): RelativeTimePeriod? {
+    if (toEpochMilliseconds() == 0L) return null
+
+    val elapsed = now - this
+    val minutes = elapsed.inWholeMinutes.toInt()
+    val hours = elapsed.inWholeHours.toInt()
+    val days = elapsed.inWholeDays.toInt()
+    return when {
+        minutes < 1 -> RelativeTimePeriod.Now
+        hours < 1 -> RelativeTimePeriod.Minutes(minutes)
+        days < 1 -> RelativeTimePeriod.Hours(hours)
+        days < 30 -> RelativeTimePeriod.Days(days)
+        days < 360 -> RelativeTimePeriod.Months((days / 30).coerceAtLeast(1))
+        else -> RelativeTimePeriod.Years((days / 365).coerceAtLeast(1))
+    }
+}
+
 /**
  * Formats this instant as a human-readable "x ago" string (now / minutes / hours / days / months / years).
  * Returns null for the epoch-zero sentinel, i.e. when no modification date is known.
  */
 @Composable
-fun Instant.formatRelativeTime(): String? {
-    if (toEpochMilliseconds() == 0L) return null
-
-    val elapsed = Clock.System.now() - this
-    val minutes = elapsed.inWholeMinutes.toInt()
-    val hours = elapsed.inWholeHours.toInt()
-    val days = elapsed.inWholeDays.toInt()
-    return when {
-        minutes < 1 -> stringResource(Res.string.time_ago_now)
-        hours < 1 -> pluralStringResource(Res.plurals.time_ago_minutes, minutes, minutes)
-        days < 1 -> pluralStringResource(Res.plurals.time_ago_hours, hours, hours)
-        days < 30 -> pluralStringResource(Res.plurals.time_ago_days, days, days)
-        days < 365 -> {
-            val months = (days / 30).coerceAtLeast(1)
-            pluralStringResource(Res.plurals.time_ago_months, months, months)
-        }
-
-        else -> {
-            val years = (days / 365).coerceAtLeast(1)
-            pluralStringResource(Res.plurals.time_ago_years, years, years)
-        }
+fun Instant.formatRelativeTime(now: Instant = Clock.System.now()): String? {
+    return when (val period = getRelativeTimePeriod(now)) {
+        null -> null
+        RelativeTimePeriod.Now -> stringResource(Res.string.time_ago_now)
+        is RelativeTimePeriod.Minutes -> pluralStringResource(Res.plurals.time_ago_minutes, period.count, period.count)
+        is RelativeTimePeriod.Hours -> pluralStringResource(Res.plurals.time_ago_hours, period.count, period.count)
+        is RelativeTimePeriod.Days -> pluralStringResource(Res.plurals.time_ago_days, period.count, period.count)
+        is RelativeTimePeriod.Months -> pluralStringResource(Res.plurals.time_ago_months, period.count, period.count)
+        is RelativeTimePeriod.Years -> pluralStringResource(Res.plurals.time_ago_years, period.count, period.count)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/viewmodel/HomeViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/viewmodel/HomeViewModel.kt
@@ -36,7 +36,9 @@ class HomeViewModel(
         viewModelScope.launch {
             if (showLoading) state.update { it.copy(body = HomeState.Body.Loading) }
             try {
-                val characters = repository.getAll(filter = null).take(RECENT_LIMIT)
+                val characters = repository.getAll(filter = null)
+                    .sortedByDescending { it.lastModified }
+                    .take(RECENT_LIMIT)
                 state.update { it.copy(body = HomeState.Body.WithData(characters)) }
             } catch (e: CancellationException) {
                 throw e

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListItem.kt
@@ -7,24 +7,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.formatRelativeTime
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.domain.UserList
 import org.jetbrains.compose.resources.pluralStringResource
-import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.creature_count
 import rpg_companion.composeapp.generated.resources.magical_item_count
 import rpg_companion.composeapp.generated.resources.spell_count
-import rpg_companion.composeapp.generated.resources.time_ago_days
-import rpg_companion.composeapp.generated.resources.time_ago_hours
-import rpg_companion.composeapp.generated.resources.time_ago_minutes
-import rpg_companion.composeapp.generated.resources.time_ago_months
-import rpg_companion.composeapp.generated.resources.time_ago_now
-import rpg_companion.composeapp.generated.resources.time_ago_years
-import kotlin.time.Clock
 
 @Composable
 fun UserListItem(
@@ -49,7 +42,7 @@ fun UserListItem(
 @Composable
 private fun UserList.subtitle(): String {
     val countItemText = formattedCount()
-    val relativeTimeText = formattedElapsedTime()
+    val relativeTimeText = lastModified.formatRelativeTime()
     return if (relativeTimeText == null) countItemText else "$countItemText - $relativeTimeText"
 }
 
@@ -65,31 +58,6 @@ private fun UserList.formattedCount(): String {
         quantity = count,
         count,
     )
-}
-
-@Composable
-private fun UserList.formattedElapsedTime(): String? {
-    if (lastModified.toEpochMilliseconds() == 0L) return null
-
-    val elapsed = Clock.System.now() - lastModified
-    val minutes = elapsed.inWholeMinutes.toInt()
-    val hours = elapsed.inWholeHours.toInt()
-    val days = elapsed.inWholeDays.toInt()
-    return when {
-        minutes < 1 -> stringResource(Res.string.time_ago_now)
-        hours < 1 -> pluralStringResource(Res.plurals.time_ago_minutes, minutes, minutes)
-        days < 1 -> pluralStringResource(Res.plurals.time_ago_hours, hours, hours)
-        days < 30 -> pluralStringResource(Res.plurals.time_ago_days, days, days)
-        days < 365 -> {
-            val months = (days / 30).coerceAtLeast(1)
-            pluralStringResource(Res.plurals.time_ago_months, months, months)
-        }
-
-        else -> {
-            val years = (days / 365).coerceAtLeast(1)
-            pluralStringResource(Res.plurals.time_ago_years, years, years)
-        }
-    }
 }
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/core/presentation/RelativeTimeTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/core/presentation/RelativeTimeTest.kt
@@ -1,0 +1,69 @@
+package com.cyrillrx.rpg.core.presentation
+
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class RelativeTimeTest {
+
+    private val now = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    private fun periodBefore(elapsed: Duration): RelativeTimePeriod? =
+        (now - elapsed).getRelativeTimePeriod(now)
+
+    @Test
+    fun `epoch-zero sentinel returns null`() {
+        assertNull(Instant.fromEpochMilliseconds(0).getRelativeTimePeriod(now))
+    }
+
+    @Test
+    fun `less than a minute is Now`() {
+        assertEquals(RelativeTimePeriod.Now, periodBefore(30.seconds))
+    }
+
+    @Test
+    fun `minutes below an hour`() {
+        assertEquals(RelativeTimePeriod.Minutes(5), periodBefore(5.minutes))
+    }
+
+    @Test
+    fun `hours below a day`() {
+        assertEquals(RelativeTimePeriod.Hours(2), periodBefore(2.hours))
+    }
+
+    @Test
+    fun `days below a month`() {
+        assertEquals(RelativeTimePeriod.Days(29), periodBefore(29.days))
+    }
+
+    @Test
+    fun `thirty days rounds to one month`() {
+        assertEquals(RelativeTimePeriod.Months(1), periodBefore(30.days))
+    }
+
+    @Test
+    fun `months below a year`() {
+        assertEquals(RelativeTimePeriod.Months(2), periodBefore(60.days))
+    }
+
+    @Test
+    fun `359 days still reads as months`() {
+        assertEquals(RelativeTimePeriod.Months(11), periodBefore(359.days))
+    }
+
+    @Test
+    fun `360 days rounds up to one year`() {
+        assertEquals(RelativeTimePeriod.Years(1), periodBefore(360.days))
+    }
+
+    @Test
+    fun `multiple years`() {
+        assertEquals(RelativeTimePeriod.Years(2), periodBefore(730.days))
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/domain/Character.kt
@@ -5,6 +5,7 @@ import com.cyrillrx.rpg.creature.domain.Abilities
 import com.cyrillrx.rpg.creature.domain.Creature
 import com.cyrillrx.rpg.creature.domain.Skills
 import com.cyrillrx.rpg.creature.domain.Speeds
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -26,6 +27,7 @@ data class Character(
     val background: Background? = null,
     val currentHitPoints: Int = maxHitPoints,
     val temporaryHitPoints: Int = 0,
+    val lastModified: Instant = Instant.fromEpochMilliseconds(0L),
 ) : Creature() {
     fun resolveTranslation(locale: String): Translation? = translations[locale]
         ?: translations[FALLBACK_LOCALE]

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/CharacterSerializationTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/data/CharacterSerializationTest.kt
@@ -3,8 +3,10 @@ package com.cyrillrx.rpg.character.data
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.data.serialize
 import com.cyrillrx.rpg.character.domain.Character
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class CharacterSerializationTest {
 
@@ -22,5 +24,26 @@ class CharacterSerializationTest {
         val roundTripped = original.serialize().deserialize<Character>()
         assertEquals(5, roundTripped.currentHitPoints)
         assertEquals(3, roundTripped.temporaryHitPoints)
+    }
+
+    @Test
+    fun `lastModified defaults to epoch zero when absent from the json`() {
+        // Default values are not encoded, so a freshly-built character (epoch 0) is
+        // serialized without the key — exactly like characters stored before the field existed.
+        val json = SampleCharacterRepository.humanFighter().serialize()
+        assertFalse(json.contains("lastModified"), "expected lastModified to be omitted, was: $json")
+
+        val restored = json.deserialize<Character>()
+        assertEquals(Instant.fromEpochMilliseconds(0L), restored.lastModified)
+    }
+
+    @Test
+    fun `lastModified survives a serialization round-trip`() {
+        val original = SampleCharacterRepository.humanFighter()
+            .copy(lastModified = Instant.fromEpochMilliseconds(1_700_000_000_000L))
+
+        val restored = original.serialize().deserialize<Character>()
+
+        assertEquals(original.lastModified, restored.lastModified)
     }
 }


### PR DESCRIPTION
## 📝 Description

Sorts the home "Character sheets" previews (and the full character list) by **last modified date**, so the most recently edited sheets surface first — and shows that date on the list items to help users orient.

This is the follow-up to #140, which surfaced the previews in DB order.

Approach (this PR keeps it pragmatic, consistent with `UserList`):
- `lastModified: Instant` is added **to the `Character` entity** (serialized in the existing `data` blob — **no schema migration**), defaulting to the epoch-zero sentinel. It is stamped with the current time when a character is saved or quick-created (ViewModel side, like `UserList`).
- The home previews and the character list are ordered by `lastModified` descending.
- The relative date ("x ago") is shown on `CharacterListItem`, reusing a formatter extracted from `UserListItem` into a shared `Instant.formatRelativeTime()` (returns null for epoch zero → presets show no date).

Commits are organised one concern each: formatter extraction, domain field, sorting, list-item display.

> Note: moving `lastModified` **out of the domain** (storage-layer column + migration), consistently for **both** `Character` and `UserList`, is intentionally deferred to a dedicated follow-up PR. The `CharacterListItem` arrangement is also left minimal here and will be reworked separately.

> ⚠️ Behaviour change: extracting the formatter also switches the months→years boundary from `days < 365` to `days < 360`. As a result, a date in the **360–364 days** window now reads "1 year ago" instead of "12 months ago". This also affects `UserList`, which reuses the same formatter. It's a deliberate wording trade-off (avoids the awkward "12 months"), not an accuracy improvement — the months bucket counts on a 30-day basis (`days / 30`, so 12 months = 360 days) while years still divide by 365, so the two bases don't line up exactly. Reconciling the two bases is left for a follow-up.

## 🖼️ Media

<img width="1808" height="1190" alt="image" src="https://github.com/user-attachments/assets/b232f26a-136c-4746-a6b8-44d5915551c3" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
