### PR TITLE
fix(spells): add legacy FR name to Greater Invisibility

### DIFF
--- a/data/compendium/spells.json
+++ b/data/compendium/spells.json
@@ -6352,7 +6352,7 @@
         "description": "A creature you touch has the Invisible condition until the spell ends."
       },
       "fr": {
-        "name": "Invisibilité suprême",
+        "name": "Invisibilité supérieure / suprême",
         "castingTime": "Action",
         "range": "Contact",
         "duration": "Concentration, jusqu'à 1 minute",

--- a/data/compendium/spells/greater-invisibility.yaml
+++ b/data/compendium/spells/greater-invisibility.yaml
@@ -22,7 +22,7 @@ translations:
     description: |-
       A creature you touch has the Invisible condition until the spell ends.
   fr:
-    name: Invisibilité suprême
+    name: Invisibilité supérieure / suprême
     castingTime: Action
     range: Contact
     duration: Concentration, jusqu'à 1 minute

--- a/docs/data/srd-fr-en-spell.md
+++ b/docs/data/srd-fr-en-spell.md
@@ -183,7 +183,7 @@ English key is the slugified EN name used as `id` in `data/compendium/spells/*.y
 | goodberry                          | Goodberry                          | Baies nourricières                        |
 | grasping-vine                      | Grasping Vine                      | Liane avide                               |
 | grease                             | Grease                             | Graisse                                   |
-| greater-invisibility               | Greater Invisibility               | Invisibilité suprême                      |
+| greater-invisibility               | Greater Invisibility               | Invisibilité supérieure / suprême         |
 | greater-restoration                | Greater Restoration                | Restauration suprême                      |
 | guardian-of-faith                  | Guardian of Faith                  | Gardien de la foi                         |
 | guards-and-wards                   | Guards and Wards                   | Protections et sceaux                     |


### PR DESCRIPTION
## 📝 Description

The French name of *Greater Invisibility* changed from **"Invisibilité supérieure"** (D&D 2014) to **"Invisibilité suprême"** (D&D 2024). As a result, searching for the legacy name returned no results.

This PR shows both names as **"Invisibilité supérieure / suprême"**, following the existing compendium convention for renamed entities (e.g. `Ours-hibou / Hibours`, `Selle du cavalier / du hussard`) — legacy name first, current name second. The spell can now be found under either name.

Changes:
- `data/compendium/spells/greater-invisibility.yaml` — updated `translations.fr.name`
- `docs/data/srd-fr-en-spell.md` — updated the EN↔FR reference table (row 186)
- `data/compendium/spells.json` — regenerated via `build_compendium.py`

> Note: the spell search remains accent-sensitive (`SpellFilter.kt` uses `contains(ignoreCase = true)` without Unicode normalization), so typing without accents still won't match. That is a separate concern, not addressed here.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
