### PR TITLE
feat(spell): filter spells by their V/S/M components

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -45,6 +45,9 @@
     <string name="formatted_spell_duration">Durée :</string>
     <string name="spell_ritual">Rituel</string>
     <string name="spell_concentration">Concentration</string>
+    <string name="component_verbal">Verbale</string>
+    <string name="component_somatic">Somatique</string>
+    <string name="component_material">Matérielle</string>
 
     <!-- Spell Level -->
     <string name="spell_level_cantrip">Tour de magie</string>
@@ -73,5 +76,6 @@
     <string name="label_filter_level">Niveau</string>
     <string name="label_filter_class">Classe</string>
     <string name="label_filter_school">Ecole</string>
+    <string name="label_filter_components">Composantes</string>
 
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values-fr/strings_dnd.xml
@@ -77,5 +77,7 @@
     <string name="label_filter_class">Classe</string>
     <string name="label_filter_school">Ecole</string>
     <string name="label_filter_components">Composantes</string>
+    <string name="filter_component_required">Requise</string>
+    <string name="filter_component_excluded">Exclue</string>
 
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -45,6 +45,9 @@
     <string name="formatted_spell_duration">Duration:</string>
     <string name="spell_ritual">Ritual</string>
     <string name="spell_concentration">Concentration</string>
+    <string name="component_verbal">Verbal</string>
+    <string name="component_somatic">Somatic</string>
+    <string name="component_material">Material</string>
 
     <!-- Spell Level -->
     <string name="spell_level_cantrip">Cantrip</string>
@@ -73,5 +76,6 @@
     <string name="label_filter_level">Level</string>
     <string name="label_filter_class">Class</string>
     <string name="label_filter_school">School</string>
+    <string name="label_filter_components">Components</string>
 
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/composeResources/values/strings_dnd.xml
@@ -77,5 +77,7 @@
     <string name="label_filter_class">Class</string>
     <string name="label_filter_school">School</string>
     <string name="label_filter_components">Components</string>
+    <string name="filter_component_required">Required</string>
+    <string name="filter_component_excluded">Excluded</string>
 
 </resources>

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
@@ -72,11 +72,11 @@ private fun Spell.Components.toFormattedString(): String = buildList {
 }.joinToString(", ")
 
 @Composable
