### PR TITLE
fix(character): avoid comma in meters walk speed test names

### DIFF
--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CoerceToValidWalkSpeedInMetersTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/CoerceToValidWalkSpeedInMetersTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 class CoerceToValidWalkSpeedInMetersTest {
 
     @Test
-    fun `clamps values below 7,5 to 7,5`() {
+    fun `clamps values below 7 point 5 to 7 point 5`() {
         assertEquals(7.5f, 0f.coerceToValidWalkSpeedInMeters())
         assertEquals(7.5f, 5f.coerceToValidWalkSpeedInMeters())
         assertEquals(7.5f, 7f.coerceToValidWalkSpeedInMeters()) // closer to 7.5 than to 9
@@ -19,7 +19,7 @@ class CoerceToValidWalkSpeedInMetersTest {
     }
 
     @Test
-    fun `rounds to nearest multiple of 1,5`() {
+    fun `rounds to nearest multiple of 1 point 5`() {
         assertEquals(7.5f, 8f.coerceToValidWalkSpeedInMeters()) // closer to 7.5 than to 9
         assertEquals(10.5f, 10f.coerceToValidWalkSpeedInMeters()) // closer to 10.5 than to 9
         assertEquals(10.5f, 11f.coerceToValidWalkSpeedInMeters()) // closer to 10.5 than to 12

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/IsValidWalkSpeedInMetersTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/rpg/character/domain/IsValidWalkSpeedInMetersTest.kt
@@ -7,14 +7,14 @@ import kotlin.test.assertTrue
 class IsValidWalkSpeedInMetersTest {
 
     @Test
-    fun `returns false for values below 7,5`() {
+    fun `returns false for values below 7 point 5`() {
         assertFalse(isValidWalkSpeedInMeters(0f))
         assertFalse(isValidWalkSpeedInMeters(5f))
         assertFalse(isValidWalkSpeedInMeters(7f))
     }
 
     @Test
-    fun `returns false for non-multiples of 1,5`() {
+    fun `returns false for non-multiples of 1 point 5`() {
         assertFalse(isValidWalkSpeedInMeters(8f))
         assertFalse(isValidWalkSpeedInMeters(10f))
         assertFalse(isValidWalkSpeedInMeters(11f))


### PR DESCRIPTION
## 📝 Description

Fix the iOS test compilation of the meters walk-speed tests.

`CoerceToValidWalkSpeedInMetersTest` and `IsValidWalkSpeedInMetersTest` had backtick function names containing a comma decimal separator (`7,5`, `1,5`). These compile on JVM but are rejected by Kotlin/Native ("Name contains illegal characters"), which broke the `compileTestKotlinIos*` targets and `./gradlew build`.

The decimal separator is now spelled out as "point" (e.g. `7 point 5`), keeping the exact values while staying valid on all targets. Test logic and assertions are unchanged.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed
