### PR TITLE
perf: debounce compendium search and avoid list flicker

### DIFF
--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/viewmodel/BaseListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/viewmodel/BaseListViewModel.kt
@@ -5,6 +5,9 @@ import com.cyrillrx.rpg.core.presentation.ScrollPosition
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 
+/** Delay before re-filtering after a search-query change, so typing doesn't filter on every keystroke. */
+internal const val SEARCH_DEBOUNCE_MS = 250L
+
 abstract class BaseListViewModel : ViewModel() {
 
     var savedScrollPosition: ScrollPosition = ScrollPosition()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/viewmodel/BaseListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/viewmodel/BaseListViewModel.kt
@@ -5,9 +5,6 @@ import com.cyrillrx.rpg.core.presentation.ScrollPosition
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 
-/** Delay before re-filtering after a search-query change, so typing doesn't filter on every keystroke. */
-internal const val SEARCH_DEBOUNCE_MS = 250L
-
 abstract class BaseListViewModel : ViewModel() {
 
     var savedScrollPosition: ScrollPosition = ScrollPosition()

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/viewmodel/SearchableListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/core/presentation/viewmodel/SearchableListViewModel.kt
@@ -1,0 +1,77 @@
+package com.cyrillrx.rpg.core.presentation.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+
+/** Delay before re-filtering after a search-query change, so typing doesn't filter on every keystroke. */
+internal const val SEARCH_DEBOUNCE_MS = 250L
+
+/**
+ * Base view model for filterable/searchable lists. Owns the load lifecycle shared by every
+ * compendium list: a single cancellable [updateJob], search-query debouncing, scroll reset timing
+ * and the "keep current results visible while re-filtering" behavior. Subclasses only describe how
+ * to read/write their own [State]/[Body] and how to fetch results for the current filter.
+ */
+abstract class SearchableListViewModel<State : Any, Body : Any>(
+    initialState: State,
+) : BaseListViewModel() {
+
+    protected val mutableState = MutableStateFlow(initialState)
+    val state: StateFlow<State> = mutableState.asStateFlow()
+
+    private var updateJob: Job? = null
+
+    protected abstract fun State.body(): Body
+    protected abstract fun State.withBody(body: Body): State
+
+    /** Body shown while the initial (or a post-error) load is running. */
+    protected abstract fun loadingBody(): Body
+
+    /** Body shown when [loadContent] fails. */
+    protected abstract fun errorBody(): Body
+
+    /**
+     * Whether [body] already shows something the user can keep looking at (results or an empty
+     * result) while a new load runs. When true, no loader is shown, avoiding a list → loader → list
+     * flicker on every re-filter.
+     */
+    protected abstract fun showsContent(body: Body): Boolean
+
+    /** Fetches the results for the current filter and maps them to a display body. */
+    protected abstract suspend fun loadContent(): Body
+
+    /**
+     * Cancels any in-flight load and (re)loads the list.
+     *
+     * @param debounce collapses a burst of query changes into a single load once the user pauses.
+     * @param resetScroll scrolls the list back to top on the same (debounced) path, so the scroll
+     *   reset stays in sync with the results instead of firing on every keystroke.
+     */
+    protected fun refresh(debounce: Boolean = false, resetScroll: Boolean = false) {
+        updateJob?.cancel()
+        updateJob = viewModelScope.launch {
+            if (debounce) delay(SEARCH_DEBOUNCE_MS)
+            if (resetScroll) scrollToTop()
+
+            if (!showsContent(mutableState.value.body())) {
+                mutableState.update { it.withBody(loadingBody()) }
+            }
+
+            val body = try {
+                loadContent()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                errorBody()
+            }
+            mutableState.update { it.withBody(body) }
+        }
+    }
+}

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
@@ -1,33 +1,23 @@
 package com.cyrillrx.rpg.creature.presentation.viewmodel
 
-import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.domain.toggled
-import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
-import com.cyrillrx.rpg.core.presentation.viewmodel.SEARCH_DEBOUNCE_MS
+import com.cyrillrx.rpg.core.presentation.viewmodel.SearchableListViewModel
 import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.MonsterRepository
 import com.cyrillrx.rpg.creature.presentation.MonsterListState
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_monsters
-import kotlin.coroutines.cancellation.CancellationException
 
 class MonsterListViewModel(
     private val repository: MonsterRepository,
-) : BaseListViewModel() {
-
-    private var updateJob: Job? = null
-    val state: StateFlow<MonsterListState>
-        field = MutableStateFlow(MonsterListState(body = MonsterListState.Body.Empty))
+) : SearchableListViewModel<MonsterListState, MonsterListState.Body>(
+        initialState = MonsterListState(body = MonsterListState.Body.Loading),
+    ) {
 
     init {
-        refreshData()
+        refresh()
     }
 
     fun filterByQuery(query: String) {
@@ -47,39 +37,28 @@ class MonsterListViewModel(
     }
 
     private fun updateFilter(debounce: Boolean = false, transform: (MonsterFilter) -> MonsterFilter) {
-        state.update { it.copy(filter = transform(it.filter)) }
-        scrollToTop()
-        refreshData(debounce)
+        mutableState.update { it.copy(filter = transform(it.filter)) }
+        refresh(debounce = debounce, resetScroll = true)
     }
 
-    private fun refreshData(debounce: Boolean = false) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch {
-            if (debounce) delay(SEARCH_DEBOUNCE_MS)
-            updateData()
-        }
-    }
+    override fun MonsterListState.body(): MonsterListState.Body = body
 
-    private suspend fun updateData() {
-        val filter = state.value.filter
-        if (state.value.body !is MonsterListState.Body.WithData) {
-            state.update { it.copy(body = MonsterListState.Body.Loading) }
-        }
+    override fun MonsterListState.withBody(body: MonsterListState.Body): MonsterListState = copy(body = body)
 
-        try {
-            val monsters = repository.getAll(filter)
-            val body = if (monsters.isEmpty()) {
-                MonsterListState.Body.Empty
-            } else {
-                MonsterListState.Body.WithData(searchResults = monsters)
-            }
-            state.update { it.copy(body = body) }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            state.update {
-                it.copy(body = MonsterListState.Body.Error(errorMessage = Res.string.error_while_loading_monsters))
-            }
+    override fun loadingBody(): MonsterListState.Body = MonsterListState.Body.Loading
+
+    override fun errorBody(): MonsterListState.Body =
+        MonsterListState.Body.Error(errorMessage = Res.string.error_while_loading_monsters)
+
+    override fun showsContent(body: MonsterListState.Body): Boolean =
+        body is MonsterListState.Body.WithData || body is MonsterListState.Body.Empty
+
+    override suspend fun loadContent(): MonsterListState.Body {
+        val monsters = repository.getAll(mutableState.value.filter)
+        return if (monsters.isEmpty()) {
+            MonsterListState.Body.Empty
+        } else {
+            MonsterListState.Body.WithData(searchResults = monsters)
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModel.kt
@@ -3,11 +3,13 @@ package com.cyrillrx.rpg.creature.presentation.viewmodel
 import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
+import com.cyrillrx.rpg.core.presentation.viewmodel.SEARCH_DEBOUNCE_MS
 import com.cyrillrx.rpg.creature.domain.Monster
 import com.cyrillrx.rpg.creature.domain.MonsterFilter
 import com.cyrillrx.rpg.creature.domain.MonsterRepository
 import com.cyrillrx.rpg.creature.presentation.MonsterListState
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -29,7 +31,7 @@ class MonsterListViewModel(
     }
 
     fun filterByQuery(query: String) {
-        updateFilter { it.copy(query = query) }
+        updateFilter(debounce = true) { it.copy(query = query) }
     }
 
     fun onTypeToggled(type: Monster.Type) {
@@ -44,20 +46,25 @@ class MonsterListViewModel(
         updateFilter { MonsterFilter(query = it.query) }
     }
 
-    private fun updateFilter(transform: (MonsterFilter) -> MonsterFilter) {
+    private fun updateFilter(debounce: Boolean = false, transform: (MonsterFilter) -> MonsterFilter) {
         state.update { it.copy(filter = transform(it.filter)) }
         scrollToTop()
-        refreshData()
+        refreshData(debounce)
     }
 
-    private fun refreshData() {
+    private fun refreshData(debounce: Boolean = false) {
         updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData() }
+        updateJob = viewModelScope.launch {
+            if (debounce) delay(SEARCH_DEBOUNCE_MS)
+            updateData()
+        }
     }
 
     private suspend fun updateData() {
         val filter = state.value.filter
-        state.update { it.copy(body = MonsterListState.Body.Loading) }
+        if (state.value.body !is MonsterListState.Body.WithData) {
+            state.update { it.copy(body = MonsterListState.Body.Loading) }
+        }
 
         try {
             val monsters = repository.getAll(filter)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -3,11 +3,13 @@ package com.cyrillrx.rpg.magicalitem.presentation.viewmodel
 import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
+import com.cyrillrx.rpg.core.presentation.viewmodel.SEARCH_DEBOUNCE_MS
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -29,7 +31,7 @@ class MagicalItemListViewModel(
     }
 
     fun filterByQuery(query: String) {
-        updateFilter { it.copy(query = query) }
+        updateFilter(debounce = true) { it.copy(query = query) }
     }
 
     fun onTypeToggled(type: MagicalItem.Type) {
@@ -44,20 +46,25 @@ class MagicalItemListViewModel(
         updateFilter { MagicalItemFilter(query = it.query) }
     }
 
-    private fun updateFilter(transform: (MagicalItemFilter) -> MagicalItemFilter) {
+    private fun updateFilter(debounce: Boolean = false, transform: (MagicalItemFilter) -> MagicalItemFilter) {
         state.update { it.copy(filter = transform(it.filter)) }
         scrollToTop()
-        refreshData()
+        refreshData(debounce)
     }
 
-    private fun refreshData() {
+    private fun refreshData(debounce: Boolean = false) {
         updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData() }
+        updateJob = viewModelScope.launch {
+            if (debounce) delay(SEARCH_DEBOUNCE_MS)
+            updateData()
+        }
     }
 
     private suspend fun updateData() {
         val filter = state.value.filter
-        state.update { it.copy(body = MagicalItemListState.Body.Loading) }
+        if (state.value.body !is MagicalItemListState.Body.WithData) {
+            state.update { it.copy(body = MagicalItemListState.Body.Loading) }
+        }
 
         try {
             val magicalItems = repository.getAll(filter)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModel.kt
@@ -1,33 +1,23 @@
 package com.cyrillrx.rpg.magicalitem.presentation.viewmodel
 
-import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.core.domain.toggled
-import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
-import com.cyrillrx.rpg.core.presentation.viewmodel.SEARCH_DEBOUNCE_MS
+import com.cyrillrx.rpg.core.presentation.viewmodel.SearchableListViewModel
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItem
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemFilter
 import com.cyrillrx.rpg.magicalitem.domain.MagicalItemRepository
 import com.cyrillrx.rpg.magicalitem.presentation.MagicalItemListState
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_magical_items
-import kotlin.coroutines.cancellation.CancellationException
 
 class MagicalItemListViewModel(
     private val repository: MagicalItemRepository,
-) : BaseListViewModel() {
-
-    private var updateJob: Job? = null
-    val state: StateFlow<MagicalItemListState>
-        field = MutableStateFlow(MagicalItemListState(body = MagicalItemListState.Body.Empty))
+) : SearchableListViewModel<MagicalItemListState, MagicalItemListState.Body>(
+        initialState = MagicalItemListState(body = MagicalItemListState.Body.Loading),
+    ) {
 
     init {
-        refreshData()
+        refresh()
     }
 
     fun filterByQuery(query: String) {
@@ -47,41 +37,29 @@ class MagicalItemListViewModel(
     }
 
     private fun updateFilter(debounce: Boolean = false, transform: (MagicalItemFilter) -> MagicalItemFilter) {
-        state.update { it.copy(filter = transform(it.filter)) }
-        scrollToTop()
-        refreshData(debounce)
+        mutableState.update { it.copy(filter = transform(it.filter)) }
+        refresh(debounce = debounce, resetScroll = true)
     }
 
-    private fun refreshData(debounce: Boolean = false) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch {
-            if (debounce) delay(SEARCH_DEBOUNCE_MS)
-            updateData()
-        }
-    }
+    override fun MagicalItemListState.body(): MagicalItemListState.Body = body
 
-    private suspend fun updateData() {
-        val filter = state.value.filter
-        if (state.value.body !is MagicalItemListState.Body.WithData) {
-            state.update { it.copy(body = MagicalItemListState.Body.Loading) }
-        }
+    override fun MagicalItemListState.withBody(body: MagicalItemListState.Body): MagicalItemListState =
+        copy(body = body)
 
-        try {
-            val magicalItems = repository.getAll(filter)
-            val body = if (magicalItems.isEmpty()) {
-                MagicalItemListState.Body.Empty
-            } else {
-                MagicalItemListState.Body.WithData(searchResults = magicalItems)
-            }
-            state.update { it.copy(body = body) }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            state.update {
-                it.copy(
-                    body = MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items),
-                )
-            }
+    override fun loadingBody(): MagicalItemListState.Body = MagicalItemListState.Body.Loading
+
+    override fun errorBody(): MagicalItemListState.Body =
+        MagicalItemListState.Body.Error(errorMessage = Res.string.error_while_loading_magical_items)
+
+    override fun showsContent(body: MagicalItemListState.Body): Boolean =
+        body is MagicalItemListState.Body.WithData || body is MagicalItemListState.Body.Empty
+
+    override suspend fun loadContent(): MagicalItemListState.Body {
+        val magicalItems = repository.getAll(mutableState.value.filter)
+        return if (magicalItems.isEmpty()) {
+            MagicalItemListState.Body.Empty
+        } else {
+            MagicalItemListState.Body.WithData(searchResults = magicalItems)
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -4,12 +4,14 @@ import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.domain.toggled
 import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
+import com.cyrillrx.rpg.core.presentation.viewmodel.SEARCH_DEBOUNCE_MS
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.domain.cycled
 import com.cyrillrx.rpg.spell.presentation.SpellListState
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -31,7 +33,7 @@ class SpellListViewModel(
     }
 
     fun filterByQuery(query: String) {
-        updateFilter { it.copy(query = query) }
+        updateFilter(debounce = true) { it.copy(query = query) }
     }
 
     fun onLevelToggled(level: Int) {
@@ -54,20 +56,25 @@ class SpellListViewModel(
         updateFilter { SpellFilter(query = it.query) }
     }
 
-    private fun updateFilter(transform: (SpellFilter) -> SpellFilter) {
+    private fun updateFilter(debounce: Boolean = false, transform: (SpellFilter) -> SpellFilter) {
         state.update { it.copy(filter = transform(it.filter)) }
         scrollToTop()
-        refreshData()
+        refreshData(debounce)
     }
 
-    private fun refreshData() {
+    private fun refreshData(debounce: Boolean = false) {
         updateJob?.cancel()
-        updateJob = viewModelScope.launch { updateData() }
+        updateJob = viewModelScope.launch {
+            if (debounce) delay(SEARCH_DEBOUNCE_MS)
+            updateData()
+        }
     }
 
     private suspend fun updateData() {
         val filter = state.value.filter
-        state.update { it.copy(body = SpellListState.Body.Loading) }
+        if (state.value.body !is SpellListState.Body.WithData) {
+            state.update { it.copy(body = SpellListState.Body.Loading) }
+        }
 
         try {
             val spells = repository.getAll(filter)

--- a/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonMain/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModel.kt
@@ -1,35 +1,25 @@
 package com.cyrillrx.rpg.spell.presentation.viewmodel
 
-import androidx.lifecycle.viewModelScope
 import com.cyrillrx.rpg.character.domain.Character
 import com.cyrillrx.rpg.core.domain.toggled
-import com.cyrillrx.rpg.core.presentation.viewmodel.BaseListViewModel
-import com.cyrillrx.rpg.core.presentation.viewmodel.SEARCH_DEBOUNCE_MS
+import com.cyrillrx.rpg.core.presentation.viewmodel.SearchableListViewModel
 import com.cyrillrx.rpg.spell.domain.Spell
 import com.cyrillrx.rpg.spell.domain.SpellFilter
 import com.cyrillrx.rpg.spell.domain.SpellRepository
 import com.cyrillrx.rpg.spell.domain.cycled
 import com.cyrillrx.rpg.spell.presentation.SpellListState
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import rpg_companion.composeapp.generated.resources.Res
 import rpg_companion.composeapp.generated.resources.error_while_loading_spells
-import kotlin.coroutines.cancellation.CancellationException
 
 class SpellListViewModel(
     private val repository: SpellRepository,
-) : BaseListViewModel() {
-
-    private var updateJob: Job? = null
-    val state: StateFlow<SpellListState>
-        field = MutableStateFlow(SpellListState(body = SpellListState.Body.Empty))
+) : SearchableListViewModel<SpellListState, SpellListState.Body>(
+        initialState = SpellListState(body = SpellListState.Body.Loading),
+    ) {
 
     init {
-        refreshData()
+        refresh()
     }
 
     fun filterByQuery(query: String) {
@@ -57,39 +47,28 @@ class SpellListViewModel(
     }
 
     private fun updateFilter(debounce: Boolean = false, transform: (SpellFilter) -> SpellFilter) {
-        state.update { it.copy(filter = transform(it.filter)) }
-        scrollToTop()
-        refreshData(debounce)
+        mutableState.update { it.copy(filter = transform(it.filter)) }
+        refresh(debounce = debounce, resetScroll = true)
     }
 
-    private fun refreshData(debounce: Boolean = false) {
-        updateJob?.cancel()
-        updateJob = viewModelScope.launch {
-            if (debounce) delay(SEARCH_DEBOUNCE_MS)
-            updateData()
-        }
-    }
+    override fun SpellListState.body(): SpellListState.Body = body
 
-    private suspend fun updateData() {
-        val filter = state.value.filter
-        if (state.value.body !is SpellListState.Body.WithData) {
-            state.update { it.copy(body = SpellListState.Body.Loading) }
-        }
+    override fun SpellListState.withBody(body: SpellListState.Body): SpellListState = copy(body = body)
 
-        try {
-            val spells = repository.getAll(filter)
-            val body = if (spells.isEmpty()) {
-                SpellListState.Body.Empty
-            } else {
-                SpellListState.Body.WithData(spells)
-            }
-            state.update { it.copy(body = body) }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            state.update {
-                it.copy(body = SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells))
-            }
+    override fun loadingBody(): SpellListState.Body = SpellListState.Body.Loading
+
+    override fun errorBody(): SpellListState.Body =
+        SpellListState.Body.Error(errorMessage = Res.string.error_while_loading_spells)
+
+    override fun showsContent(body: SpellListState.Body): Boolean =
+        body is SpellListState.Body.WithData || body is SpellListState.Body.Empty
+
+    override suspend fun loadContent(): SpellListState.Body {
+        val spells = repository.getAll(mutableState.value.filter)
+        return if (spells.isEmpty()) {
+            SpellListState.Body.Empty
+        } else {
+            SpellListState.Body.WithData(spells)
         }
     }
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -165,6 +166,48 @@ class MonsterListViewModelTest {
     }
 
     @Test
+    fun `filterByQuery debounces rapid input into a single load`() = runTest(testDispatcher) {
+        val countingRepository = CountingMonsterRepository()
+        val viewModel = MonsterListViewModel(countingRepository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+        val loadsAfterInit = countingRepository.getAllCount
+
+        viewModel.filterByQuery("a")
+        advanceTimeBy(100)
+        viewModel.filterByQuery("ab")
+        advanceTimeBy(100)
+        viewModel.filterByQuery("abc")
+        advanceUntilIdle()
+
+        assertEquals(expected = loadsAfterInit + 1, actual = countingRepository.getAllCount)
+        assertEquals(expected = "abc", actual = viewModel.state.value.filter.query)
+    }
+
+    @Test
+    fun `filterByQuery does not flash Loading while data is shown`() = runTest(testDispatcher) {
+        val viewModel = MonsterListViewModel(repository)
+        val bodies = mutableListOf<MonsterListState.Body>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { bodies.add(it.body) }
+        }
+
+        advanceUntilIdle()
+        bodies.clear()
+
+        viewModel.filterByQuery(goblin.resolveTranslation("en").name)
+        advanceUntilIdle()
+
+        assertFalse(bodies.any { it is MonsterListState.Body.Loading })
+        assertIs<MonsterListState.Body.WithData>(viewModel.state.value.body)
+    }
+
+    @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
         val failingRepository = FailingMonsterRepository()
         val viewModel = MonsterListViewModel(failingRepository)
@@ -187,4 +230,17 @@ private class FailingMonsterRepository : MonsterRepository {
     override suspend fun getById(id: String): Monster? {
         throw RuntimeException("Simulated repository error")
     }
+}
+
+private class CountingMonsterRepository : MonsterRepository {
+    private val delegate = SampleMonsterRepository()
+    var getAllCount = 0
+        private set
+
+    override suspend fun getAll(filter: MonsterFilter?): List<Monster> {
+        getAllCount++
+        return delegate.getAll(filter)
+    }
+
+    override suspend fun getById(id: String): Monster? = delegate.getById(id)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/creature/presentation/viewmodel/MonsterListViewModelTest.kt
@@ -208,6 +208,28 @@ class MonsterListViewModelTest {
     }
 
     @Test
+    fun `filterByQuery does not flash Loading after an empty result`() = runTest(testDispatcher) {
+        val viewModel = MonsterListViewModel(repository)
+        val bodies = mutableListOf<MonsterListState.Body>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { bodies.add(it.body) }
+        }
+
+        advanceUntilIdle()
+        viewModel.filterByQuery("no_match")
+        advanceUntilIdle()
+        assertIs<MonsterListState.Body.Empty>(viewModel.state.value.body)
+        bodies.clear()
+
+        viewModel.filterByQuery("still_no_match")
+        advanceUntilIdle()
+
+        assertFalse(bodies.any { it is MonsterListState.Body.Loading })
+        assertIs<MonsterListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
         val failingRepository = FailingMonsterRepository()
         val viewModel = MonsterListViewModel(failingRepository)

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -159,6 +160,48 @@ class MagicalItemListViewModelTest {
     }
 
     @Test
+    fun `filterByQuery debounces rapid input into a single load`() = runTest(testDispatcher) {
+        val countingRepository = CountingMagicalItemRepository()
+        val viewModel = MagicalItemListViewModel(countingRepository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+        val loadsAfterInit = countingRepository.getAllCount
+
+        viewModel.filterByQuery("a")
+        advanceTimeBy(100)
+        viewModel.filterByQuery("ab")
+        advanceTimeBy(100)
+        viewModel.filterByQuery("abc")
+        advanceUntilIdle()
+
+        assertEquals(expected = loadsAfterInit + 1, actual = countingRepository.getAllCount)
+        assertEquals(expected = "abc", actual = viewModel.state.value.filter.query)
+    }
+
+    @Test
+    fun `filterByQuery does not flash Loading while data is shown`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(repository)
+        val bodies = mutableListOf<MagicalItemListState.Body>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { bodies.add(it.body) }
+        }
+
+        advanceUntilIdle()
+        bodies.clear()
+
+        viewModel.filterByQuery(item.resolveTranslation("en").name)
+        advanceUntilIdle()
+
+        assertFalse(bodies.any { it is MagicalItemListState.Body.Loading })
+        assertIs<MagicalItemListState.Body.WithData>(viewModel.state.value.body)
+    }
+
+    @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
         val failingRepository = FailingMagicalItemRepository()
         val viewModel = MagicalItemListViewModel(failingRepository)
@@ -181,4 +224,17 @@ private class FailingMagicalItemRepository : MagicalItemRepository {
     override suspend fun getById(id: String): MagicalItem? {
         throw RuntimeException("Simulated repository error")
     }
+}
+
+private class CountingMagicalItemRepository : MagicalItemRepository {
+    private val delegate = SampleMagicalItemRepository()
+    var getAllCount = 0
+        private set
+
+    override suspend fun getAll(filter: MagicalItemFilter?): List<MagicalItem> {
+        getAllCount++
+        return delegate.getAll(filter)
+    }
+
+    override suspend fun getById(id: String): MagicalItem? = delegate.getById(id)
 }

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/magicalitem/presentation/viewmodel/MagicalItemListViewModelTest.kt
@@ -202,6 +202,28 @@ class MagicalItemListViewModelTest {
     }
 
     @Test
+    fun `filterByQuery does not flash Loading after an empty result`() = runTest(testDispatcher) {
+        val viewModel = MagicalItemListViewModel(repository)
+        val bodies = mutableListOf<MagicalItemListState.Body>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { bodies.add(it.body) }
+        }
+
+        advanceUntilIdle()
+        viewModel.filterByQuery("no_match")
+        advanceUntilIdle()
+        assertIs<MagicalItemListState.Body.Empty>(viewModel.state.value.body)
+        bodies.clear()
+
+        viewModel.filterByQuery("still_no_match")
+        advanceUntilIdle()
+
+        assertFalse(bodies.any { it is MagicalItemListState.Body.Loading })
+        assertIs<MagicalItemListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
         val failingRepository = FailingMagicalItemRepository()
         val viewModel = MagicalItemListViewModel(failingRepository)

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
@@ -223,6 +223,28 @@ class SpellListViewModelTest {
     }
 
     @Test
+    fun `filterByQuery does not flash Loading after an empty result`() = runTest(testDispatcher) {
+        val viewModel = SpellListViewModel(repository)
+        val bodies = mutableListOf<SpellListState.Body>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { bodies.add(it.body) }
+        }
+
+        advanceUntilIdle()
+        viewModel.filterByQuery("no_match")
+        advanceUntilIdle()
+        assertIs<SpellListState.Body.Empty>(viewModel.state.value.body)
+        bodies.clear()
+
+        viewModel.filterByQuery("still_no_match")
+        advanceUntilIdle()
+
+        assertFalse(bodies.any { it is SpellListState.Body.Loading })
+        assertIs<SpellListState.Body.Empty>(viewModel.state.value.body)
+    }
+
+    @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
         val failingRepository = FailingSpellRepository()
         val viewModel = SpellListViewModel(failingRepository)

--- a/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
+++ b/cmp-ttrpg-companion/composeApp/src/commonTest/kotlin/com/cyrillrx/rpg/spell/presentation/viewmodel/SpellListViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -178,6 +179,50 @@ class SpellListViewModelTest {
     }
 
     @Test
+    fun `filterByQuery debounces rapid input into a single load`() = runTest(testDispatcher) {
+        val countingRepository = CountingSpellRepository()
+        val viewModel = SpellListViewModel(countingRepository)
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect {}
+        }
+
+        advanceUntilIdle()
+        val loadsAfterInit = countingRepository.getAllCount
+
+        viewModel.filterByQuery("a")
+        advanceTimeBy(100)
+        viewModel.filterByQuery("ab")
+        advanceTimeBy(100)
+        viewModel.filterByQuery("abc")
+        advanceUntilIdle()
+
+        // The whole burst triggers a single load, not one per keystroke.
+        assertEquals(expected = loadsAfterInit + 1, actual = countingRepository.getAllCount)
+        assertEquals(expected = "abc", actual = viewModel.state.value.filter.query)
+    }
+
+    @Test
+    fun `filterByQuery does not flash Loading while data is shown`() = runTest(testDispatcher) {
+        val viewModel = SpellListViewModel(repository)
+        val bodies = mutableListOf<SpellListState.Body>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.state.collect { bodies.add(it.body) }
+        }
+
+        advanceUntilIdle()
+        bodies.clear()
+
+        val spellName = requireNotNull(spell.translations["en"]).name
+        viewModel.filterByQuery(spellName)
+        advanceUntilIdle()
+
+        assertFalse(bodies.any { it is SpellListState.Body.Loading })
+        assertIs<SpellListState.Body.WithData>(viewModel.state.value.body)
+    }
+
+    @Test
     fun `state is Error when repository throws`() = runTest(testDispatcher) {
         val failingRepository = FailingSpellRepository()
         val viewModel = SpellListViewModel(failingRepository)
@@ -200,4 +245,17 @@ private class FailingSpellRepository : SpellRepository {
     override suspend fun getById(id: String): Spell? {
         throw RuntimeException("Simulated repository error")
     }
+}
+
+private class CountingSpellRepository : SpellRepository {
+    private val delegate = SampleSpellRepository()
+    var getAllCount = 0
+        private set
+
+    override suspend fun getAll(filter: SpellFilter?): List<Spell> {
+        getAllCount++
+        return delegate.getAll(filter)
+    }
+
+    override suspend fun getById(id: String): Spell? = delegate.getById(id)
 }

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/MonsterFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/creature/domain/MonsterFilter.kt
@@ -6,6 +6,8 @@ data class MonsterFilter(
     val challengeRatings: Set<Float> = emptySet(),
 ) {
     val hasActiveFilters: Boolean = types.isNotEmpty() || challengeRatings.isNotEmpty()
+
+    internal val trimmedQuery: String = query.trim()
 }
 
 fun List<Monster>.applyFilter(filter: MonsterFilter?): List<Monster> {
@@ -16,12 +18,10 @@ fun List<Monster>.applyFilter(filter: MonsterFilter?): List<Monster> {
 internal fun Monster.matches(filter: MonsterFilter): Boolean =
     (filter.types.isEmpty() || filter.types.any { it in types }) &&
         (filter.challengeRatings.isEmpty() || filter.challengeRatings.contains(challengeRating)) &&
-        (filter.query.isBlank() || matches(filter.query))
+        (filter.trimmedQuery.isEmpty() || matches(filter.trimmedQuery))
 
-private fun Monster.matches(query: String): Boolean {
-    val trimmedQuery = query.trim()
-    return translations.values.any { t ->
-        t.name.contains(trimmedQuery, ignoreCase = true) ||
-            t.description.contains(trimmedQuery, ignoreCase = true)
+private fun Monster.matches(query: String): Boolean =
+    translations.values.any { t ->
+        t.name.contains(query, ignoreCase = true) ||
+            t.description.contains(query, ignoreCase = true)
     }
-}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/magicalitem/domain/MagicalItemFilter.kt
@@ -6,6 +6,8 @@ data class MagicalItemFilter(
     val rarities: Set<MagicalItem.Rarity> = emptySet(),
 ) {
     val hasActiveFilters: Boolean = types.isNotEmpty() || rarities.isNotEmpty()
+
+    internal val trimmedQuery: String = query.trim()
 }
 
 fun List<MagicalItem>.applyFilter(filter: MagicalItemFilter?): List<MagicalItem> {
@@ -16,12 +18,10 @@ fun List<MagicalItem>.applyFilter(filter: MagicalItemFilter?): List<MagicalItem>
 internal fun MagicalItem.matches(filter: MagicalItemFilter): Boolean =
     (filter.types.isEmpty() || filter.types.contains(type)) &&
         (filter.rarities.isEmpty() || filter.rarities.contains(rarity)) &&
-        (filter.query.isBlank() || matchesQuery(filter.query))
+        (filter.trimmedQuery.isEmpty() || matchesQuery(filter.trimmedQuery))
 
-private fun MagicalItem.matchesQuery(query: String): Boolean {
-    val trimmed = query.trim()
-    return translations.values.any { translation ->
-        translation.name.contains(trimmed, ignoreCase = true) ||
-            translation.description.contains(trimmed, ignoreCase = true)
+private fun MagicalItem.matchesQuery(query: String): Boolean =
+    translations.values.any { translation ->
+        translation.name.contains(query, ignoreCase = true) ||
+            translation.description.contains(query, ignoreCase = true)
     }
-}

--- a/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
+++ b/cmp-ttrpg-companion/shared/core/src/commonMain/kotlin/com/cyrillrx/rpg/spell/domain/SpellFilter.kt
@@ -35,6 +35,8 @@ data class SpellFilter(
             characterClasses.isNotEmpty() ||
             levels.isNotEmpty() ||
             components.values.any { it != ComponentFilterState.NONE }
+
+    internal val trimmedQuery: String = query.trim()
 }
 
 fun List<Spell>.applyFilter(filter: SpellFilter?): List<Spell> {
@@ -53,7 +55,7 @@ internal fun Spell.matches(filter: SpellFilter): Boolean =
                 ComponentFilterState.EXCLUDED -> !component.isPresentIn(components)
             }
         } &&
-        (filter.query.isBlank() || matchesQuery(filter.query))
+        (filter.trimmedQuery.isEmpty() || matchesQuery(filter.trimmedQuery))
 
 private fun Spell.ComponentType.isPresentIn(components: Spell.Components): Boolean = when (this) {
     Spell.ComponentType.VERBAL -> components.verbal
@@ -61,10 +63,8 @@ private fun Spell.ComponentType.isPresentIn(components: Spell.Components): Boole
     Spell.ComponentType.MATERIAL -> components.material
 }
 
-private fun Spell.matchesQuery(query: String): Boolean {
-    val trimmed = query.trim()
-    return translations.values.any { translation ->
-        translation.name.contains(trimmed, ignoreCase = true) ||
-            translation.description.contains(trimmed, ignoreCase = true)
+private fun Spell.matchesQuery(query: String): Boolean =
+    translations.values.any { translation ->
+        translation.name.contains(query, ignoreCase = true) ||
+            translation.description.contains(query, ignoreCase = true)
     }
-}


### PR DESCRIPTION
## 📝 Description

Improves the compendium search (spells, monsters, magical items). Each keystroke previously launched/cancelled a coroutine job, forced the list to `Body.Loading` (list → loader → list flicker), emitted a scroll-to-top event, and ran an O(n) filter scanning each entry's name + full description with `query.trim()` recomputed per element.

Changes:
- **Debounce** (~250 ms) the search query, so filtering runs once the user pauses instead of on every character. Structural filters (school / level / type / CR / rarity / components) stay immediate.
- **No Loading flicker**: the current results stay visible while re-filtering; the loader only shows on the initial load.
- **Filter micro-opt**: the trimmed query is computed once per filter instance (like the existing `hasActiveFilters`) instead of `query.trim()` per element. Search semantics unchanged (name + description, case-insensitive).

Scoped to the three compendium lists (spell, creature, magicalitem); character and campaign lists are out of scope. Independent of #163.

## 🖼️ Media

N/A — no layout change; the visible effect is the removal of the loader flash while typing.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] New/changed logic is covered by tests (debounce + no-Loading, per ViewModel)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [ ] Documentation updated if public APIs or architecture decisions changed (N/A)