-fun Spell.Component.toFormattedString(): String {
+fun Spell.ComponentType.toFormattedString(): String {
     val stringRes = when (this) {
-        Spell.Component.VERBAL -> Res.string.component_verbal
-        Spell.Component.SOMATIC -> Res.string.component_somatic
-        Spell.Component.MATERIAL -> Res.string.component_material
+        Spell.ComponentType.VERBAL -> Res.string.component_verbal
+        Spell.ComponentType.SOMATIC -> Res.string.component_somatic
+        Spell.ComponentType.MATERIAL -> Res.string.component_material
     }
     return stringResource(stringRes)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/dnd/SpellFormatExt.kt
@@ -23,6 +23,9 @@ import com.cyrillrx.rpg.core.presentation.theme.SchoolTransmutation
 import com.cyrillrx.rpg.spell.domain.Spell
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.component_material
+import rpg_companion.composeapp.generated.resources.component_somatic
+import rpg_companion.composeapp.generated.resources.component_verbal
 import rpg_companion.composeapp.generated.resources.formatted_spell_school_level
 import rpg_companion.composeapp.generated.resources.school_abjuration
 import rpg_companion.composeapp.generated.resources.school_conjuration
@@ -67,6 +70,16 @@ private fun Spell.Components.toFormattedString(): String = buildList {
     if (somatic) add("S")
     if (material) add("M*")
 }.joinToString(", ")
+
+@Composable
+fun Spell.Component.toFormattedString(): String {
+    val stringRes = when (this) {
+        Spell.Component.VERBAL -> Res.string.component_verbal
+        Spell.Component.SOMATIC -> Res.string.component_somatic
+        Spell.Component.MATERIAL -> Res.string.component_material
+    }
+    return stringResource(stringRes)
+}
 
 @Composable
 fun Spell.getSchool(): String = school.toFormattedString()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -59,7 +59,7 @@ fun SpellCardCarouselScreen(
     onLevelToggled: (Int) -> Unit,
     onSchoolToggled: (Spell.School) -> Unit,
     onClassToggled: (Character.Class) -> Unit,
-    onComponentToggled: (Spell.Component) -> Unit,
+    onComponentToggled: (Spell.ComponentType) -> Unit,
     onResetFilters: () -> Unit,
 ) {
     var showFilterSheet by remember { mutableStateOf(false) }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellCardCarouselScreen.kt
@@ -45,6 +45,7 @@ fun SpellCardCarouselScreen(viewModel: SpellListViewModel, router: SpellRouter) 
         onLevelToggled = viewModel::onLevelToggled,
         onSchoolToggled = viewModel::onSchoolToggled,
         onClassToggled = viewModel::onClassToggled,
+        onComponentToggled = viewModel::onComponentToggled,
         onResetFilters = viewModel::onResetFilters,
     )
 }
@@ -58,6 +59,7 @@ fun SpellCardCarouselScreen(
     onLevelToggled: (Int) -> Unit,
     onSchoolToggled: (Spell.School) -> Unit,
     onClassToggled: (Character.Class) -> Unit,
+    onComponentToggled: (Spell.Component) -> Unit,
     onResetFilters: () -> Unit,
 ) {
     var showFilterSheet by remember { mutableStateOf(false) }
@@ -90,6 +92,7 @@ fun SpellCardCarouselScreen(
             onLevelToggled = onLevelToggled,
             onSchoolToggled = onSchoolToggled,
             onClassToggled = onClassToggled,
+            onComponentToggled = onComponentToggled,
             onResetFilters = onResetFilters,
             onDismiss = { showFilterSheet = false },
         )
@@ -130,7 +133,7 @@ private val stateWithSampleData = SpellListState(
 @Composable
 fun PreviewSpellCardCarouselScreenLight() {
     AppThemePreview(darkTheme = false) {
-        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
+        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -138,6 +141,6 @@ fun PreviewSpellCardCarouselScreenLight() {
 @Composable
 fun PreviewSpellCardCarouselScreenDark() {
     AppThemePreview(darkTheme = true) {
-        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {})
+        SpellCardCarouselScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -54,7 +54,7 @@ fun SpellFilterBottomSheet(
     onLevelToggled: (Int) -> Unit,
     onSchoolToggled: (Spell.School) -> Unit,
     onClassToggled: (Character.Class) -> Unit,
-    onComponentToggled: (Spell.Component) -> Unit,
+    onComponentToggled: (Spell.ComponentType) -> Unit,
     onResetFilters: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -142,7 +142,7 @@ fun SpellFilterBottomSheet(
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(spacingMedium),
             ) {
-                Spell.Component.entries.forEach { component ->
+                Spell.ComponentType.entries.forEach { component ->
                     ComponentFilterChip(
                         label = component.toFormattedString(),
                         state = filter.components[component],
@@ -204,8 +204,8 @@ private fun PreviewSpellFilterBottomSheetLight() {
         characterClasses = setOf(Character.Class.SORCERER),
         schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
         components = mapOf(
-            Spell.Component.SOMATIC to ComponentFilter.REQUIRED,
-            Spell.Component.MATERIAL to ComponentFilter.EXCLUDED,
+            Spell.ComponentType.SOMATIC to ComponentFilter.REQUIRED,
+            Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED,
         ),
     )
     AppThemePreview(darkTheme = false) {
@@ -221,8 +221,8 @@ private fun PreviewSpellFilterBottomSheetDark() {
         characterClasses = setOf(Character.Class.SORCERER),
         schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
         components = mapOf(
-            Spell.Component.SOMATIC to ComponentFilter.REQUIRED,
-            Spell.Component.MATERIAL to ComponentFilter.EXCLUDED,
+            Spell.ComponentType.SOMATIC to ComponentFilter.REQUIRED,
+            Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED,
         ),
     )
     AppThemePreview(darkTheme = true) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -33,7 +33,7 @@ import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.spell.domain.ComponentFilter
+import com.cyrillrx.rpg.spell.domain.ComponentFilterState
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import org.jetbrains.compose.resources.stringResource
@@ -149,14 +149,14 @@ private fun SchoolFilterSection(
 
 @Composable
 private fun ComponentFilterSection(
-    components: Map<Spell.ComponentType, ComponentFilter>,
+    components: Map<Spell.ComponentType, ComponentFilterState>,
     onComponentToggled: (Spell.ComponentType) -> Unit,
 ) {
     FilterSection(title = stringResource(Res.string.label_filter_components)) {
         Spell.ComponentType.entries.forEach { component ->
             ComponentFilterChip(
                 label = component.toFormattedString(),
-                state = components[component],
+                state = components[component] ?: ComponentFilterState.NONE,
                 onClick = { onComponentToggled(component) },
             )
         }
@@ -183,21 +183,21 @@ private fun FilterSection(
 @Composable
 private fun ComponentFilterChip(
     label: String,
-    state: ComponentFilter?,
+    state: ComponentFilterState,
     onClick: () -> Unit,
 ) {
     val leadingIcon: ImageVector? = when (state) {
-        ComponentFilter.REQUIRED -> Icons.Default.Check
-        ComponentFilter.EXCLUDED -> Icons.Default.Close
-        null -> null
+        ComponentFilterState.NONE -> null
+        ComponentFilterState.REQUIRED -> Icons.Default.Check
+        ComponentFilterState.EXCLUDED -> Icons.Default.Close
     }
     val iconContentDescription = when (state) {
-        ComponentFilter.REQUIRED -> stringResource(Res.string.filter_component_required)
-        ComponentFilter.EXCLUDED -> stringResource(Res.string.filter_component_excluded)
-        null -> null
+        ComponentFilterState.NONE -> null
+        ComponentFilterState.REQUIRED -> stringResource(Res.string.filter_component_required)
+        ComponentFilterState.EXCLUDED -> stringResource(Res.string.filter_component_excluded)
     }
     val colors = when (state) {
-        ComponentFilter.EXCLUDED -> FilterChipDefaults.filterChipColors(
+        ComponentFilterState.EXCLUDED -> FilterChipDefaults.filterChipColors(
             selectedContainerColor = MaterialTheme.colorScheme.errorContainer,
             selectedLabelColor = MaterialTheme.colorScheme.onErrorContainer,
             selectedLeadingIconColor = MaterialTheme.colorScheme.onErrorContainer,
@@ -205,7 +205,7 @@ private fun ComponentFilterChip(
         else -> FilterChipDefaults.filterChipColors()
     }
     FilterChip(
-        selected = state != null,
+        selected = state != ComponentFilterState.NONE,
         onClick = onClick,
         label = { Text(text = label) },
         leadingIcon = leadingIcon?.let { icon ->
@@ -229,8 +229,8 @@ private fun PreviewSpellFilterBottomSheetLight() {
         characterClasses = setOf(Character.Class.SORCERER),
         schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
         components = mapOf(
-            Spell.ComponentType.SOMATIC to ComponentFilter.REQUIRED,
-            Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED,
+            Spell.ComponentType.SOMATIC to ComponentFilterState.REQUIRED,
+            Spell.ComponentType.MATERIAL to ComponentFilterState.EXCLUDED,
         ),
     )
     AppThemePreview(darkTheme = false) {
@@ -246,8 +246,8 @@ private fun PreviewSpellFilterBottomSheetDark() {
         characterClasses = setOf(Character.Class.SORCERER),
         schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
         components = mapOf(
-            Spell.ComponentType.SOMATIC to ComponentFilter.REQUIRED,
-            Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED,
+            Spell.ComponentType.SOMATIC to ComponentFilterState.REQUIRED,
+            Spell.ComponentType.MATERIAL to ComponentFilterState.EXCLUDED,
         ),
     )
     AppThemePreview(darkTheme = true) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.FlowRowScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -47,7 +48,7 @@ import rpg_companion.composeapp.generated.resources.label_filter_level
 import rpg_companion.composeapp.generated.resources.label_filter_school
 import rpg_companion.composeapp.generated.resources.title_filter_spells
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SpellFilterBottomSheet(
     filter: SpellFilter,
@@ -69,89 +70,113 @@ fun SpellFilterBottomSheet(
                 .padding(bottom = spacingLarge),
             verticalArrangement = Arrangement.spacedBy(spacingCommon),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringResource(Res.string.title_filter_spells),
-                    style = MaterialTheme.typography.titleLarge,
-                )
-                TextButton(onClick = onResetFilters) {
-                    Text(text = stringResource(Res.string.btn_reset_all))
-                }
-            }
-
-            // Level
-            Text(
-                text = stringResource(Res.string.label_filter_level),
-                style = MaterialTheme.typography.titleSmall,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
-                (0..9).forEach { level ->
-                    FilterChip(
-                        selected = level in filter.levels,
-                        onClick = { onLevelToggled(level) },
-                        label = { Text(text = level.toString()) },
-                    )
-                }
-            }
-
-            // Class
-            Text(
-                text = stringResource(Res.string.label_filter_class),
-                style = MaterialTheme.typography.titleSmall,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
-                Character.Class.entries.filter { it != Character.Class.UNKNOWN }.forEach { characterClass ->
-                    FilterChip(
-                        selected = characterClass in filter.characterClasses,
-                        onClick = { onClassToggled(characterClass) },
-                        label = { Text(text = characterClass.toFormattedString()) },
-                    )
-                }
-            }
-
-            // School
-            Text(
-                text = stringResource(Res.string.label_filter_school),
-                style = MaterialTheme.typography.titleSmall,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
-                Spell.School.entries.forEach { school ->
-                    FilterChip(
-                        selected = school in filter.schools,
-                        onClick = { onSchoolToggled(school) },
-                        label = { Text(text = school.toFormattedString()) },
-                    )
-                }
-            }
-
-            // Components (tri-state: indifferent, required, excluded)
-            Text(
-                text = stringResource(Res.string.label_filter_components),
-                style = MaterialTheme.typography.titleSmall,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
-                Spell.ComponentType.entries.forEach { component ->
-                    ComponentFilterChip(
-                        label = component.toFormattedString(),
-                        state = filter.components[component],
-                        onClick = { onComponentToggled(component) },
-                    )
-                }
-            }
+            FilterSheetHeader(onResetFilters = onResetFilters)
+            LevelFilterSection(filter.levels, onLevelToggled)
+            ClassFilterSection(filter.characterClasses, onClassToggled)
+            SchoolFilterSection(filter.schools, onSchoolToggled)
+            ComponentFilterSection(filter.components, onComponentToggled)
         }
     }
+}
+
+@Composable
+private fun FilterSheetHeader(onResetFilters: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(Res.string.title_filter_spells),
+            style = MaterialTheme.typography.titleLarge,
+        )
+        TextButton(onClick = onResetFilters) {
+            Text(text = stringResource(Res.string.btn_reset_all))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LevelFilterSection(
+    selectedLevels: Set<Int>,
+    onLevelToggled: (Int) -> Unit,
+) {
+    FilterSection(title = stringResource(Res.string.label_filter_level)) {
+        (0..9).forEach { level ->
+            FilterChip(
+                selected = level in selectedLevels,
+                onClick = { onLevelToggled(level) },
+                label = { Text(text = level.toString()) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ClassFilterSection(
+    selectedClasses: Set<Character.Class>,
+    onClassToggled: (Character.Class) -> Unit,
+) {
+    FilterSection(title = stringResource(Res.string.label_filter_class)) {
+        Character.Class.entries.filter { it != Character.Class.UNKNOWN }.forEach { characterClass ->
+            FilterChip(
+                selected = characterClass in selectedClasses,
+                onClick = { onClassToggled(characterClass) },
+                label = { Text(text = characterClass.toFormattedString()) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SchoolFilterSection(
+    selectedSchools: Set<Spell.School>,
+    onSchoolToggled: (Spell.School) -> Unit,
+) {
+    FilterSection(title = stringResource(Res.string.label_filter_school)) {
+        Spell.School.entries.forEach { school ->
+            FilterChip(
+                selected = school in selectedSchools,
+                onClick = { onSchoolToggled(school) },
+                label = { Text(text = school.toFormattedString()) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ComponentFilterSection(
+    components: Map<Spell.ComponentType, ComponentFilter>,
+    onComponentToggled: (Spell.ComponentType) -> Unit,
+) {
+    FilterSection(title = stringResource(Res.string.label_filter_components)) {
+        Spell.ComponentType.entries.forEach { component ->
+            ComponentFilterChip(
+                label = component.toFormattedString(),
+                state = components[component],
+                onClick = { onComponentToggled(component) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FilterSection(
+    title: String,
+    content: @Composable FlowRowScope.() -> Unit,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+    )
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+        content = content,
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -39,6 +39,8 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_reset_all
+import rpg_companion.composeapp.generated.resources.filter_component_excluded
+import rpg_companion.composeapp.generated.resources.filter_component_required
 import rpg_companion.composeapp.generated.resources.label_filter_class
 import rpg_companion.composeapp.generated.resources.label_filter_components
 import rpg_companion.composeapp.generated.resources.label_filter_level
@@ -164,6 +166,11 @@ private fun ComponentFilterChip(
         ComponentFilter.EXCLUDED -> Icons.Default.Close
         null -> null
     }
+    val iconContentDescription = when (state) {
+        ComponentFilter.REQUIRED -> stringResource(Res.string.filter_component_required)
+        ComponentFilter.EXCLUDED -> stringResource(Res.string.filter_component_excluded)
+        null -> null
+    }
     val colors = when (state) {
         ComponentFilter.EXCLUDED -> FilterChipDefaults.filterChipColors(
             selectedContainerColor = MaterialTheme.colorScheme.errorContainer,
@@ -180,7 +187,7 @@ private fun ComponentFilterChip(
             {
                 Icon(
                     imageVector = icon,
-                    contentDescription = null,
+                    contentDescription = iconContentDescription,
                     modifier = Modifier.size(FilterChipDefaults.IconSize),
                 )
             }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -7,10 +7,16 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -19,12 +25,14 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.spell.domain.ComponentFilter
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import org.jetbrains.compose.resources.stringResource
@@ -32,6 +40,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_reset_all
 import rpg_companion.composeapp.generated.resources.label_filter_class
+import rpg_companion.composeapp.generated.resources.label_filter_components
 import rpg_companion.composeapp.generated.resources.label_filter_level
 import rpg_companion.composeapp.generated.resources.label_filter_school
 import rpg_companion.composeapp.generated.resources.title_filter_spells
@@ -43,6 +52,7 @@ fun SpellFilterBottomSheet(
     onLevelToggled: (Int) -> Unit,
     onSchoolToggled: (Spell.School) -> Unit,
     onClassToggled: (Character.Class) -> Unit,
+    onComponentToggled: (Spell.Component) -> Unit,
     onResetFilters: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -121,8 +131,62 @@ fun SpellFilterBottomSheet(
                     )
                 }
             }
+
+            // Components (tri-state: indifferent, required, excluded)
+            Text(
+                text = stringResource(Res.string.label_filter_components),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            ) {
+                Spell.Component.entries.forEach { component ->
+                    ComponentFilterChip(
+                        label = component.toFormattedString(),
+                        state = filter.components[component],
+                        onClick = { onComponentToggled(component) },
+                    )
+                }
+            }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ComponentFilterChip(
+    label: String,
+    state: ComponentFilter?,
+    onClick: () -> Unit,
+) {
+    val leadingIcon: ImageVector? = when (state) {
+        ComponentFilter.REQUIRED -> Icons.Default.Check
+        ComponentFilter.EXCLUDED -> Icons.Default.Close
+        null -> null
+    }
+    val colors = when (state) {
+        ComponentFilter.EXCLUDED -> FilterChipDefaults.filterChipColors(
+            selectedContainerColor = MaterialTheme.colorScheme.errorContainer,
+            selectedLabelColor = MaterialTheme.colorScheme.onErrorContainer,
+            selectedLeadingIconColor = MaterialTheme.colorScheme.onErrorContainer,
+        )
+        else -> FilterChipDefaults.filterChipColors()
+    }
+    FilterChip(
+        selected = state != null,
+        onClick = onClick,
+        label = { Text(text = label) },
+        leadingIcon = leadingIcon?.let { icon ->
+            {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                )
+            }
+        },
+        colors = colors,
+    )
 }
 
 @Preview
@@ -132,9 +196,13 @@ private fun PreviewSpellFilterBottomSheetLight() {
         levels = setOf(0, 3),
         characterClasses = setOf(Character.Class.SORCERER),
         schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
+        components = mapOf(
+            Spell.Component.SOMATIC to ComponentFilter.REQUIRED,
+            Spell.Component.MATERIAL to ComponentFilter.EXCLUDED,
+        ),
     )
     AppThemePreview(darkTheme = false) {
-        SpellFilterBottomSheet(sampleFilter, {}, {}, {}, {}, {})
+        SpellFilterBottomSheet(sampleFilter, {}, {}, {}, {}, {}, {})
     }
 }
 
@@ -145,8 +213,12 @@ private fun PreviewSpellFilterBottomSheetDark() {
         levels = setOf(0, 3),
         characterClasses = setOf(Character.Class.SORCERER),
         schools = setOf(Spell.School.ABJURATION, Spell.School.EVOCATION),
+        components = mapOf(
+            Spell.Component.SOMATIC to ComponentFilter.REQUIRED,
+            Spell.Component.MATERIAL to ComponentFilter.EXCLUDED,
+        ),
     )
     AppThemePreview(darkTheme = true) {
-        SpellFilterBottomSheet(sampleFilter, {}, {}, {}, {}, {})
+        SpellFilterBottomSheet(sampleFilter, {}, {}, {}, {}, {}, {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -80,7 +80,7 @@ fun SpellListScreen(
     onLevelToggled: (Int) -> Unit,
     onSchoolToggled: (Spell.School) -> Unit,
     onClassToggled: (Character.Class) -> Unit,
-    onComponentToggled: (Spell.Component) -> Unit,
+    onComponentToggled: (Spell.ComponentType) -> Unit,
     onResetFilters: () -> Unit,
     addToListProvider: AddToListProvider<Spell>,
     initialScrollPosition: ScrollPosition = ScrollPosition(),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellListScreen.kt
@@ -62,6 +62,7 @@ fun SpellListScreen(
         onLevelToggled = viewModel::onLevelToggled,
         onSchoolToggled = viewModel::onSchoolToggled,
         onClassToggled = viewModel::onClassToggled,
+        onComponentToggled = viewModel::onComponentToggled,
         onResetFilters = viewModel::onResetFilters,
         addToListProvider = addToListProvider,
         initialScrollPosition = viewModel.savedScrollPosition,
@@ -79,6 +80,7 @@ fun SpellListScreen(
     onLevelToggled: (Int) -> Unit,
     onSchoolToggled: (Spell.School) -> Unit,
     onClassToggled: (Character.Class) -> Unit,
+    onComponentToggled: (Spell.Component) -> Unit,
     onResetFilters: () -> Unit,
     addToListProvider: AddToListProvider<Spell>,
     initialScrollPosition: ScrollPosition = ScrollPosition(),
@@ -128,6 +130,7 @@ fun SpellListScreen(
             onLevelToggled = onLevelToggled,
             onSchoolToggled = onSchoolToggled,
             onClassToggled = onClassToggled,
+            onComponentToggled = onComponentToggled,
             onResetFilters = onResetFilters,
             onDismiss = { showFilterSheet = false },
         )
@@ -209,5 +212,5 @@ private fun SpellListPeekScreenPreview() {
     )
     val bottomSheetProvider = SpellAddToListProvider(spellRepository, userListRepository)
 
-    SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {}, bottomSheetProvider)
+    SpellListScreen(stateWithSampleData, {}, {}, {}, {}, {}, {}, {}, {}, bottomSheetProvider)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
-import com.cyrillrx.rpg.spell.domain.ComponentFilterState
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
+import com.cyrillrx.rpg.spell.domain.cycled
 import com.cyrillrx.rpg.spell.presentation.SpellListState
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,13 +58,6 @@ class SpellListViewModel(
         state.update { it.copy(filter = transform(it.filter)) }
         scrollToTop()
         refreshData()
-    }
-
-    private fun Map<Spell.ComponentType, ComponentFilterState>.cycled(
-        component: Spell.ComponentType,
-    ): Map<Spell.ComponentType, ComponentFilterState> {
-        val nextState = (this[component] ?: ComponentFilterState.NONE).next()
-        return if (nextState == ComponentFilterState.NONE) this - component else this + (component to nextState)
     }
 
     private fun refreshData() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -46,7 +46,7 @@ class SpellListViewModel(
         updateFilter { it.copy(characterClasses = it.characterClasses.toggled(characterClass)) }
     }
 
-    fun onComponentToggled(component: Spell.Component) {
+    fun onComponentToggled(component: Spell.ComponentType) {
         updateFilter { it.copy(components = it.components.cycled(component)) }
     }
 
@@ -60,9 +60,9 @@ class SpellListViewModel(
         refreshData()
     }
 
-    private fun Map<Spell.Component, ComponentFilter>.cycled(
-        component: Spell.Component,
-    ): Map<Spell.Component, ComponentFilter> {
+    private fun Map<Spell.ComponentType, ComponentFilter>.cycled(
+        component: Spell.ComponentType,
+    ): Map<Spell.ComponentType, ComponentFilter> {
         val next = when (this[component]) {
             null -> ComponentFilter.REQUIRED
             ComponentFilter.REQUIRED -> ComponentFilter.EXCLUDED

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
+import com.cyrillrx.rpg.spell.domain.ComponentFilter
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
@@ -45,6 +46,10 @@ class SpellListViewModel(
         updateFilter { it.copy(characterClasses = it.characterClasses.toggled(characterClass)) }
     }
 
+    fun onComponentToggled(component: Spell.Component) {
+        updateFilter { it.copy(components = it.components.cycled(component)) }
+    }
+
     fun onResetFilters() {
         updateFilter { SpellFilter(query = it.query) }
     }
@@ -53,6 +58,17 @@ class SpellListViewModel(
         state.update { it.copy(filter = transform(it.filter)) }
         scrollToTop()
         refreshData()
+    }
+
+    private fun Map<Spell.Component, ComponentFilter>.cycled(
+        component: Spell.Component,
+    ): Map<Spell.Component, ComponentFilter> {
+        val next = when (this[component]) {
+            null -> ComponentFilter.REQUIRED
+            ComponentFilter.REQUIRED -> ComponentFilter.EXCLUDED
+            ComponentFilter.EXCLUDED -> null
+        }
+        return if (next == null) this - component else this + (component to next)
     }
 
     private fun refreshData() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
-import com.cyrillrx.rpg.spell.domain.ComponentFilter
+import com.cyrillrx.rpg.spell.domain.ComponentFilterState
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
@@ -60,15 +60,11 @@ class SpellListViewModel(
         refreshData()
     }
 
-    private fun Map<Spell.ComponentType, ComponentFilter>.cycled(
+    private fun Map<Spell.ComponentType, ComponentFilterState>.cycled(
         component: Spell.ComponentType,
-    ): Map<Spell.ComponentType, ComponentFilter> {
-        val next = when (this[component]) {
-            null -> ComponentFilter.REQUIRED
-            ComponentFilter.REQUIRED -> ComponentFilter.EXCLUDED
-            ComponentFilter.EXCLUDED -> null
-        }
-        return if (next == null) this - component else this + (component to next)
+    ): Map<Spell.ComponentType, ComponentFilterState> {
+        val next = (this[component] ?: ComponentFilterState.NONE).next()
+        return if (next == ComponentFilterState.NONE) this - component else this + (component to next)
     }
 
     private fun refreshData() {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -63,8 +63,8 @@ class SpellListViewModel(
     private fun Map<Spell.ComponentType, ComponentFilterState>.cycled(
         component: Spell.ComponentType,
     ): Map<Spell.ComponentType, ComponentFilterState> {
-        val next = (this[component] ?: ComponentFilterState.NONE).next()
-        return if (next == ComponentFilterState.NONE) this - component else this + (component to next)
+        val nextState = (this[component] ?: ComponentFilterState.NONE).next()
+        return if (nextState == ComponentFilterState.NONE) this - component else this + (component to nextState)
     }
 
     private fun refreshData() {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/SampleSpellRepository.kt
@@ -104,7 +104,7 @@ class SampleSpellRepository : SpellRepository {
             ),
         )
 
-        private fun thunderwave() = Spell(
+        fun thunderwave() = Spell(
             id = "thunderwave",
             source = "srd_5.1",
             level = 1,
@@ -129,7 +129,7 @@ class SampleSpellRepository : SpellRepository {
             ),
         )
 
-        private fun counterspell() = Spell(
+        fun counterspell() = Spell(
             id = "counterspell",
             source = "srd_5.1",
             level = 3,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
@@ -38,6 +38,12 @@ class Spell(
         TRANSMUTATION,
     }
 
+    enum class Component {
+        VERBAL,
+        SOMATIC,
+        MATERIAL,
+    }
+
     @Serializable
     data class Components(
         val verbal: Boolean,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/Spell.kt
@@ -38,7 +38,7 @@ class Spell(
         TRANSMUTATION,
     }
 
-    enum class Component {
+    enum class ComponentType {
         VERBAL,
         SOMATIC,
         MATERIAL,

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -23,7 +23,8 @@ data class SpellFilter(
     val components: Map<Spell.ComponentType, ComponentFilterState> = emptyMap(),
 ) {
     val hasActiveFilters: Boolean =
-        schools.isNotEmpty() || characterClasses.isNotEmpty() || levels.isNotEmpty() || components.isNotEmpty()
+        schools.isNotEmpty() || characterClasses.isNotEmpty() || levels.isNotEmpty() ||
+            components.values.any { it != ComponentFilterState.NONE }
 }
 
 fun List<Spell>.applyFilter(filter: SpellFilter?): List<Spell> {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -2,13 +2,17 @@ package com.cyrillrx.rpg.spell.domain
 
 import com.cyrillrx.rpg.character.domain.Character
 
+enum class ComponentFilter { REQUIRED, EXCLUDED }
+
 data class SpellFilter(
     val query: String = "",
     val schools: Set<Spell.School> = emptySet(),
     val characterClasses: Set<Character.Class> = emptySet(),
     val levels: Set<Int> = emptySet(),
+    val components: Map<Spell.Component, ComponentFilter> = emptyMap(),
 ) {
-    val hasActiveFilters: Boolean = schools.isNotEmpty() || characterClasses.isNotEmpty() || levels.isNotEmpty()
+    val hasActiveFilters: Boolean =
+        schools.isNotEmpty() || characterClasses.isNotEmpty() || levels.isNotEmpty() || components.isNotEmpty()
 }
 
 fun List<Spell>.applyFilter(filter: SpellFilter?): List<Spell> {
@@ -20,7 +24,19 @@ internal fun Spell.matches(filter: SpellFilter): Boolean =
     (filter.schools.isEmpty() || school in filter.schools) &&
         (filter.characterClasses.isEmpty() || availableClasses.any { filter.characterClasses.contains(it) }) &&
         (filter.levels.isEmpty() || filter.levels.contains(level)) &&
+        filter.components.all { (component, state) ->
+            when (state) {
+                ComponentFilter.REQUIRED -> component.isPresentIn(components)
+                ComponentFilter.EXCLUDED -> !component.isPresentIn(components)
+            }
+        } &&
         (filter.query.isBlank() || matchesQuery(filter.query))
+
+private fun Spell.Component.isPresentIn(components: Spell.Components): Boolean = when (this) {
+    Spell.Component.VERBAL -> components.verbal
+    Spell.Component.SOMATIC -> components.somatic
+    Spell.Component.MATERIAL -> components.material
+}
 
 private fun Spell.matchesQuery(query: String): Boolean {
     val trimmed = query.trim()

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -2,14 +2,25 @@ package com.cyrillrx.rpg.spell.domain
 
 import com.cyrillrx.rpg.character.domain.Character
 
-enum class ComponentFilter { REQUIRED, EXCLUDED }
+enum class ComponentFilterState {
+    NONE,
+    REQUIRED,
+    EXCLUDED,
+    ;
+
+    fun next(): ComponentFilterState = when (this) {
+        NONE -> REQUIRED
+        REQUIRED -> EXCLUDED
+        EXCLUDED -> NONE
+    }
+}
 
 data class SpellFilter(
     val query: String = "",
     val schools: Set<Spell.School> = emptySet(),
     val characterClasses: Set<Character.Class> = emptySet(),
     val levels: Set<Int> = emptySet(),
-    val components: Map<Spell.ComponentType, ComponentFilter> = emptyMap(),
+    val components: Map<Spell.ComponentType, ComponentFilterState> = emptyMap(),
 ) {
     val hasActiveFilters: Boolean =
         schools.isNotEmpty() || characterClasses.isNotEmpty() || levels.isNotEmpty() || components.isNotEmpty()
@@ -26,8 +37,9 @@ internal fun Spell.matches(filter: SpellFilter): Boolean =
         (filter.levels.isEmpty() || filter.levels.contains(level)) &&
         filter.components.all { (component, state) ->
             when (state) {
-                ComponentFilter.REQUIRED -> component.isPresentIn(components)
-                ComponentFilter.EXCLUDED -> !component.isPresentIn(components)
+                ComponentFilterState.NONE -> true
+                ComponentFilterState.REQUIRED -> component.isPresentIn(components)
+                ComponentFilterState.EXCLUDED -> !component.isPresentIn(components)
             }
         } &&
         (filter.query.isBlank() || matchesQuery(filter.query))

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -9,7 +9,7 @@ data class SpellFilter(
     val schools: Set<Spell.School> = emptySet(),
     val characterClasses: Set<Character.Class> = emptySet(),
     val levels: Set<Int> = emptySet(),
-    val components: Map<Spell.Component, ComponentFilter> = emptyMap(),
+    val components: Map<Spell.ComponentType, ComponentFilter> = emptyMap(),
 ) {
     val hasActiveFilters: Boolean =
         schools.isNotEmpty() || characterClasses.isNotEmpty() || levels.isNotEmpty() || components.isNotEmpty()
@@ -32,10 +32,10 @@ internal fun Spell.matches(filter: SpellFilter): Boolean =
         } &&
         (filter.query.isBlank() || matchesQuery(filter.query))
 
-private fun Spell.Component.isPresentIn(components: Spell.Components): Boolean = when (this) {
-    Spell.Component.VERBAL -> components.verbal
-    Spell.Component.SOMATIC -> components.somatic
-    Spell.Component.MATERIAL -> components.material
+private fun Spell.ComponentType.isPresentIn(components: Spell.Components): Boolean = when (this) {
+    Spell.ComponentType.VERBAL -> components.verbal
+    Spell.ComponentType.SOMATIC -> components.somatic
+    Spell.ComponentType.MATERIAL -> components.material
 }
 
 private fun Spell.matchesQuery(query: String): Boolean {

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -15,6 +15,14 @@ enum class ComponentFilterState {
     }
 }
 
+/** Cycles [component] to its next state, dropping the entry when it returns to [ComponentFilterState.NONE]. */
+fun Map<Spell.ComponentType, ComponentFilterState>.cycled(
+    component: Spell.ComponentType,
+): Map<Spell.ComponentType, ComponentFilterState> {
+    val nextState = (this[component] ?: ComponentFilterState.NONE).next()
+    return if (nextState == ComponentFilterState.NONE) this - component else this + (component to nextState)
+}
+
 data class SpellFilter(
     val query: String = "",
     val schools: Set<Spell.School> = emptySet(),
@@ -23,7 +31,9 @@ data class SpellFilter(
     val components: Map<Spell.ComponentType, ComponentFilterState> = emptyMap(),
 ) {
     val hasActiveFilters: Boolean =
-        schools.isNotEmpty() || characterClasses.isNotEmpty() || levels.isNotEmpty() ||
+        schools.isNotEmpty() ||
+            characterClasses.isNotEmpty() ||
+            levels.isNotEmpty() ||
             components.values.any { it != ComponentFilterState.NONE }
 }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/ComponentFilterCycledTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/ComponentFilterCycledTest.kt
@@ -1,0 +1,43 @@
+package com.cyrillrx.rpg.spell.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComponentFilterCycledTest {
+
+    @Test
+    fun `cycling an absent component adds it as required`() {
+        val result = emptyMap<Spell.ComponentType, ComponentFilterState>().cycled(Spell.ComponentType.VERBAL)
+        assertEquals(mapOf(Spell.ComponentType.VERBAL to ComponentFilterState.REQUIRED), result)
+    }
+
+    @Test
+    fun `cycling a required component moves it to excluded`() {
+        val filter = mapOf(Spell.ComponentType.VERBAL to ComponentFilterState.REQUIRED)
+        val result = filter.cycled(Spell.ComponentType.VERBAL)
+        assertEquals(mapOf(Spell.ComponentType.VERBAL to ComponentFilterState.EXCLUDED), result)
+    }
+
+    @Test
+    fun `cycling an excluded component drops it from the map`() {
+        val filter = mapOf(Spell.ComponentType.VERBAL to ComponentFilterState.EXCLUDED)
+        val result = filter.cycled(Spell.ComponentType.VERBAL)
+        assertEquals(emptyMap(), result)
+    }
+
+    @Test
+    fun `cycling one component leaves the others untouched`() {
+        val filter = mapOf(
+            Spell.ComponentType.VERBAL to ComponentFilterState.REQUIRED,
+            Spell.ComponentType.SOMATIC to ComponentFilterState.EXCLUDED,
+        )
+        val result = filter.cycled(Spell.ComponentType.VERBAL)
+        assertEquals(
+            mapOf(
+                Spell.ComponentType.VERBAL to ComponentFilterState.EXCLUDED,
+                Spell.ComponentType.SOMATIC to ComponentFilterState.EXCLUDED,
+            ),
+            result,
+        )
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/ComponentFilterStateTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/ComponentFilterStateTest.kt
@@ -1,0 +1,14 @@
+package com.cyrillrx.rpg.spell.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComponentFilterStateTest {
+
+    @Test
+    fun `next cycles none to required to excluded and back`() {
+        assertEquals(ComponentFilterState.REQUIRED, ComponentFilterState.NONE.next())
+        assertEquals(ComponentFilterState.EXCLUDED, ComponentFilterState.REQUIRED.next())
+        assertEquals(ComponentFilterState.NONE, ComponentFilterState.EXCLUDED.next())
+    }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
@@ -89,8 +89,8 @@ class SpellMatchesFilterTest {
 
     @Test
     fun `a single required component ignores the other components`() {
-        // "At least material": fireball qualifies, counterspell does not.
-        val filter = SpellFilter(components = mapOf(Spell.Component.MATERIAL to ComponentFilter.REQUIRED))
+        // "At least verbal": fireball has V+S+M and still qualifies; counterspell lacks verbal.
+        val filter = SpellFilter(components = mapOf(Spell.Component.VERBAL to ComponentFilter.REQUIRED))
         assertTrue(fireball.matches(filter))
         assertFalse(counterspell.matches(filter))
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
@@ -10,6 +10,8 @@ class SpellMatchesFilterTest {
 
     private val fireball = SampleSpellRepository.fireball()
     private val mageArmor = SampleSpellRepository.mageArmor()
+    private val thunderwave = SampleSpellRepository.thunderwave()
+    private val counterspell = SampleSpellRepository.counterspell()
 
     @Test
     fun `default filter matches any spell`() {
@@ -52,6 +54,45 @@ class SpellMatchesFilterTest {
     fun `filter by non-matching class does not match`() {
         val filter = SpellFilter(characterClasses = setOf(Character.Class.PALADIN))
         assertFalse(fireball.matches(filter))
+    }
+
+    @Test
+    fun `required component keeps spells that have it`() {
+        // Fireball has a material component, thunderwave does not.
+        val filter = SpellFilter(components = mapOf(Spell.Component.MATERIAL to ComponentFilter.REQUIRED))
+        assertTrue(fireball.matches(filter))
+        assertFalse(thunderwave.matches(filter))
+    }
+
+    @Test
+    fun `excluded component keeps spells that lack it`() {
+        // Thunderwave has no material component, fireball does.
+        val filter = SpellFilter(components = mapOf(Spell.Component.MATERIAL to ComponentFilter.EXCLUDED))
+        assertTrue(thunderwave.matches(filter))
+        assertFalse(fireball.matches(filter))
+    }
+
+    @Test
+    fun `required and excluded combine to match exact components`() {
+        // "Only somatic": counterspell has somatic alone; thunderwave also has verbal.
+        val filter = SpellFilter(
+            components = mapOf(
+                Spell.Component.VERBAL to ComponentFilter.EXCLUDED,
+                Spell.Component.SOMATIC to ComponentFilter.REQUIRED,
+                Spell.Component.MATERIAL to ComponentFilter.EXCLUDED,
+            ),
+        )
+        assertTrue(counterspell.matches(filter))
+        assertFalse(thunderwave.matches(filter))
+        assertFalse(fireball.matches(filter))
+    }
+
+    @Test
+    fun `a single required component ignores the other components`() {
+        // "At least material": fireball qualifies, counterspell does not.
+        val filter = SpellFilter(components = mapOf(Spell.Component.MATERIAL to ComponentFilter.REQUIRED))
+        assertTrue(fireball.matches(filter))
+        assertFalse(counterspell.matches(filter))
     }
 
     @Test

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
@@ -59,7 +59,7 @@ class SpellMatchesFilterTest {
     @Test
     fun `required component keeps spells that have it`() {
         // Fireball has a material component, thunderwave does not.
-        val filter = SpellFilter(components = mapOf(Spell.ComponentType.MATERIAL to ComponentFilter.REQUIRED))
+        val filter = SpellFilter(components = mapOf(Spell.ComponentType.MATERIAL to ComponentFilterState.REQUIRED))
         assertTrue(fireball.matches(filter))
         assertFalse(thunderwave.matches(filter))
     }
@@ -67,7 +67,7 @@ class SpellMatchesFilterTest {
     @Test
     fun `excluded component keeps spells that lack it`() {
         // Thunderwave has no material component, fireball does.
-        val filter = SpellFilter(components = mapOf(Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED))
+        val filter = SpellFilter(components = mapOf(Spell.ComponentType.MATERIAL to ComponentFilterState.EXCLUDED))
         assertTrue(thunderwave.matches(filter))
         assertFalse(fireball.matches(filter))
     }
@@ -77,9 +77,9 @@ class SpellMatchesFilterTest {
         // "Only somatic": counterspell has somatic alone; thunderwave also has verbal.
         val filter = SpellFilter(
             components = mapOf(
-                Spell.ComponentType.VERBAL to ComponentFilter.EXCLUDED,
-                Spell.ComponentType.SOMATIC to ComponentFilter.REQUIRED,
-                Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED,
+                Spell.ComponentType.VERBAL to ComponentFilterState.EXCLUDED,
+                Spell.ComponentType.SOMATIC to ComponentFilterState.REQUIRED,
+                Spell.ComponentType.MATERIAL to ComponentFilterState.EXCLUDED,
             ),
         )
         assertTrue(counterspell.matches(filter))
@@ -90,7 +90,7 @@ class SpellMatchesFilterTest {
     @Test
     fun `a single required component ignores the other components`() {
         // "At least verbal": fireball has V+S+M and still qualifies; counterspell lacks verbal.
-        val filter = SpellFilter(components = mapOf(Spell.ComponentType.VERBAL to ComponentFilter.REQUIRED))
+        val filter = SpellFilter(components = mapOf(Spell.ComponentType.VERBAL to ComponentFilterState.REQUIRED))
         assertTrue(fireball.matches(filter))
         assertFalse(counterspell.matches(filter))
     }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/spell/domain/SpellMatchesFilterTest.kt
@@ -59,7 +59,7 @@ class SpellMatchesFilterTest {
     @Test
     fun `required component keeps spells that have it`() {
         // Fireball has a material component, thunderwave does not.
-        val filter = SpellFilter(components = mapOf(Spell.Component.MATERIAL to ComponentFilter.REQUIRED))
+        val filter = SpellFilter(components = mapOf(Spell.ComponentType.MATERIAL to ComponentFilter.REQUIRED))
         assertTrue(fireball.matches(filter))
         assertFalse(thunderwave.matches(filter))
     }
@@ -67,7 +67,7 @@ class SpellMatchesFilterTest {
     @Test
     fun `excluded component keeps spells that lack it`() {
         // Thunderwave has no material component, fireball does.
-        val filter = SpellFilter(components = mapOf(Spell.Component.MATERIAL to ComponentFilter.EXCLUDED))
+        val filter = SpellFilter(components = mapOf(Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED))
         assertTrue(thunderwave.matches(filter))
         assertFalse(fireball.matches(filter))
     }
@@ -77,9 +77,9 @@ class SpellMatchesFilterTest {
         // "Only somatic": counterspell has somatic alone; thunderwave also has verbal.
         val filter = SpellFilter(
             components = mapOf(
-                Spell.Component.VERBAL to ComponentFilter.EXCLUDED,
-                Spell.Component.SOMATIC to ComponentFilter.REQUIRED,
-                Spell.Component.MATERIAL to ComponentFilter.EXCLUDED,
+                Spell.ComponentType.VERBAL to ComponentFilter.EXCLUDED,
+                Spell.ComponentType.SOMATIC to ComponentFilter.REQUIRED,
+                Spell.ComponentType.MATERIAL to ComponentFilter.EXCLUDED,
             ),
         )
         assertTrue(counterspell.matches(filter))
@@ -90,7 +90,7 @@ class SpellMatchesFilterTest {
     @Test
     fun `a single required component ignores the other components`() {
         // "At least verbal": fireball has V+S+M and still qualifies; counterspell lacks verbal.
-        val filter = SpellFilter(components = mapOf(Spell.Component.VERBAL to ComponentFilter.REQUIRED))
+        val filter = SpellFilter(components = mapOf(Spell.ComponentType.VERBAL to ComponentFilter.REQUIRED))
         assertTrue(fireball.matches(filter))
         assertFalse(counterspell.matches(filter))
     }


### PR DESCRIPTION
## 📝 Description

Adds a **Components** section to the spell filter so spells can be narrowed by their V / S / M components.

Each component chip is **tri-state** and cycles on tap: *indifferent → required (✓) → excluded (✕)*. The predicate keeps a spell when every **required** component is present **and** every **excluded** component is absent, combined (AND) with the existing school / level / class / query filters.

This single control expresses the two intents a set of simple checkboxes could not cover at once:
- « only S » → V excluded, S required, M excluded
- « at least M » → M required, the rest indifferent
- « without material » → M excluded

**Changes**
- Domain: new `Spell.ComponentType` enum, a `ComponentFilterState` tri-state enum (`NONE` / `REQUIRED` / `EXCLUDED`) with a `next()` transition, and a `components: Map<Spell.ComponentType, ComponentFilterState>` on `SpellFilter`; matching predicate updated.
- View model: `onComponentToggled` cycles a component through the three states.
- UI: `SpellFilterBottomSheet` split into per-section private composables; tri-state component chips (required uses the default selected style, excluded uses the error container with a ✕ icon).
- Tests: `SpellMatchesFilterTest` covers required, excluded, exact (« only S ») and « at least M »; `ComponentFilterStateTest` covers the `next()` cycle.

## 🖼️ Media

<img width="1626" height="1358" alt="image" src="https://github.com/user-attachments/assets/29cb07fb-f5e5-479a-b99b-0c8e2a7ddd3d" />

<img width="1624" height="1360" alt="image" src="https://github.com/user-attachments/assets/8f29dd37-d890-4cb5-8b00-a8aeabf017ac" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed
