### PR TITLE
perf: compose swipe backgrounds only during active swipe

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAdd.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToAdd.kt
@@ -51,21 +51,30 @@ fun SwipeToAdd(
         enableDismissFromStartToEnd = true,
         enableDismissFromEndToStart = false,
         backgroundContent = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(Green500)
-                    .padding(start = spacingMedium),
-                contentAlignment = Alignment.CenterStart,
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary,
-                )
+            // Compose the background only while a swipe is in progress; every non-swiped row
+            // (the common case during scroll) then skips this subtree entirely.
+            if (dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd) {
+                SwipeAddBackground()
             }
         },
         content = content,
     )
+}
+
+@Composable
+private fun SwipeAddBackground() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(MaterialTheme.shapes.medium)
+            .background(Green500)
+            .padding(start = spacingMedium),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimary,
+        )
+    }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToDelete.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/component/SwipeToDelete.kt
@@ -38,21 +38,30 @@ fun SwipeToDelete(
         enableDismissFromStartToEnd = false,
         enableDismissFromEndToStart = true,
         backgroundContent = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(MaterialTheme.colorScheme.errorContainer)
-                    .padding(end = spacingMedium),
-                contentAlignment = Alignment.CenterEnd,
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onErrorContainer,
-                )
+            // Compose the background only while a swipe is in progress; every non-swiped row
+            // (the common case during scroll) then skips this subtree entirely.
+            if (dismissState.dismissDirection == SwipeToDismissBoxValue.EndToStart) {
+                SwipeDeleteBackground()
             }
         },
         content = content,
     )
+}
+
+@Composable
+private fun SwipeDeleteBackground() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(MaterialTheme.shapes.medium)
+            .background(MaterialTheme.colorScheme.errorContainer)
+            .padding(end = spacingMedium),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Delete,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onErrorContainer,
+        )
+    }
 }


### PR DESCRIPTION
## 📝 Description

Extracts a self-contained scroll optimization from #163 (which is otherwise gated on on-device baseline-profile measurements).

`SwipeToAdd` / `SwipeToDelete` previously composed their swipe background `Box` unconditionally for every row. This composes the background only while a swipe is in progress (`dismissDirection` is `StartToEnd` / `EndToStart`), so every non-swiped row — the common case during scroll — skips that subtree entirely and trims per-item composition cost.

No user-visible change: the background is only ever shown during an active swipe.

## 🖼️ Media

N/A — no visible UI change.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (behavior-neutral Compose refactor; no dedicated tests for these components)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [x] Documentation updated if public APIs or architecture decisions changed
