### PR TITLE
feat(core): unify dialog styling across the app

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/AbilityEditDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/AbilityEditDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.withStyle
 import com.cyrillrx.rpg.character.domain.MAX_ABILITY_SCORE
 import com.cyrillrx.rpg.character.domain.MIN_ABILITY_SCORE
 import com.cyrillrx.rpg.core.domain.toSignedString
+import com.cyrillrx.rpg.core.presentation.component.dialog.EditDialog
 import com.cyrillrx.rpg.core.presentation.component.dnd.ProficiencyCheckbox
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/CharacterEditDialogs.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/CharacterEditDialogs.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -36,6 +34,8 @@ import com.cyrillrx.rpg.character.presentation.CharacterEditState
 import com.cyrillrx.rpg.character.presentation.CharacterEditState.Loaded.EditingField
 import com.cyrillrx.rpg.core.domain.toSignedString
 import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
+import com.cyrillrx.rpg.core.presentation.component.dialog.DialogTextField
+import com.cyrillrx.rpg.core.presentation.component.dialog.EditDialog
 import com.cyrillrx.rpg.core.presentation.component.dnd.ProficiencyCheckbox
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.getFontWeight
@@ -266,16 +266,11 @@ private fun ShortDescriptionEditDialog(
         onDismiss = onDismiss,
         onConfirm = { onConfirm(text) },
     ) {
-        TextField(
+        DialogTextField(
             value = text,
             onValueChange = { text = it },
-            singleLine = true,
-            placeholder = { Text(stringResource(Res.string.hint_short_description)) },
+            placeholder = stringResource(Res.string.hint_short_description),
             textStyle = MaterialTheme.typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = MaterialTheme.colorScheme.surface,
-                unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-            ),
         )
     }
 }
@@ -320,15 +315,10 @@ private fun NumberEditDialog(
         onConfirm = { parsedValue?.let(onConfirm) },
         confirmEnabled = parsedValue != null,
     ) {
-        TextField(
+        DialogTextField(
             value = text,
             onValueChange = { text = it },
-            singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = MaterialTheme.colorScheme.surface,
-                unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-            ),
         )
     }
 }
