### PR TITLE
ui(magicalitem): rework the detail view

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FadingTitleScaffold.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FadingTitleScaffold.kt
@@ -1,0 +1,82 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import kotlin.math.abs
+
+/**
+ * Scaffold for detail screens whose top-bar title fades in as the scrollable header name
+ * scrolls up behind the bar: alpha ramps from 0 (no scroll) to 1 when the scroll offset
+ * reaches the name's bottom, and fades back out on scroll up.
+ *
+ * @param content receives the [Modifier] to apply to the scrollable container ([scrollModifier])
+ *   and the [Modifier] to attach to the header name whose bottom drives the fade ([titleModifier]).
+ */
+@Composable
+fun FadingTitleScaffold(
+    title: String,
+    onNavigateUpClicked: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit = {},
+    content: @Composable (scrollModifier: Modifier, titleModifier: Modifier) -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    var containerCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    var titleBottomOffset by remember { mutableFloatStateOf(0f) }
+    val titleAlpha by remember {
+        derivedStateOf {
+            if (titleBottomOffset <= 0f) 0f else (scrollState.value / titleBottomOffset).coerceIn(0f, 1f)
+        }
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            SimpleTopBar(
+                title = title,
+                onNavigateUpClicked = onNavigateUpClicked,
+                titleAlpha = titleAlpha,
+                actions = actions,
+            )
+        },
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .onGloballyPositioned { containerCoordinates = it },
+        ) {
+            content(
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState),
+                Modifier.onGloballyPositioned { coordinates ->
+                    // Name bottom offset relative to the container, stable across scroll.
+                    containerCoordinates?.let { container ->
+                        val positionInContainer = container.localPositionOf(coordinates, Offset.Zero)
+                        val newValue = positionInContainer.y + coordinates.size.height + scrollState.value
+                        if (abs(titleBottomOffset - newValue) > 0.5f) {
+                            titleBottomOffset = newValue
+                        }
+                    }
+                },
+            )
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/TintedTag.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/TintedTag.kt
@@ -1,0 +1,49 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Small uppercase pill in a [tint] color over a faint [tint]-tinted background.
+ * Used on detail screens to surface flags such as attunement, ritual or concentration.
+ */
+@Composable
+fun TintedTag(text: String, tint: Color, modifier: Modifier = Modifier) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = tint,
+        modifier = modifier
+            .clip(MaterialTheme.shapes.small)
+            .background(tint.copy(alpha = 0.15f))
+            .padding(horizontal = spacingMedium, vertical = spacingSmall),
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewTintedTagLight() {
+    AppThemePreview(darkTheme = false) {
+        TintedTag(text = "Requires attunement", tint = MaterialTheme.colorScheme.primary)
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewTintedTagDark() {
+    AppThemePreview(darkTheme = true) {
+        TintedTag(text = "Requires attunement", tint = MaterialTheme.colorScheme.primary)
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
@@ -1,6 +1,5 @@
 package com.cyrillrx.rpg.magicalitem.presentation.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,11 +10,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.cyrillrx.rpg.app.currentLocale
+import com.cyrillrx.rpg.core.presentation.component.TintedTag
 import com.cyrillrx.rpg.core.presentation.component.MarkdownText
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
@@ -85,23 +84,9 @@ private fun MagicalItemHeader(
             modifier = Modifier.padding(horizontal = spacingCommon, vertical = spacingSmall),
         )
         if (magicalItem.attunement) {
-            MagicalItemBadge(stringResource(Res.string.item_requires_attunement), accent)
+            TintedTag(stringResource(Res.string.item_requires_attunement), accent)
         }
     }
-}
-
-@Composable
-private fun MagicalItemBadge(text: String, accent: Color) {
-    Text(
-        text = text.uppercase(),
-        style = MaterialTheme.typography.labelSmall,
-        fontWeight = FontWeight.Bold,
-        color = accent,
-        modifier = Modifier
-            .clip(MaterialTheme.shapes.small)
-            .background(accent.copy(alpha = 0.15f))
-            .padding(horizontal = spacingSmall, vertical = spacingSmall / 2),
-    )
 }
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
@@ -1,0 +1,121 @@
+package com.cyrillrx.rpg.magicalitem.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import com.cyrillrx.rpg.app.currentLocale
+import com.cyrillrx.rpg.core.presentation.component.MarkdownText
+import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
+import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
+import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
+import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.item_requires_attunement
+
+@Composable
+fun MagicalItemDetail(
+    magicalItem: MagicalItem,
+    modifier: Modifier = Modifier,
+    titleModifier: Modifier = Modifier,
+) {
+    val translation = magicalItem.resolveTranslation(currentLocale())
+    val accent = magicalItem.getColor()
+
+    Column(
+        modifier = modifier.padding(spacingCommon),
+        verticalArrangement = Arrangement.spacedBy(spacingCommon),
+    ) {
+        MagicalItemHeader(magicalItem, translation, accent, titleModifier)
+        MarkdownText(text = translation.description, modifier = Modifier.fillMaxWidth())
+    }
+}
+
+@Composable
+private fun MagicalItemHeader(
+    magicalItem: MagicalItem,
+    translation: MagicalItem.Translation,
+    accent: Color,
+    titleModifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = "${magicalItem.type.toFormattedString()} - ${magicalItem.rarity.toFormattedString()}".uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+        )
+        Text(
+            text = translation.name,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = titleModifier,
+        )
+        translation.subtype?.takeIf { it.isNotBlank() }?.let { subtype ->
+            Text(
+                text = subtype,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        HorizontalDivider(
+            color = accent,
+            modifier = Modifier.padding(horizontal = spacingCommon, vertical = spacingSmall),
+        )
+        if (magicalItem.attunement) {
+            MagicalItemBadge(stringResource(Res.string.item_requires_attunement), accent)
+        }
+    }
+}
+
+@Composable
+private fun MagicalItemBadge(text: String, accent: Color) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = accent,
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.small)
+            .background(accent.copy(alpha = 0.15f))
+            .padding(horizontal = spacingSmall, vertical = spacingSmall / 2),
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewMagicalItemDetailLight() {
+    AppThemePreview(darkTheme = false) {
+        MagicalItemDetail(SampleMagicalItemRepository.getFirst())
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMagicalItemDetailDark() {
+    AppThemePreview(darkTheme = true) {
+        MagicalItemDetail(SampleMagicalItemRepository.getFirst())
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.cyrillrx.rpg.app.currentLocale
-import com.cyrillrx.rpg.core.presentation.component.TintedTag
 import com.cyrillrx.rpg.core.presentation.component.MarkdownText
+import com.cyrillrx.rpg.core.presentation.component.TintedTag
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetail.kt
@@ -60,12 +60,6 @@ private fun MagicalItemHeader(
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(
-            text = "${magicalItem.type.toFormattedString()} - ${magicalItem.rarity.toFormattedString()}".uppercase(),
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.Bold,
-            color = accent,
-        )
-        Text(
             text = translation.name,
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold,
@@ -80,6 +74,12 @@ private fun MagicalItemHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        Text(
+            text = "${magicalItem.type.toFormattedString()} - ${magicalItem.rarity.toFormattedString()}".uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+        )
         HorizontalDivider(
             color = accent,
             modifier = Modifier.padding(horizontal = spacingCommon, vertical = spacingSmall),

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetailScreen.kt
@@ -1,32 +1,32 @@
 package com.cyrillrx.rpg.magicalitem.presentation.component
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
-import com.cyrillrx.rpg.core.presentation.component.MarkdownText
-import com.cyrillrx.rpg.core.presentation.component.dnd.getSubtitle
+import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
-import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
-import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemAddToListProvider
@@ -41,7 +41,7 @@ import rpg_companion.composeapp.generated.resources.btn_add_to_list
 import rpg_companion.composeapp.generated.resources.error_magical_item_not_found
 
 @Composable
-fun MagicalItemCardScreen(
+fun MagicalItemDetailScreen(
     viewModel: MagicalItemDetailViewModel,
     router: MagicalItemRouter,
     addToListProvider: AddToListProvider<MagicalItem>,
@@ -50,7 +50,7 @@ fun MagicalItemCardScreen(
     when (val s = state) {
         DetailState.Loading -> Loader()
         is DetailState.NotFound -> ErrorLayout(stringResource(Res.string.error_magical_item_not_found, s.id))
-        is DetailState.Found -> MagicalItemCardContent(
+        is DetailState.Found -> MagicalItemDetailContent(
             magicalItem = s.item,
             onNavigateUpClicked = router::navigateUp,
             addToListProvider = addToListProvider,
@@ -59,53 +59,54 @@ fun MagicalItemCardScreen(
 }
 
 @Composable
-private fun MagicalItemCardContent(
+private fun MagicalItemDetailContent(
     magicalItem: MagicalItem,
     onNavigateUpClicked: () -> Unit,
     addToListProvider: AddToListProvider<MagicalItem>,
 ) {
     var showAddToListBottomSheet by remember { mutableStateOf(false) }
 
-    Scaffold { paddingValues ->
-        Column(modifier = Modifier.padding(paddingValues)) {
-            MagicalItemCard(
-                magicalItem = magicalItem,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(spacingSmall)
-                    .clickable { onNavigateUpClicked() },
-                content = {
-                    val translation = magicalItem.resolveTranslation(currentLocale())
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .verticalScroll(rememberScrollState()),
-                    ) {
-                        Text(
-                            text = magicalItem.getSubtitle(translation),
-                            style = MaterialTheme.typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(start = spacingMedium, end = spacingMedium, top = spacingMedium),
-                        )
-                        MarkdownText(
-                            text = translation.description,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(spacingMedium),
+    val scrollState = rememberScrollState()
+    var contentTop by remember { mutableFloatStateOf(0f) }
+    var titleBottomOffset by remember { mutableFloatStateOf(0f) }
+    val titleAlpha by remember {
+        derivedStateOf {
+            if (titleBottomOffset <= 0f) 0f else (scrollState.value / titleBottomOffset).coerceIn(0f, 1f)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            SimpleTopBar(
+                title = magicalItem.resolveTranslation(currentLocale()).name,
+                onNavigateUpClicked = onNavigateUpClicked,
+                titleAlpha = titleAlpha,
+                actions = {
+                    IconButton(onClick = { showAddToListBottomSheet = true }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                            contentDescription = stringResource(Res.string.btn_add_to_list),
                         )
                     }
                 },
             )
-            Button(
-                onClick = { showAddToListBottomSheet = true },
+        },
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .onGloballyPositioned { contentTop = it.positionInRoot().y },
+        ) {
+            MagicalItemDetail(
+                magicalItem = magicalItem,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = spacingMedium),
-            ) {
-                Text(stringResource(Res.string.btn_add_to_list))
-            }
+                    .fillMaxSize()
+                    .verticalScroll(scrollState),
+                titleModifier = Modifier.onGloballyPositioned {
+                    titleBottomOffset = it.positionInRoot().y + it.size.height - contentTop + scrollState.value
+                },
+            )
         }
     }
 
@@ -119,21 +120,21 @@ private fun MagicalItemCardContent(
 
 @Preview
 @Composable
-fun PreviewMagicalItemCardScreenLight() {
-    PreviewMagicalItemCardScreen(darkTheme = false)
+fun PreviewMagicalItemDetailScreenLight() {
+    PreviewMagicalItemDetailScreen(darkTheme = false)
 }
 
 @Preview
 @Composable
-fun PreviewMagicalItemCardScreenDark() {
-    PreviewMagicalItemCardScreen(darkTheme = true)
+fun PreviewMagicalItemDetailScreenDark() {
+    PreviewMagicalItemDetailScreen(darkTheme = true)
 }
 
 @Composable
-private fun PreviewMagicalItemCardScreen(darkTheme: Boolean) {
+private fun PreviewMagicalItemDetailScreen(darkTheme: Boolean) {
     val magicalItem = SampleMagicalItemRepository.getFirst()
     val addToListProvider = MagicalItemAddToListProvider(SampleMagicalItemRepository(), SampleUserListRepository())
     AppThemePreview(darkTheme = darkTheme) {
-        MagicalItemCardContent(magicalItem, onNavigateUpClicked = {}, addToListProvider = addToListProvider)
+        MagicalItemDetailContent(magicalItem, onNavigateUpClicked = {}, addToListProvider = addToListProvider)
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetailScreen.kt
@@ -1,31 +1,19 @@
 package com.cyrillrx.rpg.magicalitem.presentation.component
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.onGloballyPositioned
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.FadingTitleScaffold
 import com.cyrillrx.rpg.core.presentation.component.Loader
-import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.magicalitem.data.SampleMagicalItemRepository
@@ -35,7 +23,6 @@ import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouter
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModel
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListProvider
-import kotlin.math.abs
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -68,55 +55,23 @@ private fun MagicalItemDetailContent(
 ) {
     var showAddToListBottomSheet by remember { mutableStateOf(false) }
 
-    val scrollState = rememberScrollState()
-    var containerCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
-    var titleBottomOffset by remember { mutableFloatStateOf(0f) }
-    val titleAlpha by remember {
-        derivedStateOf {
-            if (titleBottomOffset <= 0f) 0f else (scrollState.value / titleBottomOffset).coerceIn(0f, 1f)
-        }
-    }
-
-    Scaffold(
-        topBar = {
-            SimpleTopBar(
-                title = magicalItem.resolveTranslation(currentLocale()).name,
-                onNavigateUpClicked = onNavigateUpClicked,
-                titleAlpha = titleAlpha,
-                actions = {
-                    IconButton(onClick = { showAddToListBottomSheet = true }) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
-                            contentDescription = stringResource(Res.string.btn_add_to_list),
-                        )
-                    }
-                },
-            )
+    FadingTitleScaffold(
+        title = magicalItem.resolveTranslation(currentLocale()).name,
+        onNavigateUpClicked = onNavigateUpClicked,
+        actions = {
+            IconButton(onClick = { showAddToListBottomSheet = true }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    contentDescription = stringResource(Res.string.btn_add_to_list),
+                )
+            }
         },
-    ) { paddingValues ->
-        Box(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize()
-                .onGloballyPositioned { containerCoordinates = it },
-        ) {
-            MagicalItemDetail(
-                magicalItem = magicalItem,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(scrollState),
-                titleModifier = Modifier.onGloballyPositioned { coordinates ->
-                    // Name bottom offset relative to the container, stable across scroll.
-                    containerCoordinates?.let { container ->
-                        val positionInContainer = container.localPositionOf(coordinates, Offset.Zero)
-                        val newValue = positionInContainer.y + coordinates.size.height + scrollState.value
-                        if (abs(titleBottomOffset - newValue) > 0.5f) {
-                            titleBottomOffset = newValue
-                        }
-                    }
-                },
-            )
-        }
+    ) { scrollModifier, titleModifier ->
+        MagicalItemDetail(
+            magicalItem = magicalItem,
+            modifier = scrollModifier,
+            titleModifier = titleModifier,
+        )
     }
 
     if (showAddToListBottomSheet) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemDetailScreen.kt
@@ -19,8 +19,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -34,6 +35,7 @@ import com.cyrillrx.rpg.magicalitem.presentation.navigation.MagicalItemRouter
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModel
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListProvider
+import kotlin.math.abs
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -67,7 +69,7 @@ private fun MagicalItemDetailContent(
     var showAddToListBottomSheet by remember { mutableStateOf(false) }
 
     val scrollState = rememberScrollState()
-    var contentTop by remember { mutableFloatStateOf(0f) }
+    var containerCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
     var titleBottomOffset by remember { mutableFloatStateOf(0f) }
     val titleAlpha by remember {
         derivedStateOf {
@@ -96,15 +98,22 @@ private fun MagicalItemDetailContent(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
-                .onGloballyPositioned { contentTop = it.positionInRoot().y },
+                .onGloballyPositioned { containerCoordinates = it },
         ) {
             MagicalItemDetail(
                 magicalItem = magicalItem,
                 modifier = Modifier
                     .fillMaxSize()
                     .verticalScroll(scrollState),
-                titleModifier = Modifier.onGloballyPositioned {
-                    titleBottomOffset = it.positionInRoot().y + it.size.height - contentTop + scrollState.value
+                titleModifier = Modifier.onGloballyPositioned { coordinates ->
+                    // Name bottom offset relative to the container, stable across scroll.
+                    containerCoordinates?.let { container ->
+                        val positionInContainer = container.localPositionOf(coordinates, Offset.Zero)
+                        val newValue = positionInContainer.y + coordinates.size.height + scrollState.value
+                        if (abs(titleBottomOffset - newValue) > 0.5f) {
+                            titleBottomOffset = newValue
+                        }
+                    }
                 },
             )
         }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/navigation/MagicalItemRoute.kt
@@ -7,7 +7,7 @@ import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemAddToListProvider
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemItemProvider
-import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemCardScreen
+import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemDetailScreen
 import com.cyrillrx.rpg.magicalitem.presentation.component.MagicalItemListScreen
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModel
 import com.cyrillrx.rpg.magicalitem.presentation.viewmodel.MagicalItemDetailViewModelFactory
@@ -55,7 +55,7 @@ fun EntryProviderScope<NavKey>.handleMagicalItemRoutes(
         val viewModelFactory = MagicalItemDetailViewModelFactory(magicalItemId, repository)
         val viewModel = viewModel<MagicalItemDetailViewModel>(key = magicalItemId, factory = viewModelFactory)
         val addToListProvider = MagicalItemAddToListProvider(repository, userListRepository)
-        MagicalItemCardScreen(viewModel, router, addToListProvider)
+        MagicalItemDetailScreen(viewModel, router, addToListProvider)
     }
 
     entry<MagicalItemRoute.UserListDetail> { route ->

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetail.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetail.kt
@@ -1,6 +1,5 @@
 package com.cyrillrx.rpg.spell.presentation.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -25,7 +24,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.SpanStyle
@@ -34,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import com.cyrillrx.rpg.app.currentLocale
+import com.cyrillrx.rpg.core.presentation.component.TintedTag
 import com.cyrillrx.rpg.core.presentation.component.MarkdownText
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.getFormattedComponents
@@ -153,13 +152,13 @@ private fun SpellHeader(spell: Spell, accent: Color, titleModifier: Modifier = M
             color = accent,
             modifier = Modifier.padding(horizontal = spacingCommon, vertical = spacingSmall),
         )
-        val badges = buildList {
+        val tags = buildList {
             if (spell.ritual) add(stringResource(Res.string.spell_ritual))
             if (spell.concentration) add(stringResource(Res.string.spell_concentration))
         }
-        if (badges.isNotEmpty()) {
+        if (tags.isNotEmpty()) {
             Row(horizontalArrangement = Arrangement.spacedBy(spacingSmall)) {
-                badges.forEach { SpellBadge(it, accent) }
+                tags.forEach { TintedTag(it, accent) }
             }
         }
     }
@@ -205,20 +204,6 @@ private fun RowScope.SpellMetaCell(
             )
         }
     }
-}
-
-@Composable
-private fun SpellBadge(text: String, accent: Color) {
-    Text(
-        text = text.uppercase(),
-        style = MaterialTheme.typography.labelSmall,
-        fontWeight = FontWeight.Bold,
-        color = accent,
-        modifier = Modifier
-            .clip(MaterialTheme.shapes.small)
-            .background(accent.copy(alpha = 0.15f))
-            .padding(horizontal = spacingSmall, vertical = spacingSmall / 2),
-    )
 }
 
 @Preview

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetail.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetail.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import com.cyrillrx.rpg.app.currentLocale
-import com.cyrillrx.rpg.core.presentation.component.TintedTag
 import com.cyrillrx.rpg.core.presentation.component.MarkdownText
+import com.cyrillrx.rpg.core.presentation.component.TintedTag
 import com.cyrillrx.rpg.core.presentation.component.dnd.getColor
 import com.cyrillrx.rpg.core.presentation.component.dnd.getFormattedComponents
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedSchoolAndLevel

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetailScreen.kt
@@ -1,31 +1,19 @@
 package com.cyrillrx.rpg.spell.presentation.component
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.onGloballyPositioned
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
+import com.cyrillrx.rpg.core.presentation.component.FadingTitleScaffold
 import com.cyrillrx.rpg.core.presentation.component.Loader
-import com.cyrillrx.rpg.core.presentation.component.SimpleTopBar
 import com.cyrillrx.rpg.core.presentation.state.DetailState
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.spell.data.SampleSpellRepository
@@ -35,7 +23,6 @@ import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouter
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListProvider
-import kotlin.math.abs
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -68,57 +55,23 @@ private fun SpellDetailContent(
 ) {
     var showAddToListBottomSheet by remember { mutableStateOf(false) }
 
-    // Reveal the top-bar title as the header name scrolls up: alpha ramps from 0 (no
-    // scroll) to 1 when the scroll offset reaches the name's bottom (name behind the bar).
-    val scrollState = rememberScrollState()
-    var containerCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
-    var titleBottomOffset by remember { mutableFloatStateOf(0f) }
-    val titleAlpha by remember {
-        derivedStateOf {
-            if (titleBottomOffset <= 0f) 0f else (scrollState.value / titleBottomOffset).coerceIn(0f, 1f)
-        }
-    }
-
-    Scaffold(
-        topBar = {
-            SimpleTopBar(
-                title = spell.resolveTranslation(currentLocale()).name,
-                onNavigateUpClicked = onNavigateUpClicked,
-                titleAlpha = titleAlpha,
-                actions = {
-                    IconButton(onClick = { showAddToListBottomSheet = true }) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
-                            contentDescription = stringResource(Res.string.btn_add_to_list),
-                        )
-                    }
-                },
-            )
+    FadingTitleScaffold(
+        title = spell.resolveTranslation(currentLocale()).name,
+        onNavigateUpClicked = onNavigateUpClicked,
+        actions = {
+            IconButton(onClick = { showAddToListBottomSheet = true }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    contentDescription = stringResource(Res.string.btn_add_to_list),
+                )
+            }
         },
-    ) { paddingValues ->
-        Box(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize()
-                .onGloballyPositioned { containerCoordinates = it },
-        ) {
-            SpellDetail(
-                spell = spell,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(scrollState),
-                titleModifier = Modifier.onGloballyPositioned { coordinates ->
-                    // Name bottom offset relative to the container, stable across scroll.
-                    containerCoordinates?.let { container ->
-                        val positionInContainer = container.localPositionOf(coordinates, Offset.Zero)
-                        val newValue = positionInContainer.y + coordinates.size.height + scrollState.value
-                        if (abs(titleBottomOffset - newValue) > 0.5f) {
-                            titleBottomOffset = newValue
-                        }
-                    }
-                },
-            )
-        }
+    ) { scrollModifier, titleModifier ->
+        SpellDetail(
+            spell = spell,
+            modifier = scrollModifier,
+            titleModifier = titleModifier,
+        )
     }
 
     if (showAddToListBottomSheet) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetailScreen.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellDetailScreen.kt
@@ -19,8 +19,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
 import com.cyrillrx.rpg.app.currentLocale
 import com.cyrillrx.rpg.core.presentation.component.ErrorLayout
 import com.cyrillrx.rpg.core.presentation.component.Loader
@@ -34,6 +35,7 @@ import com.cyrillrx.rpg.spell.presentation.navigation.SpellRouter
 import com.cyrillrx.rpg.spell.presentation.viewmodel.SpellDetailViewModel
 import com.cyrillrx.rpg.userlist.data.SampleUserListRepository
 import com.cyrillrx.rpg.userlist.presentation.AddToListProvider
+import kotlin.math.abs
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
@@ -69,7 +71,7 @@ private fun SpellDetailContent(
     // Reveal the top-bar title as the header name scrolls up: alpha ramps from 0 (no
     // scroll) to 1 when the scroll offset reaches the name's bottom (name behind the bar).
     val scrollState = rememberScrollState()
-    var contentTop by remember { mutableFloatStateOf(0f) }
+    var containerCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
     var titleBottomOffset by remember { mutableFloatStateOf(0f) }
     val titleAlpha by remember {
         derivedStateOf {
@@ -98,18 +100,22 @@ private fun SpellDetailContent(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()
-                .onGloballyPositioned { contentTop = it.positionInRoot().y },
+                .onGloballyPositioned { containerCoordinates = it },
         ) {
             SpellDetail(
                 spell = spell,
                 modifier = Modifier
                     .fillMaxSize()
                     .verticalScroll(scrollState),
-                titleModifier = Modifier.onGloballyPositioned {
-                    // Name bottom offset from the content top, stable across scroll.
-                    // positionInRoot is unclipped (unlike boundsInRoot, which clamps once
-                    // the name scrolls out of the viewport and corrupts the value).
-                    titleBottomOffset = it.positionInRoot().y + it.size.height - contentTop + scrollState.value
+                titleModifier = Modifier.onGloballyPositioned { coordinates ->
+                    // Name bottom offset relative to the container, stable across scroll.
+                    containerCoordinates?.let { container ->
+                        val positionInContainer = container.localPositionOf(coordinates, Offset.Zero)
+                        val newValue = positionInContainer.y + coordinates.size.height + scrollState.value
+                        if (abs(titleBottomOffset - newValue) > 0.5f) {
+                            titleBottomOffset = newValue
+                        }
+                    }
                 },
             )
         }


### PR DESCRIPTION
## 📝 Description

Reworks the magical item detail view to match the spirit of the reworked spell detail, replacing the old tap-card-to-close layout. Also extracts two reusable pieces shared by the magical item and spell detail screens: the scroll-driven title fade and the accent tag pill.

**New `MagicalItemDetail` composable**
- **Header** (centered): the item name, an optional subtype line, a `TYPE - RARITY` label in the item's accent color, an accent divider, and a **REQUIRES ATTUNEMENT** tag when applicable.
- **Description** via `MarkdownText`.

**`MagicalItemDetailScreen`** (renamed from `MagicalItemCardScreen`)
- `SimpleTopBar` with a real **back button** (removed the tap-anywhere-to-close) and a discreet **add-to-list** top-bar action.
- The top-bar **title fades in progressively as you scroll**, so the name is not duplicated at rest.

**New shared `FadingTitleScaffold`** (`core/presentation/component/`)
- Extracts the scroll-to-reveal title logic that was inlined in `SpellDetailScreen`; both the spell and magical item detail screens now consume it.
- Fixes a title fade-in race condition and scroll jank in the process (offsets computed relative to the scroll container, stable across scroll).

**New shared `TintedTag`** (`core/presentation/component/`)
- Extracts the tinted uppercase pill that was duplicated as `SpellBadge` / `MagicalItemBadge`; both detail screens now consume it (attunement, ritual, concentration flags).
- Not built on Material 3 `Badge` (count/dot status indicator) nor `Chip` (interactive), which don't fit a static informational tag.

**Per-type accent color**: reuses `MagicalItem.getColor()` (weapon / armor / object families) for the label, divider and tag.

`MagicalItemCard` is left untouched (still used by the carousel screen).

## 🖼️ Media

<img width="922" height="1442" alt="image" src="https://github.com/user-attachments/assets/ebb297c8-5639-4385-bb56-ca347cb65243" />

<img width="922" height="1440" alt="image" src="https://github.com/user-attachments/assets/64918f81-221e-4b1a-bbf5-1300a26bf73f" />

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed

