### PR TITLE
build(gradle): upgrade AGP to 9.3.0 and Gradle to 9.6.1

### DIFF
--- a/cmp-ttrpg-companion/buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/cmp-ttrpg-companion/buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/cmp-ttrpg-companion/gradle/libs.versions.toml
+++ b/cmp-ttrpg-companion/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.3.20"
 ktlint = "14.2.0"
-agp = "9.0.1"
+agp = "9.3.0"
 compose-plugin = "1.10.3"
 kotlinx-coroutines-core = "1.10.2"
 kotlinx-serialization = "1.11.0"

--- a/cmp-ttrpg-companion/gradle/wrapper/gradle-wrapper.properties
+++ b/cmp-ttrpg-companion/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 📝 Description

Upgrade the build toolchain:

- **Android Gradle Plugin**: `9.0.1` → `9.3.0`
- **Gradle wrapper** (root and `buildSrc`): `9.4.1` → `9.6.1`

## ✅ Checklist

- [x] Code follows the conventions in `AGENTS.md` and `docs/conventions/`
- [x] The author has proofread the PR
- [ ] New/changed logic is covered by tests (unit and/or integration)
- [x] No compiler warnings introduced
- [x] No sensitive data (secrets, credentials, tokens) committed
- [ ] Documentation updated if public APIs or architecture decisions changed