@@ -349,15 +339,10 @@ private fun FloatEditDialog(
         onConfirm = { parsedValue?.let(onConfirm) },
         confirmEnabled = parsedValue != null,
     ) {
-        TextField(
+        DialogTextField(
             value = text,
             onValueChange = { text = it },
-            singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = MaterialTheme.colorScheme.surface,
-                unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-            ),
         )
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/DialogComponents.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/DialogComponents.kt
@@ -3,15 +3,12 @@ package com.cyrillrx.rpg.character.presentation.component.dialog
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -24,51 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.cyrillrx.rpg.core.presentation.theme.iconButtonSize
 import kotlinx.coroutines.delay
-import org.jetbrains.compose.resources.stringResource
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_cancel
-import rpg_companion.composeapp.generated.resources.btn_confirm
-
-@Composable
-internal fun EditDialog(
-    title: String,
-    subtitle: String? = null,
-    onDismiss: () -> Unit,
-    onConfirm: (() -> Unit)? = null,
-    confirmEnabled: Boolean = true,
-    content: @Composable () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            if (subtitle == null) {
-                Text(title)
-            } else {
-                Column {
-                    Text(title)
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        },
-        text = content,
-        confirmButton = {
-            if (onConfirm != null) {
-                TextButton(onClick = onConfirm, enabled = confirmEnabled) {
-                    Text(stringResource(Res.string.btn_confirm))
-                }
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.btn_cancel))
-            }
-        },
-    )
-}
 
 @Composable
 internal fun DecrementIncrementRow(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/SingleChoiceDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/dialog/SingleChoiceDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
+import com.cyrillrx.rpg.core.presentation.component.dialog.EditDialog
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
@@ -1,9 +1,5 @@
 package com.cyrillrx.rpg.core.presentation.component.dialog
 
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -11,9 +7,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.component.accessibilityId
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_cancel
 import rpg_companion.composeapp.generated.resources.btn_create_list
 import rpg_companion.composeapp.generated.resources.hint_list_name
 import rpg_companion.composeapp.generated.resources.title_create_list
@@ -25,29 +22,34 @@ fun CreateListDialog(
 ) {
     var name by remember { mutableStateOf("") }
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.title_create_list)) },
-        text = {
-            TextField(
-                value = name,
-                onValueChange = { name = it },
-                placeholder = { Text(stringResource(Res.string.hint_list_name)) },
-                singleLine = true,
-                modifier = Modifier.accessibilityId("input_list_name"),
-            )
-        },
-        confirmButton = {
-            TextButton(
-                onClick = { if (name.isNotBlank()) onConfirm(name) },
-            ) {
-                Text(stringResource(Res.string.btn_create_list))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.btn_cancel))
-            }
-        },
-    )
+    EditDialog(
+        title = stringResource(Res.string.title_create_list),
+        onDismiss = onDismiss,
+        onConfirm = { onConfirm(name) },
+        confirmEnabled = name.isNotBlank(),
+        confirmLabel = stringResource(Res.string.btn_create_list),
+    ) {
+        DialogTextField(
+            value = name,
+            onValueChange = { name = it },
+            placeholder = stringResource(Res.string.hint_list_name),
+            modifier = Modifier.accessibilityId("input_list_name"),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreateListDialogLight() {
+    AppThemePreview(darkTheme = false) {
+        CreateListDialog(onConfirm = {}, onDismiss = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCreateListDialogDark() {
+    AppThemePreview(darkTheme = true) {
+        CreateListDialog(onConfirm = {}, onDismiss = {})
+    }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/CreateListDialog.kt
@@ -21,12 +21,13 @@ fun CreateListDialog(
     onDismiss: () -> Unit,
 ) {
     var name by remember { mutableStateOf("") }
+    val trimmedName = name.trim()
 
     EditDialog(
         title = stringResource(Res.string.title_create_list),
         onDismiss = onDismiss,
-        onConfirm = { onConfirm(name) },
-        confirmEnabled = name.isNotBlank(),
+        onConfirm = { onConfirm(trimmedName) },
+        confirmEnabled = trimmedName.isNotBlank(),
         confirmLabel = stringResource(Res.string.btn_create_list),
     ) {
         DialogTextField(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/DialogTextField.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/DialogTextField.kt
@@ -2,17 +2,15 @@ package com.cyrillrx.rpg.core.presentation.component.dialog
 
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 
 /**
- * Shared text field for dialogs. Forces the container color to [MaterialTheme.colorScheme.surface]
- * so the field blends with the dialog surface consistently across every dialog.
+ * Shared text field for dialogs. Uses an outlined style so the field blends with the dialog
+ * surface consistently across every dialog.
  */
 @Composable
 fun DialogTextField(
@@ -24,7 +22,7 @@ fun DialogTextField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     textStyle: TextStyle = LocalTextStyle.current,
 ) {
-    TextField(
+    OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         modifier = modifier,
@@ -32,9 +30,5 @@ fun DialogTextField(
         keyboardOptions = keyboardOptions,
         textStyle = textStyle,
         placeholder = placeholder?.let { { Text(it) } },
-        colors = TextFieldDefaults.colors(
-            focusedContainerColor = MaterialTheme.colorScheme.surface,
-            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-        ),
     )
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/DialogTextField.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/DialogTextField.kt
@@ -1,0 +1,40 @@
+package com.cyrillrx.rpg.core.presentation.component.dialog
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+
+/**
+ * Shared text field for dialogs. Forces the container color to [MaterialTheme.colorScheme.surface]
+ * so the field blends with the dialog surface consistently across every dialog.
+ */
+@Composable
+fun DialogTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String? = null,
+    singleLine: Boolean = true,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    textStyle: TextStyle = LocalTextStyle.current,
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        singleLine = singleLine,
+        keyboardOptions = keyboardOptions,
+        textStyle = textStyle,
+        placeholder = placeholder?.let { { Text(it) } },
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = MaterialTheme.colorScheme.surface,
+            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+        ),
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/EditDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/EditDialog.kt
@@ -1,0 +1,58 @@
+package com.cyrillrx.rpg.core.presentation.component.dialog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_cancel
+import rpg_companion.composeapp.generated.resources.btn_confirm
+
+/**
+ * Shared base dialog for editing/input operations across features.
+ * Wraps [AlertDialog] with a title (+ optional subtitle), a content slot, and confirm/cancel buttons.
+ */
+@Composable
+fun EditDialog(
+    title: String,
+    onDismiss: () -> Unit,
+    subtitle: String? = null,
+    onConfirm: (() -> Unit)? = null,
+    confirmEnabled: Boolean = true,
+    confirmLabel: String = stringResource(Res.string.btn_confirm),
+    content: @Composable () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            if (subtitle == null) {
+                Text(title)
+            } else {
+                Column {
+                    Text(title)
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
+        text = content,
+        confirmButton = {
+            if (onConfirm != null) {
+                TextButton(onClick = onConfirm, enabled = confirmEnabled) {
+                    Text(confirmLabel)
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.btn_cancel))
+            }
+        },
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dialog/RenameListDialog.kt
@@ -1,9 +1,5 @@
 package com.cyrillrx.rpg.core.presentation.component.dialog
 
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -11,10 +7,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.component.accessibilityId
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_cancel
-import rpg_companion.composeapp.generated.resources.btn_confirm
 import rpg_companion.composeapp.generated.resources.dialog_rename_list_title
 import rpg_companion.composeapp.generated.resources.hint_list_name
 
@@ -25,32 +21,35 @@ fun RenameListDialog(
     onDismiss: () -> Unit,
 ) {
     var name by remember { mutableStateOf(currentName) }
+    val trimmedName = name.trim()
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.dialog_rename_list_title)) },
-        text = {
-            TextField(
-                value = name,
-                onValueChange = { name = it },
-                placeholder = { Text(stringResource(Res.string.hint_list_name)) },
-                singleLine = true,
-                modifier = Modifier.accessibilityId("input_list_name"),
-            )
-        },
-        confirmButton = {
-            val trimmedName = name.trim()
-            TextButton(
-                onClick = { onConfirm(trimmedName) },
-                enabled = trimmedName.isNotBlank() && trimmedName != currentName,
-            ) {
-                Text(stringResource(Res.string.btn_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.btn_cancel))
-            }
-        },
-    )
+    EditDialog(
+        title = stringResource(Res.string.dialog_rename_list_title),
+        onDismiss = onDismiss,
+        onConfirm = { onConfirm(trimmedName) },
+        confirmEnabled = trimmedName.isNotBlank() && trimmedName != currentName,
+    ) {
+        DialogTextField(
+            value = name,
+            onValueChange = { name = it },
+            placeholder = stringResource(Res.string.hint_list_name),
+            modifier = Modifier.accessibilityId("input_list_name"),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewRenameListDialogLight() {
+    AppThemePreview(darkTheme = false) {
+        RenameListDialog(currentName = "My list", onConfirm = {}, onDismiss = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewRenameListDialogDark() {
+    AppThemePreview(darkTheme = true) {
+        RenameListDialog(currentName = "My list", onConfirm = {}, onDismiss = {})
+    }
 }


### PR DESCRIPTION
## 📝 Description

Unifies dialog styling across the app so every dialog shares a single base and a single input-field style.

**Root cause:** two parallel dialog implementations existed with no common base. The core list dialogs used a bare `AlertDialog` + default `TextField` (grey filled container), while character dialogs went through an internal `EditDialog` wrapper and forced the field container color to `surface`. This produced the visible mismatch (e.g. create-list name field vs character short-description field).

**Changes:**
- New `core` component `EditDialog` — the dialog base, promoted from the character module and made `public`, with a configurable `confirmLabel` (defaults to `btn_confirm`).
- New `core` component `DialogTextField` — a shared text field built on `OutlinedTextField` so the input blends with the dialog surface consistently, removing the duplicated `TextFieldDefaults.colors(...)` blocks.
- `CreateListDialog` / `RenameListDialog` rebuilt on the shared components; the "Create" label is preserved via `confirmLabel`. Added light/dark previews.
- Character short-description, number and float dialogs now use `DialogTextField`; the other character dialogs reference the shared `EditDialog`.

## 🖼️ Media

<img width="808" height="586" alt="image" src="https://github.com/user-attachments/assets/55211735-f91b-4252-bf75-6b852b24c287" />

<img width="1052" height="748" alt="image" src="https://github.com/user-attachments/assets/9137e8e9-f9ea-432d-91a0-f6447d480db7" />

## ✅ Checklist
* [x] The author has proofread the PR
* [x] Address lint warnings
