### PR TITLE
ci(sonar): skip the baselineprofile module in Sonar analysis

### DIFF
--- a/cmp-ttrpg-companion/build.gradle.kts
+++ b/cmp-ttrpg-companion/build.gradle.kts
@@ -13,11 +13,13 @@ plugins {
     alias(libs.plugins.sonarqube)
 }
 
-// The androidApp launcher module has no analyzable code and trips a scanner/AGP 9
-// incompatibility (sonarResolver queries res providers before their producing task runs).
-project(":androidApp") {
-    extensions.configure<org.sonarqube.gradle.SonarExtension>("sonar") {
-        isSkipProject = true
+// These modules have no analyzable code and trip a scanner/AGP 9 incompatibility
+// (sonarResolver queries res providers before their producing task runs).
+listOf(":androidApp", ":baselineprofile").forEach { path ->
+    project(path) {
+        extensions.configure<org.sonarqube.gradle.SonarExtension>("sonar") {
+            isSkipProject = true
+        }
     }
 }
 

--- a/cmp-ttrpg-companion/build.gradle.kts
+++ b/cmp-ttrpg-companion/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.sonarqube.gradle.SonarExtension
+
 plugins {
     // trick: for the same plugin versions in all submodules
     alias(libs.plugins.android.application) apply false
@@ -17,7 +19,7 @@ plugins {
 // (sonarResolver queries res providers before their producing task runs).
 listOf(":androidApp", ":baselineprofile").forEach { path ->
     project(path) {
-        extensions.configure<org.sonarqube.gradle.SonarExtension>("sonar") {
+        extensions.configure<SonarExtension>("sonar") {
             isSkipProject = true
         }
     }


### PR DESCRIPTION
## 📝 Description

The `:baselineprofile` module (a `com.android.test` module using the `androidx.baselineprofile` plugin) trips the same scanner/AGP 9 incompatibility that was already worked around for `:androidApp`: the Sonar plugin's `sonarResolver` task eagerly queries the `res` directory providers produced by `generateNonMinifiedReleaseResValues` before that task has run, which Gradle no longer tolerates. This fails the `:baselineprofile:sonarResolver` task and breaks the SonarCloud CI step:

```
Execution failed for task ':baselineprofile:sonarResolver'.
> Querying the mapped value of ... res ... before task ':baselineprofile:generateNonMinifiedReleaseResValues' has completed is not supported
```

The module carries no analyzable production code and no Kover coverage is configured for it, so it should be excluded from Sonar analysis — exactly like `:androidApp`. This PR extends the existing `isSkipProject` workaround to both modules via a shared list, removing the duplication.

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
