### PR TITLE
feat: replace hardcoded dimensions with Dimen tokens

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Dimen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Dimen.kt
@@ -14,6 +14,7 @@ val borderWidth = 1.dp
 val borderAlpha = 0.3f
 val iconSizeSmall = 14.dp
 val iconSizeMedium = 20.dp
+val iconSizeMediumLarge = 32.dp
 val iconSizeLarge = 44.dp
 val iconButtonSize = 56.dp
 val avatarSize = 72.dp

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.ListItemCard
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
@@ -29,6 +28,7 @@ import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedCR
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.component.dnd.toIcon
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.iconSizeMediumLarge
 import com.cyrillrx.rpg.core.presentation.theme.iconSizeSmall
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
@@ -41,8 +41,8 @@ import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.value_armor_class
 import rpg_companion.composeapp.generated.resources.value_hit_points
 
-private val typeIconSize = 36.dp
-private val typeIconPadding = 8.dp
+private val typeIconSize = iconSizeMediumLarge
+private val typeIconPadding = spacingCommon
 
 @Composable
 fun MonsterListItem(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/IconLabelButton.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/IconLabelButton.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.iconCardMaxHeight
+import com.cyrillrx.rpg.core.presentation.theme.iconSizeMediumLarge
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -48,7 +49,7 @@ fun IconLabelButton(
                 tint = MaterialTheme.colorScheme.primary,
                 contentDescription = label,
                 modifier = Modifier
-                    .size(32.dp)
+                    .size(iconSizeMediumLarge)
                     .padding(bottom = spacingSmall),
             )
             Text(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/EmptyListLayout.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/EmptyListLayout.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -38,13 +39,13 @@ fun EmptyListLayout(
             modifier = Modifier.size(72.dp),
             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(spacingCommon))
         Text(
             text = message,
             color = MaterialTheme.colorScheme.onBackground,
             style = MaterialTheme.typography.bodyLarge,
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(spacingCommon))
         Button(onClick = onBtnClicked) {
             Text(text = btnText)
         }


### PR DESCRIPTION
## 📝 Description

Replaces hardcoded `.dp` values with `Dimen.kt` tokens, per the "never hardcode dp; use Dimen.kt constants" convention.

**Changes:**
- **`Dimen.kt`**: add `iconSizeMediumLarge = 32.dp`, on the 8dp grid, between `iconSizeMedium` (20dp) and `iconSizeLarge` (44dp). Shared by the previously off-scale icon sizes.
- **`IconLabelButton.kt`**: icon size `32.dp` → the shared token (same value, no visual change).
- **`MonsterListItem.kt`**: back the type icon with `iconSizeMediumLarge` and pad its tinted box with `spacingCommon` so the badge grows to align with the three-line content (box **52dp → 64dp**). Visible change, hence `feat`.
- **`EmptyListLayout.kt`**: the two `16.dp` spacer heights → `spacingCommon` (no visual change).

Left as-is: the empty-state illustration icon (`72.dp`, a one-off decorative size), responsive width constraints, and preview-only widths.

## 🖼️ Media

Only the monster list badge changes: its tinted box now matches the row's three-line content height (52dp → 64dp). 

<img width="1032" height="1408" alt="image" src="https://github.com/user-attachments/assets/61feceee-7cdb-4eff-9627-47ff945aae26" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
