### PR TITLE
feat(theme): define an explicit typography scale

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/CreateCampaignScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/create/CreateCampaignScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cyrillrx.rpg.campaign.common.LocalizedRuleSet
 import com.cyrillrx.rpg.campaign.common.getMessage
@@ -121,8 +120,7 @@ fun CreateCampaignScreen(
             ) {
                 Text(
                     text = stringResource(Res.string.label_campaign_rule_set),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontSize = 16.sp,
+                    style = MaterialTheme.typography.bodyLarge,
                 )
 
                 ChooseRuleSetButton(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListItem.kt
@@ -63,7 +63,6 @@ fun CharacterListItem(
                 Text(
                     text = primaryText,
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Type.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Type.kt
@@ -1,5 +1,26 @@
 package com.cyrillrx.rpg.core.presentation.theme
 
 import androidx.compose.material3.Typography
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 
-val Typography = Typography()
+private val default = Typography()
+
+/**
+ * App type scale, built on the Material 3 defaults (default font family).
+ * The `title*` roles carry their own weight/size so components no longer
+ * re-specify `fontSize`/`fontWeight` inline.
+ */
+val Typography = default.copy(
+    titleLarge = default.titleLarge.copy(
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+    ),
+    titleMedium = default.titleMedium.copy(
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Bold,
+    ),
+    titleSmall = default.titleSmall.copy(
+        fontWeight = FontWeight.Bold,
+    ),
+)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MainStatLayout.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MainStatLayout.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.core.presentation.LocalDistanceUnit
 import com.cyrillrx.rpg.core.presentation.component.dnd.getSubtitle
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
@@ -31,12 +30,7 @@ fun MainStatLayout(
     Column(modifier) {
         Text(
             buildAnnotatedString {
-                withStyle(
-                    SpanStyle(
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 18.sp,
-                    ),
-                ) {
+                withStyle(MaterialTheme.typography.titleMedium.toSpanStyle()) {
                     append(monster.getSubtitle())
                 }
             },

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -85,7 +85,6 @@ fun MonsterListItem(
                 Text(
                     text = translation.name,
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemCard.kt
@@ -13,8 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.MarkdownText
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
@@ -70,7 +68,7 @@ internal fun MagicalItemCardHeader(magicalItem: MagicalItem) {
     val color = magicalItem.getColor()
     Text(
         text = translation.name,
-        style = MaterialTheme.typography.titleLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.Bold),
+        style = MaterialTheme.typography.titleLarge,
         color = MaterialTheme.colorScheme.onPrimary,
         modifier = Modifier
             .fillMaxWidth()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListItem.kt
@@ -45,7 +45,6 @@ fun MagicalItemListItem(
                 Text(
                     text = translation.name,
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.sp
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.MarkdownText
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
@@ -75,7 +74,7 @@ internal fun SpellCardHeader(spell: Spell) {
     val spellColor = spell.getColor()
     Text(
         text = translation.name,
-        style = MaterialTheme.typography.titleLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.Bold),
+        style = MaterialTheme.typography.titleLarge,
         textAlign = TextAlign.Center,
         modifier = Modifier
             .fillMaxWidth()
@@ -140,7 +139,7 @@ private fun SpellGridItem(label: String, value: String, spellColor: Color) {
     Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         Text(
             text = label,
-            style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp, fontWeight = FontWeight.Bold),
+            style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
             maxLines = 1,
             color = spellColor,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListItem.kt
@@ -52,7 +52,6 @@ fun SpellListItem(
                 Text(
                     text = translation.name,
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 


### PR DESCRIPTION
## 📝 Description

First step of the styles/theme rework: give the app an **owned typography scale** instead of the unmodified Material 3 default, and stop components from overriding `fontSize`/`fontWeight` inline.

**Approach:** keep the default font family; only rework sizes/weights/roles. `title*` roles now carry their own weight/size so components use the role directly.

**Changes:**
- **`Type.kt`**: explicit `Typography` built on the Material 3 defaults, overriding the title roles — `titleLarge` 22→**20/Bold**, `titleMedium` 16→**18/Bold**, `titleSmall` 14/Medium→**14/Bold**. This is where the visual change lives (section/filter titles and title-role text app-wide).
- **Absorb the 5 inline `fontSize` overrides**: spell/item card headers → `titleLarge`; spell grid label → `titleMedium`; monster subtitle span → `titleMedium.toSpanStyle()`; campaign rule-set label → `bodyLarge` (16sp). No visual change (roles now carry the values).
- **Drop redundant `fontWeight = Bold`** on the four list-item titles (the `titleSmall` role is bold now).

**Out of scope (later phases):** body-level emphasis `fontWeight = Bold` (stat labels, abilities, tables) left inline; the 3 detail views (spell/item/monster) are slated for a full visual rework that will build on this scale; colors/shapes review; custom font.

Impact to review (role census): `titleLarge` ×11, `titleSmall` ×12, `titleMedium` ×4.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
