### PR TITLE
ui(creature): color the monster type badge with theme roles

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/list/CampaignListScreen.kt
@@ -82,7 +82,7 @@ fun CampaignListScreen(
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    tint = MaterialTheme.colorScheme.onPrimary,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
                     contentDescription = "Create campaign",
                 )
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterHeader.kt
@@ -148,9 +148,9 @@ private fun ClassIconBox(clazz: Character.Class, onClick: () -> Unit) {
     val iconState by produceState<ClassIconState>(ClassIconState.Loading, clazz) {
         value = resolveClassIconState(clazz) { Res.readBytes(it) }
     }
-    val iconColor = MaterialTheme.colorScheme.primary
+    val iconColor = MaterialTheme.colorScheme.onPrimaryContainer
     val backgroundColor = MaterialTheme.colorScheme.primaryContainer
-    val borderColor = MaterialTheme.colorScheme.primary
+    val borderColor = MaterialTheme.colorScheme.onPrimaryContainer
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MonsterFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/MonsterFormatExt.kt
@@ -15,9 +15,7 @@ import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Water
 import androidx.compose.material.icons.filled.Whatshot
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.creature.domain.Monster
 import org.jetbrains.compose.resources.stringResource
@@ -80,11 +78,6 @@ fun Monster.Type.toIcon(): ImageVector = when (this) {
     Monster.Type.SWARM -> Icons.Filled.Grain
     Monster.Type.UNDEAD -> Icons.Filled.Dangerous
     Monster.Type.UNKNOWN -> Icons.Filled.QuestionMark
-}
-
-@Composable
-fun Monster.Type.getColor(): Color = when (this) {
-    else -> MaterialTheme.colorScheme.primary
 }
 
 @Composable

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/AppPalette.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/theme/AppPalette.kt
@@ -20,7 +20,9 @@ private val PurpleLightScheme = lightColorScheme(
     primary = Color(0xFF512DA8),
     onPrimary = Color(0xFFFFFFFF),
     primaryContainer = Color(0xFFE9DDFF),
-    onPrimaryContainer = Color(0xFF21005E),
+    // Deliberately the `primary` tone rather than the high-contrast M3 default, so a
+    // primary-hued icon reads as tonal on `primaryContainer` badges (~7:1 contrast here).
+    onPrimaryContainer = Color(0xFF512DA8),
     inversePrimary = Color(0xFFD0BCFF),
     secondary = Color(0xFF625B71),
     onSecondary = Color(0xFFFFFFFF),
@@ -57,7 +59,9 @@ private val PurpleDarkScheme = darkColorScheme(
     primary = Color(0xFFB69DF8),
     onPrimary = Color(0xFF381E72),
     primaryContainer = Color(0xFF4F378A),
-    onPrimaryContainer = Color(0xFFE9DDFF),
+    // Deliberately the `primary` tone rather than the high-contrast M3 default, so a
+    // primary-hued icon reads as tonal on `primaryContainer` badges (~4:1 contrast here).
+    onPrimaryContainer = Color(0xFFB69DF8),
     inversePrimary = Color(0xFF512DA8),
     secondary = Color(0xFFD3C1EC),
     onSecondary = Color(0xFF382C4B),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -68,7 +68,7 @@ fun MonsterListItem(
                 Icon(
                     imageVector = monsterType.toIcon(),
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
                     modifier = Modifier.size(typeIconSize),
                 )
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListItem.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.AppCard
-import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedCR
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.component.dnd.toIcon
@@ -51,7 +50,6 @@ fun MonsterListItem(
 ) {
     val translation = monster.resolveTranslation(currentLocale())
     val monsterType = monster.getDisplayType()
-    val typeColor = monsterType.getColor()
 
     AppCard(onClick = onClick, modifier = modifier) {
         Row(
@@ -63,14 +61,14 @@ fun MonsterListItem(
                 modifier = Modifier
                     .size(typeIconSize + typeIconPadding * 2)
                     .background(
-                        color = typeColor.copy(alpha = 0.12f),
+                        color = MaterialTheme.colorScheme.primaryContainer,
                         shape = MaterialTheme.shapes.small,
                     ),
             ) {
                 Icon(
                     imageVector = monsterType.toIcon(),
                     contentDescription = null,
-                    tint = typeColor,
+                    tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(typeIconSize),
                 )
             }
@@ -143,7 +141,7 @@ fun MonsterListItem(
                 text = monster.toFormattedCR(),
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
-                color = typeColor,
+                color = MaterialTheme.colorScheme.primary,
             )
         }
     }


### PR DESCRIPTION
## 📝 Description

Routes content placed on `primaryContainer` surfaces through the semantically correct `onPrimaryContainer` role, and drops the `Monster.Type.getColor()` placeholder.

**Theme:**
- **`AppPalette.kt`**: set `onPrimaryContainer` to the `primary` tone in both Purple schemes (`#512DA8` light / `#B69DF8` dark). This is a deliberate per-palette value (not the high-contrast M3 default) so a primary-hued icon reads as tonal on `primaryContainer` badges. Contrast verified: ~7:1 (light) / ~4:1 (dark), well above the 3:1 threshold for icons/graphical content.

**Components (content on `primaryContainer` → `onPrimaryContainer`):**
- **`MonsterListItem.kt`**: the type badge background uses `primaryContainer`; its icon now uses `onPrimaryContainer`. The challenge-rating text stays `primary` (it sits on the card surface, not on the container).
- **`CharacterHeader.kt`** (`ClassIconBox`): the class avatar icon and border now use `onPrimaryContainer`.
- **`CampaignListScreen.kt`**: the FAB icon tint was `onPrimary` (broken contrast on a `primaryContainer` FAB) and is now `onPrimaryContainer`.

**Cleanup:**
- **`MonsterFormatExt.kt`**: remove `Monster.Type.getColor()` (a placeholder that always returned `primary`) and its now-unused imports.

Because `onPrimaryContainer` equals the `primary` tone in the Purple palette, the badge/avatar rendering is unchanged while the role is now correct per-palette. The FAB icon changes from the primary-container fill's `onPrimary` (poor contrast) to `onPrimaryContainer`.

## 🖼️ Media

Monster list badge background uses `primaryContainer`.

<img width="1176" height="414" alt="image" src="https://github.com/user-attachments/assets/5510db78-dc89-4a15-8538-83e1dba5a146" />

<img width="1166" height="408" alt="image" src="https://github.com/user-attachments/assets/b3fa5342-3b43-4eef-b31a-795a6af1a7e1" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed