### PR TITLE
refactor(filter): propagate shared FilterSection to monster and magical item filters

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSection.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSection.kt
@@ -5,15 +5,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.FlowRowScope
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 /**
- * A titled section of a filter bottom sheet: a small title followed by a [FlowRow] of chips.
+ * A titled section of a filter bottom sheet: a small title above a [FlowRow] of filter controls.
+ *
+ * The [content] is emitted directly inside the [FlowRow], so callers have access to [FlowRowScope].
  * Vertical spacing between sections is expected to be provided by the parent column.
  */
 @OptIn(ExperimentalLayoutApi::class)
@@ -35,5 +40,30 @@ fun FilterSection(
             horizontalArrangement = Arrangement.spacedBy(spacingMedium),
             content = content,
         )
+    }
+}
+
+@Composable
+private fun FilterSectionSample() {
+    FilterSection(title = "Rarity") {
+        FilterChip(selected = true, onClick = {}, label = { Text("Common") })
+        FilterChip(selected = false, onClick = {}, label = { Text("Rare") })
+        FilterChip(selected = true, onClick = {}, label = { Text("Legendary") })
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewFilterSectionLight() {
+    AppThemePreview(darkTheme = false) {
+        FilterSectionSample()
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewFilterSectionDark() {
+    AppThemePreview(darkTheme = true) {
+        FilterSectionSample()
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSection.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSection.kt
@@ -5,43 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.FlowRowScope
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
-import org.jetbrains.compose.resources.stringResource
-import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_reset_all
-
-/**
- * Header row for a filter bottom sheet: a title on the left and a "reset all" button on the right.
- */
-@Composable
-fun FilterSheetHeader(
-    title: String,
-    onResetFilters: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleLarge,
-        )
-        TextButton(onClick = onResetFilters) {
-            Text(text = stringResource(Res.string.btn_reset_all))
-        }
-    }
-}
 
 /**
  * A titled section of a filter bottom sheet: a small title followed by a [FlowRow] of chips.

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
@@ -24,9 +24,10 @@ import rpg_companion.composeapp.generated.resources.btn_reset_all
 fun FilterSheetHeader(
     title: String,
     onResetFilters: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
@@ -1,0 +1,61 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.FlowRowScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_reset_all
+
+/**
+ * Header row for a filter bottom sheet: a title on the left and a "reset all" button on the right.
+ */
+@Composable
+fun FilterSheetHeader(
+    title: String,
+    onResetFilters: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+        )
+        TextButton(onClick = onResetFilters) {
+            Text(text = stringResource(Res.string.btn_reset_all))
+        }
+    }
+}
+
+/**
+ * A titled section of a filter bottom sheet: a small title followed by a [FlowRow] of chips.
+ * Vertical spacing between sections is expected to be provided by the parent column.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun FilterSection(
+    title: String,
+    content: @Composable FlowRowScope.() -> Unit,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+    )
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+        content = content,
+    )
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.core.presentation.component
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.FlowRowScope
@@ -49,14 +50,20 @@ fun FilterSheetHeader(
 @Composable
 fun FilterSection(
     title: String,
+    modifier: Modifier = Modifier,
     content: @Composable FlowRowScope.() -> Unit,
 ) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-    )
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-        content = content,
-    )
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(spacingMedium),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(spacingMedium),
+            content = content,
+        )
+    }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
+import com.cyrillrx.rpg.core.presentation.theme.spacingSmall
 import org.jetbrains.compose.resources.stringResource
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_reset_all
@@ -55,7 +56,7 @@ fun FilterSection(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(spacingMedium),
+        verticalArrangement = Arrangement.spacedBy(spacingSmall),
     ) {
         Text(
             text = title,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheetHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheetHeader.kt
@@ -1,0 +1,38 @@
+package com.cyrillrx.rpg.core.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.stringResource
+import rpg_companion.composeapp.generated.resources.Res
+import rpg_companion.composeapp.generated.resources.btn_reset_all
+
+/**
+ * Header row for a filter bottom sheet: a title on the left and a "reset all" button on the right.
+ */
+@Composable
+fun FilterSheetHeader(
+    title: String,
+    onResetFilters: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+        )
+        TextButton(onClick = onResetFilters) {
+            Text(text = stringResource(Res.string.btn_reset_all))
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheetHeader.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/FilterSheetHeader.kt
@@ -9,7 +9,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.btn_reset_all
 
@@ -34,5 +36,21 @@ fun FilterSheetHeader(
         TextButton(onClick = onResetFilters) {
             Text(text = stringResource(Res.string.btn_reset_all))
         }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewFilterSheetHeaderLight() {
+    AppThemePreview(darkTheme = false) {
+        FilterSheetHeader(title = "Filters", onResetFilters = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewFilterSheetHeaderDark() {
+    AppThemePreview(darkTheme = true) {
+        FilterSheetHeader(title = "Filters", onResetFilters = {})
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/component/MonsterFilterBottomSheet.kt
@@ -2,35 +2,28 @@ package com.cyrillrx.rpg.creature.presentation.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.FilterSection
+import com.cyrillrx.rpg.core.presentation.component.FilterSheetHeader
 import com.cyrillrx.rpg.core.presentation.component.dnd.formatCRValue
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
-import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_reset_all
 import rpg_companion.composeapp.generated.resources.label_filter_cr
 import rpg_companion.composeapp.generated.resources.label_filter_type
 import rpg_companion.composeapp.generated.resources.title_filter_monsters
@@ -63,7 +56,7 @@ private val commonCRs = listOf(
     30f,
 )
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MonsterFilterBottomSheet(
     filter: MonsterFilter,
@@ -83,28 +76,12 @@ fun MonsterFilterBottomSheet(
                 .padding(bottom = spacingLarge),
             verticalArrangement = Arrangement.spacedBy(spacingCommon),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringResource(Res.string.title_filter_monsters),
-                    style = MaterialTheme.typography.titleLarge,
-                )
-                TextButton(onClick = onResetFilters) {
-                    Text(text = stringResource(Res.string.btn_reset_all))
-                }
-            }
-
-            // Type
-            Text(
-                text = stringResource(Res.string.label_filter_type),
-                style = MaterialTheme.typography.titleSmall,
+            FilterSheetHeader(
+                title = stringResource(Res.string.title_filter_monsters),
+                onResetFilters = onResetFilters,
             )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
+
+            FilterSection(title = stringResource(Res.string.label_filter_type)) {
                 Monster.Type.entries.forEach { type ->
                     FilterChip(
                         selected = type in filter.types,
@@ -114,14 +91,7 @@ fun MonsterFilterBottomSheet(
                 }
             }
 
-            // Challenge Rating
-            Text(
-                text = stringResource(Res.string.label_filter_cr),
-                style = MaterialTheme.typography.titleSmall,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
+            FilterSection(title = stringResource(Res.string.label_filter_cr)) {
                 commonCRs.forEach { cr ->
                     val crLabel = formatCRValue(cr)
                     FilterChip(

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/component/MagicalItemFilterBottomSheet.kt
@@ -2,39 +2,32 @@ package com.cyrillrx.rpg.magicalitem.presentation.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.cyrillrx.rpg.core.presentation.component.FilterSection
+import com.cyrillrx.rpg.core.presentation.component.FilterSheetHeader
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
-import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_reset_all
 import rpg_companion.composeapp.generated.resources.label_filter_rarity
 import rpg_companion.composeapp.generated.resources.label_filter_type
 import rpg_companion.composeapp.generated.resources.title_filter_items
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MagicalItemFilterBottomSheet(
     filter: MagicalItemFilter,
@@ -54,28 +47,12 @@ fun MagicalItemFilterBottomSheet(
                 .padding(bottom = spacingLarge),
             verticalArrangement = Arrangement.spacedBy(spacingCommon),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringResource(Res.string.title_filter_items),
-                    style = MaterialTheme.typography.titleLarge,
-                )
-                TextButton(onClick = onResetFilters) {
-                    Text(text = stringResource(Res.string.btn_reset_all))
-                }
-            }
-
-            // Type
-            Text(
-                text = stringResource(Res.string.label_filter_type),
-                style = MaterialTheme.typography.titleSmall,
+            FilterSheetHeader(
+                title = stringResource(Res.string.title_filter_items),
+                onResetFilters = onResetFilters,
             )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
+
+            FilterSection(title = stringResource(Res.string.label_filter_type)) {
                 MagicalItem.Type.entries.forEach { type ->
                     FilterChip(
                         selected = type in filter.types,
@@ -85,14 +62,7 @@ fun MagicalItemFilterBottomSheet(
                 }
             }
 
-            // Rarity
-            Text(
-                text = stringResource(Res.string.label_filter_rarity),
-                style = MaterialTheme.typography.titleSmall,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-            ) {
+            FilterSection(title = stringResource(Res.string.label_filter_rarity)) {
                 MagicalItem.Rarity.entries.forEach { rarity ->
                     FilterChip(
                         selected = rarity in filter.rarities,

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/component/SpellFilterBottomSheet.kt
@@ -2,11 +2,6 @@ package com.cyrillrx.rpg.spell.presentation.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.FlowRowScope
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -21,25 +16,23 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.cyrillrx.rpg.character.domain.Character
+import com.cyrillrx.rpg.core.presentation.component.FilterSection
+import com.cyrillrx.rpg.core.presentation.component.FilterSheetHeader
 import com.cyrillrx.rpg.core.presentation.component.dnd.toFormattedString
 import com.cyrillrx.rpg.core.presentation.theme.AppThemePreview
 import com.cyrillrx.rpg.core.presentation.theme.spacingCommon
 import com.cyrillrx.rpg.core.presentation.theme.spacingLarge
-import com.cyrillrx.rpg.core.presentation.theme.spacingMedium
 import com.cyrillrx.rpg.spell.domain.ComponentFilterState
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rpg_companion.composeapp.generated.resources.Res
-import rpg_companion.composeapp.generated.resources.btn_reset_all
 import rpg_companion.composeapp.generated.resources.filter_component_excluded
 import rpg_companion.composeapp.generated.resources.filter_component_required
 import rpg_companion.composeapp.generated.resources.label_filter_class
@@ -70,28 +63,14 @@ fun SpellFilterBottomSheet(
                 .padding(bottom = spacingLarge),
             verticalArrangement = Arrangement.spacedBy(spacingCommon),
         ) {
-            FilterSheetHeader(onResetFilters = onResetFilters)
+            FilterSheetHeader(
+                title = stringResource(Res.string.title_filter_spells),
+                onResetFilters = onResetFilters,
+            )
             LevelFilterSection(filter.levels, onLevelToggled)
             ClassFilterSection(filter.characterClasses, onClassToggled)
             SchoolFilterSection(filter.schools, onSchoolToggled)
             ComponentFilterSection(filter.components, onComponentToggled)
-        }
-    }
-}
-
-@Composable
-private fun FilterSheetHeader(onResetFilters: () -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = stringResource(Res.string.title_filter_spells),
-            style = MaterialTheme.typography.titleLarge,
-        )
-        TextButton(onClick = onResetFilters) {
-            Text(text = stringResource(Res.string.btn_reset_all))
         }
     }
 }
@@ -161,22 +140,6 @@ private fun ComponentFilterSection(
             )
         }
     }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun FilterSection(
-    title: String,
-    content: @Composable FlowRowScope.() -> Unit,
-) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-    )
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(spacingMedium),
-        content = content,
-    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
## 📝 Description

Propagate the `FilterSection` refactor (introduced for spell filters) to the monster and magical item filters.

- Extract `FilterSection` and `FilterSheetHeader` out of `SpellFilterBottomSheet` into two shared components under `core/presentation/component/`. The header title is now a parameter instead of being hardcoded to the spell title.
- Rewrite the spell, monster and magical item filter bottom sheets to reuse the shared composables, removing the duplicated `Text(titleSmall) + FlowRow` blocks and the inlined header row.

Presentation-layer only: no changes to domain models, ViewModels, or the public bottom-sheet signatures.

## 🖼️ Media

**Minor spacing change (intended).** The shared `FilterSection` wraps its title and `FlowRow` in a `Column` spaced by `spacingSmall` (4.dp). Previously the title and its chips were emitted directly into the sheet's parent `Column`, so they inherited its `spacingCommon` (16.dp) gap.
As a result the **title → chips** gap tightens from 16.dp to 4.dp on all three sheets, while the gap **between sections** stays 16.dp.
This is a deliberate improvement (tighter grouping of a title with its chips);
chips and overall layout are otherwise unchanged.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
