### PR TITLE
refactor(theme): introduce a shape scale

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Shape.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/Shape.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
 val Shapes = Shapes(
-    small = RoundedCornerShape(16.dp),
+    small = RoundedCornerShape(8.dp),
     medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(24.dp),
 )

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.Shield
@@ -65,7 +64,7 @@ fun MonsterListItem(
                     .size(typeIconSize + typeIconPadding * 2)
                     .background(
                         color = typeColor.copy(alpha = 0.12f),
-                        shape = RoundedCornerShape(spacingMedium),
+                        shape = MaterialTheme.shapes.small,
                     ),
             ) {
                 Icon(


### PR DESCRIPTION
## 📝 Description

Gives the theme's shapes a real scale instead of one uniform radius, and routes the last inline shape that fits the scale through the theme.

**Changes:**
- **`Shape.kt`**: `small` / `medium` / `large` were all `16.dp`; now `8` / `16` / `24`.
- **`MonsterListItem.kt`**: the type badge used an inline `RoundedCornerShape(spacingMedium)` (8dp) → `MaterialTheme.shapes.small` (also 8dp).

Cards keep `shapes.medium` (16dp) → **no visual change**. Intentional off-scale shapes are left inline: the pill search bar (`RoundedCornerShape(50)`) and the circular avatar (`CircleShape`). `refactor` — rendered output is unchanged.

## 🖼️ Media

No visual change (the routed badge keeps its 8dp radius).

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
