### PR TITLE
fix(home): harmonize list and compendium item spacing

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/character/presentation/component/CharacterListScreen.kt
@@ -34,7 +34,6 @@ import com.cyrillrx.rpg.core.presentation.component.SwipeToDelete
 import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import org.jetbrains.compose.resources.getString
@@ -156,7 +155,7 @@ private fun CharacterList(
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(spacingMedium),
-        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
     ) {
         items(characters, key = { it.id }) { character ->
             SwipeToDelete(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterListScreen.kt
@@ -29,7 +29,6 @@ import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
 import com.cyrillrx.rpg.core.presentation.component.SwipeToAdd
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.creature.data.SampleMonsterRepository
 import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.presentation.MonsterAddToListProvider
@@ -167,7 +166,7 @@ private fun MonsterList(
         modifier = Modifier.fillMaxSize(),
         state = listState,
         contentPadding = PaddingValues(spacingMedium),
-        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
     ) {
         items(monsters, key = { it.id }) { creature ->
             SwipeToAdd(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/home/presentation/HomeScreen.kt
@@ -141,7 +141,7 @@ private fun CompendiumSection(router: HomeRouter, modifier: Modifier = Modifier)
     ) {
         SectionHeader(title = stringResource(Res.string.section_compendium))
         Row(
-            horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
             modifier = Modifier.fillMaxWidth(),
         ) {
             IconLabelButton(
@@ -174,7 +174,7 @@ private fun MyListsSection(router: HomeRouter, modifier: Modifier = Modifier) {
     ) {
         SectionHeader(title = stringResource(Res.string.section_my_lists))
         Row(
-            horizontalArrangement = Arrangement.spacedBy(spacingCommon),
+            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
             modifier = Modifier.fillMaxWidth(),
         ) {
             IconLabelButton(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemListScreen.kt
@@ -29,7 +29,6 @@ import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
 import com.cyrillrx.rpg.core.presentation.component.SwipeToAdd
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemAddToListProvider
@@ -167,7 +166,7 @@ private fun MagicalItemList(
         modifier = Modifier.fillMaxSize(),
         state = listState,
         contentPadding = PaddingValues(spacingMedium),
-        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
     ) {
         items(magicalItems, key = { it.id }) { item ->
             SwipeToAdd(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -30,7 +30,6 @@ import com.cyrillrx.rpg.core.presentation.component.SearchBarWithBack
 import com.cyrillrx.rpg.core.presentation.component.SwipeToAdd
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.presentation.SpellAddToListProvider
@@ -171,7 +170,7 @@ private fun SpellList(
         modifier = Modifier.fillMaxSize(),
         state = searchResultsListState,
         contentPadding = PaddingValues(spacingMedium),
-        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
     ) {
         items(spells, key = { it.id }) { spell ->
             SwipeToAdd(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/ListDetailScreen.kt
@@ -37,7 +37,6 @@ import com.cyrillrx.rpg.core.presentation.component.dialog.RenameListDialog
 import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
 import com.cyrillrx.rpg.spell.presentation.SpellItemProvider
 import com.cyrillrx.rpg.userlist.presentation.ListDetailState
@@ -175,7 +174,7 @@ private fun <T> EntityDetailList(
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(spacingMedium),
-        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
     ) {
         items(items, key = { uiProvider.getId(it) }) { item ->
             SwipeToDelete(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/presentation/component/UserListsScreen.kt
@@ -36,7 +36,6 @@ import com.cyrillrx.rpg.core.presentation.component.dialog.CreateListDialog
 import com.cyrillrx.rpg.core.presentation.component.rememberOptimisticDeleteHandler
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.presentation.UserListsState
@@ -171,7 +170,7 @@ private fun UserLists(
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(spacingMedium),
-        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
     ) {
         items(lists, key = { it.id }) { list ->
             SwipeToDelete(


### PR DESCRIPTION
## 📝 Description

The home screen showed inconsistent spacing: compendium/my-lists button rows used `spacingCommon` (16.dp) while the character action buttons used `spacingMedium` (8.dp), and the list screens used `spacingSmall` (4.dp) between items — tighter than the home preview.

This PR unifies the spacing on a single rhythm of **8.dp** (`spacingMedium`):

- **Home** — `CompendiumSection` and `MyListsSection` button rows: `spacingCommon` (16.dp) → `spacingMedium` (8.dp), matching the character action buttons.
- **List screens** — inter-item spacing on character, spell, magical item, monster, user lists and list detail screens: `spacingSmall` (4.dp) → `spacingMedium` (8.dp).

Result: all button rows and all list items across the app share the same 8.dp spacing.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed