### PR TITLE
refactor(data): run repository IO on an injected dispatcher

### DIFF
--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/LazyCache.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/LazyCache.kt
@@ -1,0 +1,20 @@
+package com.cyrillrx.core.data
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Memoizes the result of a suspending [loader].
+ *
+ * [loader] runs at most once even when [get] is called concurrently from several coroutines:
+ * the [Mutex] serializes the load and the double-check skips it once the value is set. This
+ * guards the lazy repository caches against the check-then-act race that a multi-threaded
+ * dispatcher makes reachable.
+ */
+class LazyCache<T : Any>(private val loader: suspend () -> T) {
+    private val mutex = Mutex()
+    private var value: T? = null
+
+    suspend fun get(): T =
+        value ?: mutex.withLock { value ?: loader().also { value = it } }
+}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/LazyCache.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/LazyCache.kt
@@ -2,6 +2,7 @@ package com.cyrillrx.core.data
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 /**
  * Memoizes the result of a suspending [loader].
@@ -13,6 +14,8 @@ import kotlinx.coroutines.sync.withLock
  */
 class LazyCache<T : Any>(private val loader: suspend () -> T) {
     private val mutex = Mutex()
+
+    @Volatile
     private var value: T? = null
 
     suspend fun get(): T =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/LazyCache.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/core/data/LazyCache.kt
@@ -11,6 +11,9 @@ import kotlin.concurrent.Volatile
  * the [Mutex] serializes the load and the double-check skips it once the value is set. This
  * guards the lazy repository caches against the check-then-act race that a multi-threaded
  * dispatcher makes reachable.
+ *
+ * A failing [loader] is not memoized: the exception propagates to the caller and the next
+ * [get] retries the load.
  */
 class LazyCache<T : Any>(private val loader: suspend () -> T) {
     private val mutex = Mutex()

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/data/SQLDelightCampaignRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/data/SQLDelightCampaignRepository.kt
@@ -5,33 +5,41 @@ import com.cyrillrx.rpg.campaign.domain.CampaignFilter
 import com.cyrillrx.rpg.campaign.domain.CampaignRepository
 import com.cyrillrx.rpg.core.data.cache.Database
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-class SQLDelightCampaignRepository(databaseDriverFactory: DatabaseDriverFactory) : CampaignRepository {
+class SQLDelightCampaignRepository(
+    databaseDriverFactory: DatabaseDriverFactory,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : CampaignRepository {
 
     private val database = Database(databaseDriverFactory)
 
-    override suspend fun getAll(filter: CampaignFilter?): List<Campaign> {
+    override suspend fun getAll(filter: CampaignFilter?): List<Campaign> = withContext(ioDispatcher) {
         val campaigns = database.getAllCampaigns()
-        filter ?: return campaigns
-
-        val query = filter.query
-        val ruleSets = filter.ruleSets
-
-        return campaigns.filter {
-            (ruleSets.isEmpty() || ruleSets.contains(it.ruleSet)) &&
-                (query.isBlank() || it.matches(query))
+        if (filter == null) {
+            campaigns
+        } else {
+            val query = filter.query
+            val ruleSets = filter.ruleSets
+            campaigns.filter {
+                (ruleSets.isEmpty() || ruleSets.contains(it.ruleSet)) &&
+                    (query.isBlank() || it.matches(query))
+            }
         }
     }
 
     private fun Campaign.matches(query: String): Boolean = name.contains(query, ignoreCase = true)
 
-    override suspend fun get(id: String): Campaign? = database.getCampaign(id)
+    override suspend fun get(id: String): Campaign? = withContext(ioDispatcher) { database.getCampaign(id) }
 
     override suspend fun save(campaign: Campaign) {
-        database.insertCampaign(campaign)
+        withContext(ioDispatcher) { database.insertCampaign(campaign) }
     }
 
     override suspend fun delete(id: String) {
-        database.deleteCampaign(id)
+        withContext(ioDispatcher) { database.deleteCampaign(id) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/data/SQLDelightCampaignRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/campaign/data/SQLDelightCampaignRepository.kt
@@ -19,19 +19,12 @@ class SQLDelightCampaignRepository(
 
     override suspend fun getAll(filter: CampaignFilter?): List<Campaign> = withContext(ioDispatcher) {
         val campaigns = database.getAllCampaigns()
-        if (filter == null) {
-            campaigns
-        } else {
-            val query = filter.query
-            val ruleSets = filter.ruleSets
-            campaigns.filter {
-                (ruleSets.isEmpty() || ruleSets.contains(it.ruleSet)) &&
-                    (query.isBlank() || it.matches(query))
-            }
-        }
+        if (filter == null) campaigns else campaigns.filter { it.matches(filter) }
     }
 
-    private fun Campaign.matches(query: String): Boolean = name.contains(query, ignoreCase = true)
+    private fun Campaign.matches(filter: CampaignFilter): Boolean =
+        (filter.ruleSets.isEmpty() || filter.ruleSets.contains(ruleSet)) &&
+            (filter.query.isBlank() || name.contains(filter.query, ignoreCase = true))
 
     override suspend fun get(id: String): Campaign? = withContext(ioDispatcher) { database.getCampaign(id) }
 

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -17,18 +17,23 @@ import com.cyrillrx.rpg.creature.data.toAlignment
 import com.cyrillrx.rpg.creature.data.toSize
 import com.cyrillrx.rpg.creature.data.toSkills
 import com.cyrillrx.rpg.creature.data.toSpeeds
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
 class JsonCharacterPresetRepository(
     private val fileReader: FileReader,
     private val filePath: String,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : CharacterRepository {
     private var cache: List<Character>? = null
 
-    override suspend fun getAll(filter: CharacterFilter?): List<Character> {
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> = withContext(ioDispatcher) {
         val all = cache ?: loadFromFile()
             .parse()
             .also { cache = it }
-        return all.applyFilter(filter)
+        all.applyFilter(filter)
     }
 
     override suspend fun get(id: String): Character? = getAll(null).firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/JsonCharacterPresetRepository.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.character.data
 
 import com.cyrillrx.core.data.FileReader
+import com.cyrillrx.core.data.LazyCache
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
 import com.cyrillrx.core.domain.partitionBy
@@ -27,13 +28,10 @@ class JsonCharacterPresetRepository(
     private val filePath: String,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : CharacterRepository {
-    private var cache: List<Character>? = null
+    private val cache = LazyCache { loadFromFile().parse() }
 
     override suspend fun getAll(filter: CharacterFilter?): List<Character> = withContext(ioDispatcher) {
-        val all = cache ?: loadFromFile()
-            .parse()
-            .also { cache = it }
-        all.applyFilter(filter)
+        cache.get().applyFilter(filter)
     }
 
     override suspend fun get(id: String): Character? = getAll(null).firstOrNull { it.id == id }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/character/data/SQLDelightCharacterRepository.kt
@@ -5,25 +5,35 @@ import com.cyrillrx.rpg.character.domain.CharacterFilter
 import com.cyrillrx.rpg.character.domain.CharacterRepository
 import com.cyrillrx.rpg.core.data.cache.Database
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-class SQLDelightCharacterRepository(databaseDriverFactory: DatabaseDriverFactory) : CharacterRepository {
+class SQLDelightCharacterRepository(
+    databaseDriverFactory: DatabaseDriverFactory,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : CharacterRepository {
 
     private val database = Database(databaseDriverFactory)
 
-    override suspend fun getAll(filter: CharacterFilter?): List<Character> {
+    override suspend fun getAll(filter: CharacterFilter?): List<Character> = withContext(ioDispatcher) {
         val characters = database.getAllCharacters()
-        filter ?: return characters
-        return characters.filter { it.matches(filter) }
+        if (filter == null) characters else characters.filter { it.matches(filter) }
     }
 
-    override suspend fun get(id: String): Character? = database.getCharacter(id)
+    override suspend fun get(id: String): Character? = withContext(ioDispatcher) { database.getCharacter(id) }
 
     override suspend fun getByIds(ids: List<String>): List<Character> =
-        database.getCharactersByIds(ids)
+        withContext(ioDispatcher) { database.getCharactersByIds(ids) }
 
-    override suspend fun save(character: Character) = database.saveCharacter(character)
+    override suspend fun save(character: Character) {
+        withContext(ioDispatcher) { database.saveCharacter(character) }
+    }
 
-    override suspend fun delete(id: String) = database.deleteCharacter(id)
+    override suspend fun delete(id: String) {
+        withContext(ioDispatcher) { database.deleteCharacter(id) }
+    }
 
     private fun Character.matches(filter: CharacterFilter): Boolean =
         filter.query.isBlank() || name.contains(filter.query, ignoreCase = true)

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -9,14 +9,21 @@ import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.MonsterRepository
 import com.cyrillrx.rpg.creature.domain.applyFilter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-class JsonMonsterRepository(private val fileReader: FileReader) : MonsterRepository {
+class JsonMonsterRepository(
+    private val fileReader: FileReader,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : MonsterRepository {
 
     private var cache: List<Monster>? = null
 
-    override suspend fun getAll(filter: MonsterFilter?): List<Monster> {
+    override suspend fun getAll(filter: MonsterFilter?): List<Monster> = withContext(ioDispatcher) {
         val all = cache ?: loadFromFile().parse().also { cache = it }
-        return all.applyFilter(filter)
+        all.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Monster? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/data/JsonMonsterRepository.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.creature.data
 
 import com.cyrillrx.core.data.FileReader
+import com.cyrillrx.core.data.LazyCache
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
 import com.cyrillrx.core.domain.partitionBy
@@ -19,11 +20,10 @@ class JsonMonsterRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : MonsterRepository {
 
-    private var cache: List<Monster>? = null
+    private val cache = LazyCache { loadFromFile().parse() }
 
     override suspend fun getAll(filter: MonsterFilter?): List<Monster> = withContext(ioDispatcher) {
-        val all = cache ?: loadFromFile().parse().also { cache = it }
-        all.applyFilter(filter)
+        cache.get().applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Monster? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -9,16 +9,23 @@ import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.domain.applyFilter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-class JsonMagicalItemRepository(private val fileReader: FileReader) : MagicalItemRepository {
+class JsonMagicalItemRepository(
+    private val fileReader: FileReader,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : MagicalItemRepository {
 
     private var cache: List<MagicalItem>? = null
 
-    override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
+    override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> = withContext(ioDispatcher) {
         val allItems = cache ?: loadFromFile()
             .parse()
             .also { cache = it }
-        return allItems.applyFilter(filter)
+        allItems.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): MagicalItem? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/data/JsonMagicalItemRepository.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.magicalitem.data
 
 import com.cyrillrx.core.data.FileReader
+import com.cyrillrx.core.data.LazyCache
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
 import com.cyrillrx.core.domain.partitionBy
@@ -19,13 +20,10 @@ class JsonMagicalItemRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : MagicalItemRepository {
 
-    private var cache: List<MagicalItem>? = null
+    private val cache = LazyCache { loadFromFile().parse() }
 
     override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> = withContext(ioDispatcher) {
-        val allItems = cache ?: loadFromFile()
-            .parse()
-            .also { cache = it }
-        allItems.applyFilter(filter)
+        cache.get().applyFilter(filter)
     }
 
     override suspend fun getById(id: String): MagicalItem? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/settings/data/SqlDelightUserPreferencesRepository.kt
@@ -6,6 +6,7 @@ import com.cyrillrx.rpg.settings.domain.DistanceUnit
 import com.cyrillrx.rpg.settings.domain.Theme
 import com.cyrillrx.rpg.settings.domain.UserPreferences
 import com.cyrillrx.rpg.settings.domain.UserPreferencesRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,28 +14,31 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
-class SqlDelightUserPreferencesRepository(driverFactory: DatabaseDriverFactory) : UserPreferencesRepository {
+class SqlDelightUserPreferencesRepository(
+    driverFactory: DatabaseDriverFactory,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : UserPreferencesRepository {
     private val db = Database(driverFactory)
 
     override val preferences: StateFlow<UserPreferences>
         field = MutableStateFlow(UserPreferences())
 
     override suspend fun initialize() {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             db.initUserPreferences()
             preferences.value = db.getUserPreferences()
         }
     }
 
     override suspend fun setTheme(theme: Theme) {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             db.updateTheme(theme)
             preferences.update { it.copy(theme = theme) }
         }
     }
 
     override suspend fun setDistanceUnit(distanceUnit: DistanceUnit) {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             db.updateDistanceUnit(distanceUnit)
             preferences.update { it.copy(distanceUnit = distanceUnit) }
         }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -1,6 +1,7 @@
 package com.cyrillrx.rpg.spell.data
 
 import com.cyrillrx.core.data.FileReader
+import com.cyrillrx.core.data.LazyCache
 import com.cyrillrx.core.data.deserialize
 import com.cyrillrx.core.domain.Result
 import com.cyrillrx.core.domain.partitionBy
@@ -20,13 +21,10 @@ class JsonSpellRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : SpellRepository {
 
-    private var cache: List<Spell>? = null
+    private val cache = LazyCache { loadFromFile().parse() }
 
     override suspend fun getAll(filter: SpellFilter?): List<Spell> = withContext(ioDispatcher) {
-        val allSpells = cache ?: loadFromFile()
-            .parse()
-            .also { cache = it }
-        allSpells.applyFilter(filter)
+        cache.get().applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Spell? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/data/JsonSpellRepository.kt
@@ -10,16 +10,23 @@ import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.domain.applyFilter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-class JsonSpellRepository(private val fileReader: FileReader) : SpellRepository {
+class JsonSpellRepository(
+    private val fileReader: FileReader,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : SpellRepository {
 
     private var cache: List<Spell>? = null
 
-    override suspend fun getAll(filter: SpellFilter?): List<Spell> {
+    override suspend fun getAll(filter: SpellFilter?): List<Spell> = withContext(ioDispatcher) {
         val allSpells = cache ?: loadFromFile()
             .parse()
             .also { cache = it }
-        return allSpells.applyFilter(filter)
+        allSpells.applyFilter(filter)
     }
 
     override suspend fun getById(id: String): Spell? =

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/SQLDelightUserListRepository.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/userlist/data/SQLDelightUserListRepository.kt
@@ -4,19 +4,27 @@ import com.cyrillrx.rpg.core.data.cache.Database
 import com.cyrillrx.rpg.core.data.cache.DatabaseDriverFactory
 import com.cyrillrx.rpg.userlist.domain.UserList
 import com.cyrillrx.rpg.userlist.domain.UserListRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-class SQLDelightUserListRepository(databaseDriverFactory: DatabaseDriverFactory) : UserListRepository {
+class SQLDelightUserListRepository(
+    databaseDriverFactory: DatabaseDriverFactory,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : UserListRepository {
     private val database = Database(databaseDriverFactory)
 
-    override suspend fun getAll(type: UserList.Type): List<UserList> = database.getAllUserLists(type)
+    override suspend fun getAll(type: UserList.Type): List<UserList> =
+        withContext(ioDispatcher) { database.getAllUserLists(type) }
 
-    override suspend fun get(id: String): UserList? = database.getUserList(id)
+    override suspend fun get(id: String): UserList? = withContext(ioDispatcher) { database.getUserList(id) }
 
     override suspend fun save(list: UserList) {
-        database.saveUserList(list)
+        withContext(ioDispatcher) { database.saveUserList(list) }
     }
 
     override suspend fun delete(id: String) {
-        database.deleteUserList(id)
+        withContext(ioDispatcher) { database.deleteUserList(id) }
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/data/LazyCacheTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/data/LazyCacheTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class LazyCacheTest {
@@ -36,5 +37,19 @@ class LazyCacheTest {
 
         assertEquals(1, loads)
         assertTrue(results.all { it == "value" })
+    }
+
+    @Test
+    fun `does not memoize a failed load and retries on the next get`() = runTest {
+        var loads = 0
+        val cache = LazyCache {
+            loads++
+            if (loads == 1) error("boom")
+            "value"
+        }
+
+        assertFailsWith<IllegalStateException> { cache.get() }
+        assertEquals("value", cache.get())
+        assertEquals(2, loads)
     }
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/data/LazyCacheTest.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonTest/kotlin/com/cyrillrx/core/data/LazyCacheTest.kt
@@ -1,0 +1,40 @@
+package com.cyrillrx.core.data
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LazyCacheTest {
+
+    @Test
+    fun `loads once across multiple sequential gets`() = runTest {
+        var loads = 0
+        val cache = LazyCache {
+            loads++
+            "value"
+        }
+
+        assertEquals("value", cache.get())
+        assertEquals("value", cache.get())
+        assertEquals(1, loads)
+    }
+
+    @Test
+    fun `concurrent gets trigger a single load`() = runTest {
+        var loads = 0
+        val cache = LazyCache {
+            loads++
+            yield()
+            "value"
+        }
+
+        val results = (1..10).map { async { cache.get() } }.awaitAll()
+
+        assertEquals(1, loads)
+        assertTrue(results.all { it == "value" })
+    }
+}


### PR DESCRIPTION
## 📝 Description

Repository reads/writes used to run on the caller's dispatcher (often the main thread): the JSON repositories read a bundled file + parse it, and the SQLDelight repositories run blocking DB queries — none wrapped in `withContext`. Only `SqlDelightUserPreferencesRepository` was protected, but with a **hardcoded** `Dispatchers.IO`.

**Dispatcher injection**
Moves all blocking repository IO off the calling thread via a **constructor-injected** `CoroutineDispatcher` (default `Dispatchers.IO`), following the convention already used by the ViewModels/Factories (`ioDispatcher: CoroutineDispatcher = Dispatchers.IO`):
- JSON repos (`JsonSpellRepository`, `JsonMonsterRepository`, `JsonMagicalItemRepository`, `JsonCharacterPresetRepository`): inject `ioDispatcher`, wrap `getAll` in `withContext(ioDispatcher)`.
- SQLDelight repos (`SQLDelightCharacterRepository`, `SQLDelightCampaignRepository`, `SQLDelightUserListRepository`): inject `ioDispatcher`, wrap each suspend accessor.
- `SqlDelightUserPreferencesRepository`: replace the hardcoded `Dispatchers.IO` with the injected `ioDispatcher`.

Thanks to the defaulted parameter, the instantiation sites in `App.kt` compile unchanged. Sample/RAM repositories do no blocking IO and are left untouched.

**Thread-safe cache (`LazyCache`)**
Running `getAll` on a multi-threaded dispatcher makes the JSON repos' `var cache` check-then-act reachable by concurrent callers (worst case: the file is parsed several times). New `LazyCache<T>` utility (Mutex + double-check) loads at most once even under concurrent `get()`; the four JSON repositories now cache through it instead of the per-repo `var cache`.

No visible behavior change.

## 🖼️ Media

_N/A — internal threading refactor, no UI change._

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed
