### PR TITLE
feat(home): use shared SimpleTopBar on the home screen

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SimpleTopBar.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SimpleTopBar.kt
@@ -19,7 +19,7 @@ import rpg_companion.composeapp.generated.resources.btn_back
 @Composable
 fun SimpleTopBar(
     titleResource: StringResource,
-    onNavigateUpClicked: () -> Unit,
+    onNavigateUpClicked: (() -> Unit)? = null,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     SimpleTopBar(stringResource(titleResource), onNavigateUpClicked, actions)
@@ -29,17 +29,19 @@ fun SimpleTopBar(
 @Composable
 fun SimpleTopBar(
     title: String,
-    onNavigateUpClicked: () -> Unit,
+    onNavigateUpClicked: (() -> Unit)? = null,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     TopAppBar(
         title = { Text(title) },
         navigationIcon = {
-            IconButton(onClick = onNavigateUpClicked) {
-                Icon(
-                    Icons.AutoMirrored.Rounded.ArrowBack,
-                    contentDescription = stringResource(Res.string.btn_back),
-                )
+            if (onNavigateUpClicked != null) {
+                IconButton(onClick = onNavigateUpClicked) {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = stringResource(Res.string.btn_back),
+                    )
+                }
             }
         },
         actions = actions,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -15,14 +15,9 @@ import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Diamond
 import androidx.compose.material.icons.filled.Pets
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -32,6 +27,7 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.character.data.SampleCharacterRepository
 import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.contentMaxWidth
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
@@ -65,19 +61,17 @@ fun HomeScreen(viewModel: HomeViewModel, router: HomeRouter) {
     HomeScreen(state = state, router = router)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(state: HomeState, router: HomeRouter) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(Res.string.app_name)) },
+            SimpleTopBar(
+                titleResource = Res.string.app_name,
                 actions = {
                     IconButton(onClick = router::openSettings) {
                         Icon(Icons.Filled.Settings, contentDescription = stringResource(Res.string.title_settings))
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
             )
         },
     ) { paddingValues ->


### PR DESCRIPTION
## 📝 Description

Unifies the home screen top bar with the rest of the app.

**Context:** `HomeScreen` declared its own inline `TopAppBar`, making it the only screen not using the shared `SimpleTopBar`. `SimpleTopBar` could not be reused as-is because it required a non-null `onNavigateUpClicked` and always rendered a back arrow — but the home screen is the root and has no back button.

**Changes:**
- `SimpleTopBar`: make `onNavigateUpClicked` optional (`(() -> Unit)? = null`) on both overloads; the back arrow now renders only when a handler is provided. Backward compatible — existing callers pass a non-null lambda.
- `HomeScreen`: replace the inline `TopAppBar` with `SimpleTopBar`, keeping the title and the Settings action, with no back arrow (as before).

The home bar now matches every other screen's top bar.

## 🖼️ Media

No visual changes

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
