### PR TITLE
refactor(theme): centralize colors into the palette

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAdd.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAdd.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import com.cyrillrx.rpg.core.presentation.theme.Green500
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 
@@ -63,7 +62,7 @@ fun SwipeToAdd(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = MaterialTheme.colorScheme.onPrimary,
                 )
             }
         },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MagicalItemFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MagicalItemFormatExt.kt
@@ -2,6 +2,9 @@ package com.cyrillrx.rpg.core.presentation.component.dnd
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.cyrillrx.rpg.core.presentation.theme.ArmorColor
+import com.cyrillrx.rpg.core.presentation.theme.ObjectColor
+import com.cyrillrx.rpg.core.presentation.theme.WeaponColor
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
@@ -60,18 +63,14 @@ fun MagicalItem.getSubtitle(translation: MagicalItem.Translation): String {
     return "${type.toFormattedString()}$subtypeStr - ${rarity.toFormattedString()}$attunementStr"
 }
 
-private val weaponColor = Color(155, 11, 78)
-private val armorColor = Color(0, 122, 179)
-private val objectColor = Color(0, 179, 140)
-
 fun MagicalItem.getColor(): Color = when (type) {
-    MagicalItem.Type.ARMOR -> armorColor
-    MagicalItem.Type.POTION -> objectColor
-    MagicalItem.Type.RING -> objectColor
-    MagicalItem.Type.ROD -> weaponColor
-    MagicalItem.Type.SCROLL -> objectColor
-    MagicalItem.Type.STAFF -> weaponColor
-    MagicalItem.Type.WAND -> weaponColor
-    MagicalItem.Type.WEAPON -> weaponColor
-    MagicalItem.Type.WONDROUS_ITEM -> objectColor
+    MagicalItem.Type.ARMOR -> ArmorColor
+    MagicalItem.Type.POTION -> ObjectColor
+    MagicalItem.Type.RING -> ObjectColor
+    MagicalItem.Type.ROD -> WeaponColor
+    MagicalItem.Type.SCROLL -> ObjectColor
+    MagicalItem.Type.STAFF -> WeaponColor
+    MagicalItem.Type.WAND -> WeaponColor
+    MagicalItem.Type.WEAPON -> WeaponColor
+    MagicalItem.Type.WONDROUS_ITEM -> ObjectColor
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.outlined.Dangerous
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.cyrillrx.rpg.core.presentation.theme.Red900
+import com.cyrillrx.rpg.core.presentation.theme.SpellColor
 import com.cyrillrx.rpg.spell.domain.Spell
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
@@ -36,7 +36,7 @@ import rpg_companion.composeapp.generated.resources.spell_level_8th
 import rpg_companion.composeapp.generated.resources.spell_level_9th
 import rpg_companion.composeapp.generated.resources.spell_level_cantrip
 
-fun Spell.getColor(): Color = Red900
+fun Spell.getColor(): Color = SpellColor
 
 @Composable
 fun Spell.getFormattedSchool() =

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Color.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Color.kt
@@ -20,12 +20,21 @@ val Purple600 = Color(0xFF5E35B1)
 val Purple700 = Color(0xFF512DA8)
 val Purple800 = Color(0xFF4527A0)
 val Purple900 = Color(0xFF311B92)
-val Scarlet = Color(0xff9b1c47)
+val Scarlet = Color(0xff9b1c47) // D&D theming accent, used directly (see note below)
 
 val Green500 = Color(0xFF4CAF50)
 
 val DarkerGrey = Color(0xFF2C2C2C)
 val DarkGrey = Color(0xFF414040)
 
+// D&D theming colors used directly in UI (Scarlet, DndParchment, DndGold) — an
+// intentional exception to the "use MaterialTheme.colorScheme" rule.
 val DndParchment = Color(0xFFF0E8D0)
 val DndGold = Color(0xFFD4AF37)
+
+// Domain / category accent colors — fixed brand colors used for item/spell typing,
+// intentionally theme-independent. Referenced by the *.getColor() format helpers.
+val WeaponColor = Color(0xFF9B0B4E)
+val ArmorColor = Color(0xFF007AB3)
+val ObjectColor = Color(0xFF00B38C)
+val SpellColor = Red900

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
@@ -72,7 +71,7 @@ internal fun MagicalItemCardHeader(magicalItem: MagicalItem) {
     Text(
         text = translation.name,
         style = MaterialTheme.typography.titleLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.Bold),
-        color = Color.White,
+        color = MaterialTheme.colorScheme.onPrimary,
         modifier = Modifier
             .fillMaxWidth()
             .background(color)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
@@ -91,7 +91,7 @@ internal fun SpellCardHeader(spell: Spell) {
         text = spell.getFormattedSchool(),
         style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
         textAlign = TextAlign.Center,
-        color = Color.White,
+        color = MaterialTheme.colorScheme.onPrimary,
         modifier = Modifier
             .fillMaxWidth()
             .background(spellColor)


### PR DESCRIPTION
## 📝 Description

Centralizes hardcoded/inline colors into the palette (`core/presentation/theme/Color.kt`), per the "no inline colors" convention. **No displayed color changes** — same values, just named/centralized or mapped to a semantic role (hence `refactor`, not `feat`).

**Changes:**
- **`Color.kt`**: add named domain accent colors (`WeaponColor`, `ArmorColor`, `ObjectColor`, `SpellColor`) and a comment documenting the directly-used D&D theming colors (`Scarlet`/`DndParchment`/`DndGold`) as an intentional exception to the colorScheme rule.
- **`MagicalItemFormatExt.kt`**: drop the 3 inline `Color(r,g,b)` values; `getColor()` references the named constants.
- **`SpellFormatExt.kt`**: `getColor()` returns `SpellColor` instead of the raw `Red900`.
- **`SwipeToAdd.kt`, `MagicalItemCard.kt`, `SpellCard.kt`**: replace hardcoded `Color.White` (content on a saturated accent background) with the semantic `MaterialTheme.colorScheme.onPrimary` role — white in both themes here, so no visual change.

Left untouched (already correct): `Theme.kt` (the `Color.White`/`Color.Black` there are the role values), `Monster.Type.getColor()` and `Proficiency.getColor()` (already `@Composable` + `MaterialTheme`).

## 🖼️ Media

_No visual change expected._

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed